### PR TITLE
Add subplot(m, n, i) and suptitle with matplotlib-matching layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test:
-    name: Linux (lfortran)
+    name: Linux (flang + lfortran)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,5 +23,7 @@ jobs:
           pixi-version: v0.76.1
           cache: true
           locked: true
+      - name: Test with Flang
+        run: pixi run test-flang
       - name: Test with LFortran
         run: pixi run test-lfortran

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,5 @@ jobs:
         run: pixi run test-flang
       - name: Test with LFortran
         run: pixi run test-lfortran
+      - name: Compare against matplotlib references
+        run: pixi run compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Linux (flang + lfortran)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.10.1
+        with:
+          pixi-version: v0.76.1
+          cache: true
+          locked: true
+      - name: Test with Flang
+        run: pixi run test-flang
+      - name: Test with LFortran
+        run: pixi run test-lfortran

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   test:
-    name: Linux (flang + lfortran)
+    name: Linux (lfortran)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,5 @@ jobs:
           pixi-version: v0.76.1
           cache: true
           locked: true
-      - name: Test with Flang
-        run: pixi run test-flang
       - name: Test with LFortran
         run: pixi run test-lfortran

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ pixi run test-lfortran
 pixi run compare
 ```
 
-CI (Linux) runs `pixi run test-flang` and `pixi run test-lfortran`.
+CI (Linux) runs `pixi run test-flang`, `pixi run test-lfortran` and
+`pixi run compare`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ call show()               ! Jupyter (LFortran) or writes fplot_show.svg
 
 ! subplots
 call clf()
-call subplot(2, 1, 1)      ! or the code form: call subplot(211)
+call subplot(2, 1, 1)
 call plot(x, y, "b-", label="sin")
 call title("top")
-call subplot(212)
+call subplot(2, 1, 2)
 call plot(x, y2, "r--", label="cos")
 call title("bottom")
 call suptitle("figure title")
@@ -32,9 +32,9 @@ call suptitle("figure title")
 - Format strings: colors `bgrcmykw` / `C0`–`C9`, markers `ox.`, linestyles `-` `--` `:` `-.`
 - Optional `label=`, `lw=`, `color=`
 - Title, axis labels, grid, legend, `xlim` / `ylim`, `clf` / `figure`
-- Subplots: `subplot(m, n, i)` (or 3-digit code form like `subplot(212)`) and
-  figure-level `suptitle`; per-axes state (series, labels, grid, legend,
-  scale, limits) with matplotlib's default subplot spacing
+- Subplots: `subplot(m, n, i)` and figure-level `suptitle`; per-axes state
+  (series, labels, grid, legend, scale, limits) with matplotlib's default
+  subplot spacing
 - SVG defaults aligned with matplotlib (6.4×4.8 in, tab10 colors, subplot margins)
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ call suptitle("figure title")
 ## Build
 
 Requires [pixi](https://pixi.sh). LFortran is installed by pixi on all platforms.
-Flang is installed by pixi on Linux (conda-forge); on macOS provide a system
-Flang on `PATH`.
+Flang is installed by pixi on Linux via conda-forge `flang_linux-64` (compiler
+plus `libflang-rt`); on macOS provide a system Flang on `PATH`.
 
 ```bash
 pixi install

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ call grid(.true.)
 call legend()
 call savefig("out.svg")   ! file backend
 call show()               ! Jupyter (LFortran) or writes fplot_show.svg
+
+! subplots
+call clf()
+call subplot(2, 1, 1)      ! or the code form: call subplot(211)
+call plot(x, y, "b-", label="sin")
+call title("top")
+call subplot(212)
+call plot(x, y2, "r--", label="cos")
+call title("bottom")
+call suptitle("figure title")
 ```
 
 ## Features (MVP)
@@ -20,6 +30,9 @@ call show()               ! Jupyter (LFortran) or writes fplot_show.svg
 - Format strings: colors `bgrcmykw` / `C0`–`C9`, markers `ox.`, linestyles `-` `--` `:` `-.`
 - Optional `label=`, `lw=`, `color=`
 - Title, axis labels, grid, legend, `xlim` / `ylim`, `clf` / `figure`
+- Subplots: `subplot(m, n, i)` (or 3-digit code form like `subplot(212)`) and
+  figure-level `suptitle`; per-axes state (series, labels, grid, legend,
+  scale, limits) with matplotlib's default subplot spacing
 - SVG defaults aligned with matplotlib (6.4×4.8 in, tab10 colors, subplot margins)
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fplot
 
+[![CI](https://github.com/certik/fplot/actions/workflows/ci.yml/badge.svg)](https://github.com/certik/fplot/actions/workflows/ci.yml)
+
 Pure Fortran plotting library that emits SVG text, with a pylab-style API.
 
 ```fortran
@@ -37,7 +39,9 @@ call suptitle("figure title")
 
 ## Build
 
-Requires **Flang** or **LFortran** on `PATH`, and [pixi](https://pixi.sh) for Python comparison tooling.
+Requires [pixi](https://pixi.sh). LFortran is installed by pixi on all platforms.
+Flang is installed by pixi on Linux (conda-forge); on macOS provide a system
+Flang on `PATH`.
 
 ```bash
 pixi install
@@ -54,6 +58,8 @@ pixi run test-lfortran
 # Compare against matplotlib reference SVGs
 pixi run compare
 ```
+
+CI (Linux) runs `pixi run test-flang` and `pixi run test-lfortran`.
 
 ## Layout
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,5 +1,11 @@
 version: 7
 platforms:
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: osx-arm64
   virtual-packages:
   - __unix=0=0
@@ -10,6 +16,177 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py314h77c0f9c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22-22.1.8-default_hd70ba2e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22.1.8-default_cfg_hecfc6a8_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang_impl_linux-64-22.1.8-default_h50bdbf7_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flang-22.1.8-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lfortran-0.64.0-hb42ed02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_hd70ba2e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.7.2-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.11.1-py314h815e797_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py314h9a9c090_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py314h2b28147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py314h3987850_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xeus-6.0.5-hbf34205_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xeus-zmq-4.0.0-ha280ed4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cairocffi-1.7.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cairosvg-2.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_linux-64-22.1.8-hffcefe0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cssselect2-0.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.63.0-pyh7db6752_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nlohmann_json-abi-3.12.0-h0f90c79_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cairocffi-1.7.1-pyhcf101f3_2.conda
@@ -109,6 +286,2193 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+  sha256: cf93ca0f1f107e95a35969a4622684e08fcb8cf37f8cf4a1e9e424828386c921
+  md5: 8904e09bda369377b3dd07e2ac828c5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - alsa-lib >=1.2.16.1,<1.3.0a0
+  size: 592377
+  timestamp: 1781521980743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.46.1-default_h4852527_102.conda
+  sha256: 659c367ef49df7741749a2ad240b007d7df51b4f210505a78543deafb001e44c
+  md5: e8452fe381cac5fff20563a07722dfa5
+  depends:
+  - binutils_impl_linux-64 >=2.46.1,<2.46.2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 35399
+  timestamp: 1784214547142
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+  sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+  md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+  depends:
+  - ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 3713752
+  timestamp: 1784214522814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
+  sha256: 1f2ccfebe6e0113bfc473b21906372c1ee4eb69bf6faef0ad7f3d4d79af63a98
+  md5: 6ff307b78fbfb7dcafb7e25ff8bc9c10
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli-bin 1.2.0 h9908984_3
+  - libbrotlidec 1.2.0 ha411449_3
+  - libbrotlienc 1.2.0 h018ffa1_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlicommon >=1.2.0,<1.3.0a0
+    - libbrotlienc >=1.2.0,<1.3.0a0
+    - libbrotlidec >=1.2.0,<1.3.0a0
+  size: 20676
+  timestamp: 1786622810792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
+  sha256: 56b2e5e8a49f9887af74cc63e0d55a3654e60b667ad5558da089549a36ae6a0c
+  md5: 8929291d9efc59715df1cfa7daf5e3ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec 1.2.0 ha411449_3
+  - libbrotlienc 1.2.0 h018ffa1_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 21598
+  timestamp: 1786622801722
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+  md5: bb6c4808bfa69d6f7f6b07e5846ced37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  run_exports:
+    weak:
+    - cairo >=1.18.4,<2.0a0
+  size: 989514
+  timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py314h77c0f9c_1.conda
+  sha256: f2be3de194658ef1733c11381fcec2853898d598e602ccbe5745d0a0700e0899
+  md5: 452e8b9d54b4ba7ab6e8129bc8a7a3ee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 305586
+  timestamp: 1786528481627
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22-22.1.8-default_hd70ba2e_6.conda
+  sha256: cd5a792ce357ba33957a63465f74d3b67aef22e340a969dbdde391e28854ddc4
+  md5: aecb172aa9bccd025bd93773c9d3b800
+  depends:
+  - compiler-rt22 ==22.1.8
+  - libclang-cpp22.1 ==22.1.8 default_h08c5240_6
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 938412
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22.1.8-default_cfg_hecfc6a8_6.conda
+  sha256: 129bc4d6c1dc0adf3ac4fa0f1585ecb46fb19ce75d36e87a5f550f0a621a1434
+  md5: eb41c6dd2af698fa23fc913f28096cb6
+  depends:
+  - clang-22 ==22.1.8 default_hd70ba2e_6
+  - llvm-openmp >=22.1.8
+  - clang_impl_linux-64 ==22.1.8 default_h50bdbf7_6
+  - binutils
+  - libgcc-devel_linux-64
+  - sysroot_linux-64
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 33910
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang_impl_linux-64-22.1.8-default_h50bdbf7_6.conda
+  sha256: 1899da88b21621d4f155e53ddf30330ae7e1e851920524d0bb28ce9c8f20c8f2
+  md5: 28db002a4e4fcbdab5cf70ac2ca1ab26
+  depends:
+  - clang-22 ==22.1.8 default_hd70ba2e_6
+  - compiler-rt_linux-64 ==22.1.8
+  - compiler-rt ==22.1.8
+  - binutils_impl_linux-64
+  - libgcc-devel_linux-64
+  - sysroot_linux-64
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 33470
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
+  sha256: 7ea97a24a9847f7ec91b959c405a9bc5b9c28d4078175dce2d2f8a2014f74969
+  md5: 21124de0100de807100d1a55c9dd118b
+  depends:
+  - compiler-rt22 22.1.8 hb700be7_1
+  - libcompiler-rt 22.1.8 hb700be7_1
+  constrains:
+  - clang 22.1.8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16599
+  timestamp: 1781741197892
+- conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
+  sha256: 34c62d3aa085945afa94930621793bccc18c47ce9657a5ef9423f76cf8e9373e
+  md5: cf8e2c7703b389548c15082694701a17
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - compiler-rt22_linux-64 22.1.8.*
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 115679
+  timestamp: 1781741196856
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
+  sha256: b0314a7f1fb4a294b1a8bcf5481d4a8d9412a9fee23b7e3f93fb10e4d504f2cc
+  md5: 95bede9cdb7a30a4b611223d52a01aa4
+  depends:
+  - numpy >=1.25
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 324013
+  timestamp: 1769155968691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+  sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
+  md5: af491aae930edc096b58466c51c4126c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=13
+  - libntlm >=1.8,<2.0a0
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.5,<4.0a0
+  license: BSD-3-Clause-Attribution
+  license_family: BSD
+  run_exports:
+    weak:
+    - cyrus-sasl >=2.1.28,<3.0a0
+  size: 210103
+  timestamp: 1771943128249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
+  run_exports:
+    weak:
+    - dbus >=1.16.2,<2.0a0
+  size: 447649
+  timestamp: 1764536047944
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+  sha256: 40cdd1b048444d3235069d75f9c8e1f286db567f6278a93b4f024e5642cfaecc
+  md5: dbe3ec0f120af456b3477743ffd99b74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - double-conversion >=3.4.0,<3.5.0a0
+  size: 71809
+  timestamp: 1765193127016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/flang-22.1.8-hecca717_0.conda
+  sha256: 2d52d69770b63d8ab0ae42770d2e6ae5fa5ede220ba7d2838404c89b3e4c4e89
+  md5: 0500ee842c1c0e39a9ce67a27fa2c6ef
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - clang 22.1.8
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - libgcc >=14
+  - libllvm22 >=22.1.8,<22.2.0a0
+  - libstdcxx >=14
+  - sysroot_linux-64 >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 71960605
+  timestamp: 1781833417650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+  sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+  md5: 922776b528a470ab5afa81fd42abfa1d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  run_exports:
+    weak:
+    - fontconfig >=2.18.3,<3.0a0
+    - fonts-conda-ecosystem
+  size: 296288
+  timestamp: 1786667377340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+  sha256: 612a8e0c1a6ecae23da54d81ef395f6ebb5c8e4468ec2611593ebce75876a4e0
+  md5: 2d0ea23b23603e07ca47f23f949f67b6
+  depends:
+  - libfreetype 2.14.3 ha770c72_2
+  - libfreetype6 2.14.3 h5e6c136_2
+  license: GPL-2.0-only OR FTL
+  run_exports:
+    weak:
+    - libfreetype >=2.14.3
+    - libfreetype6 >=2.14.3
+  size: 175239
+  timestamp: 1786641011029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+  sha256: 4846a3ca0402f3fe33ad84ed50ab213c6aafde4a0faef3c5002f6bf753e21671
+  md5: 1cd10eda5692519d01bb20e086e214c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - fribidi >=1.0.16,<2.0a0
+  size: 61782
+  timestamp: 1785912528684
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+  sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+  md5: f9fe2984587fa8235a6af6004760cd18
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 102835
+  timestamp: 1786118485753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
+  sha256: 511813aaad42ed2494efc77452738fed7734985e069efc08c279a701b1708ba0
+  md5: 7f42f814e1306f83e4cac267baa9acab
+  depends:
+  - libharfbuzz-devel 14.3.0 h17a8019_0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.0
+  size: 11045
+  timestamp: 1785770087614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+  md5: ba55d1b89fd7775e67de8291029b4059
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
+  size: 135295
+  timestamp: 1786739238128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
+  sha256: e3488ea4a336f29e57de8f282bf40c0505cfc482e03004615e694b48e7d9c79f
+  md5: 7397e418cab519b8d789936cf2dde6f6
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 77363
+  timestamp: 1773067048780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1388990
+  timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+  sha256: 112b5b9462572d970f4abd2912f76a25ee7db158b1e7260163d91dd8a630db84
+  md5: 8b3ce45e929cd8e8e5f4d18586b56d8b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - lcms2 >=2.19.1,<3.0a0
+  size: 251971
+  timestamp: 1780211695895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+  sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+  md5: fb9d356b1a57d6d54768be7ebd5fce09
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - lerc >=4.2.0,<5.0a0
+  size: 271158
+  timestamp: 1785036167977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lfortran-0.64.0-hb42ed02_0.conda
+  sha256: 1801107f21ab7264ee4dda53b1dc2b59ffdf5d705edcb7a0830f7c4caaef1d04
+  md5: a58aa99f550ec593687a4d390d593941
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libunwind >=1.7.2,<1.8.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - xeus >=6.0.1,<6.1.0a0
+  - xeus-zmq >=4.0.0,<4.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 32631824
+  timestamp: 1784358273333
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+  build_number: 9
+  sha256: 39c7b3c5427b435c9c059ede9da61d46d42574e5b846ad37fdc3af4a5eab1e48
+  md5: f5c4b041925dea221dc4bad2e50569d9
+  depends:
+  - libopenblas >=0.3.34,<0.3.35.0a0
+  - libopenblas >=0.3.34,<1.0a0
+  constrains:
+  - blas 2.309   openblas
+  - libcblas   3.11.0   9*_openblas
+  - liblapack  3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18033
+  timestamp: 1786059035239
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+  sha256: e5864f257f839ffc27d681659bac95901f524f602b9121e5dcc5e2df18437f2d
+  md5: 7a2499a177753582fb7ae7e9dc4a908a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlicommon >=1.2.0,<1.3.0a0
+  size: 80265
+  timestamp: 1786622773969
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+  sha256: dad31b6d104973deb89710929a35651033aad692d4e7793cdb5b786a9bd54678
+  md5: 6ab3315dc56618d652c1da42a648a129
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlidec >=1.2.0,<1.3.0a0
+  size: 34828
+  timestamp: 1786622783405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+  sha256: d37124d0f51816e7d5e3a94bfc9ed3d6174d077f9b4f832d20c5a08b52bebf1f
+  md5: 2ac965638d4c6b2b38383bb1aebaf543
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libbrotlienc >=1.2.0,<1.3.0a0
+  size: 298639
+  timestamp: 1786622792145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+  build_number: 9
+  sha256: 4c532a70ea9aeff2fa1aabaa4828ebc00c2ed12b22aa8ba19da5302b882fc82b
+  md5: 092c5649f3727af436ab0f67f48c3811
+  depends:
+  - libblas 3.11.0 9_h4a7cf45_openblas
+  constrains:
+  - blas 2.309   openblas
+  - liblapack  3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 17998
+  timestamp: 1786059041397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
+  sha256: fc2981a8e45dd232ae88cf2580f7e75c258f4dccdc96f879b68ef0a9b45c9a2b
+  md5: 4fd9026a57bb45cd15bd08ff8bd0578e
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  size: 24171067
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_hd70ba2e_6.conda
+  sha256: 8475136d3be6c2d16bdb801dcaf8769cb2ba372cad239c89ebd6a58912e14465
+  md5: a8e147873eca89dc1c5d319b027a6cd3
+  depends:
+  - libclang-cpp22.1 ==22.1.8 default_h08c5240_6
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang13 >=22.1.8
+  size: 14275196
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
+  sha256: da7b61922007ff1cfe015ec5156084f2b12f68f554ea8d737689c1dc898f24c0
+  md5: 03a0d91cd5997faff23727b4390f9bc6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libcompiler-rt >=22.1.8
+  size: 10100897
+  timestamp: 1781741177454
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libcups >=2.3.3,<2.4.0a0
+  size: 4518030
+  timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+  sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+  md5: 40f9b31aa9cf007789867df0decd0492
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
+  size: 73710
+  timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+  sha256: ea46b0ca0fa16af1f8b329b740e6cd8b4577c5378fa8717b28a885f70668633d
+  md5: 64cc91512b6278c315349dc13c53f680
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libdrm >=2.4.129,<2.5.0a0
+  size: 313461
+  timestamp: 1786684701973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  md5: 50708d3b951d0f8e2d7f2df5b5edc040
+  depends:
+  - ncurses
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 135098
+  timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  sha256: 9a25ea93e8272785405a21d30f84e620befb1d545f6dfaae18f06103b5df0443
+  md5: 75e9f795be506c96dd43cb09c7c8d557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 46500
+  timestamp: 1779728188901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: e4b46919c9bb65930bce238bd2736110ed7b8c30e5cd5394e4e1edb48de54843
+  md5: 5bc6d55503483aabe8a90c5e7f49a2a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_3
+  - libgl-devel 1.7.0 ha4b6fd6_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libegl >=1.7.0,<2.0a0
+  size: 31718
+  timestamp: 1779728222280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 67576
+  timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+  sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+  md5: f8054e759d0ddddaf34a5c8fedc900a1
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 8407
+  timestamp: 1786641007099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+  sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+  md5: b72a266a9317036fd0464cb98b027cd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  run_exports: {}
+  size: 387671
+  timestamp: 1786641006460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1057877
+  timestamp: 1785375436766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+  sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
+  md5: 7ed870c014a6f23c7dfafda53d2763a9
+  depends:
+  - libgcc 16.1.0 ha9f2e26_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - libgcc
+  size: 28210
+  timestamp: 1785375440733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+  sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
+  md5: 2fbed65cc90cf0724e1ec4de13696737
+  depends:
+  - libgfortran5 16.1.0 h79bb938_1
+  constrains:
+  - libgfortran-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 28134
+  timestamp: 1785375470055
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+  sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
+  md5: dd51ed33e8c70995f8e33cc9dc537297
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 2538696
+  timestamp: 1785375448623
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
+  md5: f25206d7322c0e9648e8b83694d143ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - libglx 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133469
+  timestamp: 1779728207669
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: 41d7d864ad1f199bdb06ff6cc3931455c8af62f1d2071a08c6fa08affbcb678f
+  md5: 63e43d278ee5084813fe3c2edf4834ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_3
+  - libglx-devel 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libgl >=1.7.0,<2.0a0
+  size: 115664
+  timestamp: 1779728218325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+  sha256: 4499458124bcf0bd45e8bd17576f9f007cb1373cb3b01659105443f522bab45c
+  md5: 533cb021c1bfeba9f720e669cd863fdf
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libglib >=2.88.3,<3.0a0
+  size: 4755172
+  timestamp: 1786457663614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  sha256: e019ebe4e3f5cdf23e2f5e58ddf7ade27988c53820115b17b98f218ebcc87748
+  md5: eb83f3f8cecc3e9bff9e250817fc69b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 133586
+  timestamp: 1779728183422
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  sha256: 2f74713c9ca408ea84e88a30a9028153e7b553e8bb42e06139eac9a753c27da9
+  md5: ec3c4350aa0261bf7f87b8ca15c8e80e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 76586
+  timestamp: 1779728199059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: a17ae2d4cb2de04a20882ae14ec3cc1958e868a4dec81e3d7eca30115ee50e94
+  md5: 16b6330783ce0d1ae8d22782173b32c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  run_exports:
+    weak:
+    - libglx >=1.7.0,<2.0a0
+  size: 27363
+  timestamp: 1779728211402
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640415
+  timestamp: 1785375373755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
+  sha256: fb72d6f7e90d4927cb53a4e13592559ce74b65052323d5d6dd12499b026c680e
+  md5: f33637ebded146eafa6b2197c8f597a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1333436
+  timestamp: 1785770053613
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
+  sha256: 7ce9326c2520ae758f523ae2d72a0762f7494d77fe8cc9a96065df541e1db8e2
+  md5: 15634b3c7e5a68ca7c6e0bbf84cb2383
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - freetype
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.3,<3.0a0
+  - libharfbuzz 14.3.0 h17a8019_0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.0
+  size: 2081226
+  timestamp: 1785770079548
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  run_exports:
+    weak:
+    - libiconv >=1.18,<2.0a0
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+  sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+  md5: 898d1c9793eaa52efc4727bd84d2e39a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.2.0,<4.0a0
+  size: 650434
+  timestamp: 1785896381946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+  build_number: 9
+  sha256: ea989e2dabd21d296a5a4ec515e695645aefcdf778ffdb5eeea515421d243ab5
+  md5: e51473c2b7e1f9cb61daafccfd912abf
+  depends:
+  - libblas 3.11.0 9_h4a7cf45_openblas
+  constrains:
+  - blas 2.309   openblas
+  - libcblas   3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18021
+  timestamp: 1786059046733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.8-hf7376ad_1.conda
+  sha256: e9b5f301d6b001a9b8ce782157f56b75c92c4fbc9eba95dc6345c1139251d13b
+  md5: 298bb2483fc7d15396147cf1c1465359
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm22 >=22.1.8,<22.2.0a0
+  size: 44320272
+  timestamp: 1781788728739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  md5: fcfed1dc5053eb1901b66e7b1fc32588
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  run_exports: {}
+  size: 92759
+  timestamp: 1786650399772
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+  sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+  md5: 7c7927b404672409d9917d49bff5f2d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libntlm >=1.8,<2.0a0
+  size: 33418
+  timestamp: 1734670021371
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+  sha256: 23392fc4f4e5ba230fcd1ef825878ba5ca7ee4f6259fac0cbb13299134b7bf7a
+  md5: c282d68f272927612462b5d626838ef1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.34,<0.3.35.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libopenblas >=0.3.34,<1.0a0
+  size: 5952629
+  timestamp: 1784287497473
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
+  sha256: 90777039b48529283df5f16383fc399866024257a8bd93de583f4730db1ab30a
+  md5: c2bd8055a2e2dce7a7f32cfd02101fb6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  run_exports: {}
+  size: 51767
+  timestamp: 1779728204026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+  sha256: addc80c69d362a9e6c40305c493139a8e9ee504b2f45a6687dbdaa9da3c6183c
+  md5: 35fa2b34bbced424e6976d30f5fde576
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libpciaccess >=0.19,<0.20.0a0
+  size: 30070
+  timestamp: 1785971678815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+  sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+  md5: fcf71c8d979148873f6f8ad4cfc73d86
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: zlib-acknowledgement
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
+  size: 316643
+  timestamp: 1786616563127
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+  sha256: b1eb210c180fda9c445b11cba1286ec250ce2c2a85ccb0551a4ed5423df51e68
+  md5: 72e019c04ed02a179da38c56965802d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=15
+  - openldap >=2.6.13,<2.7.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: PostgreSQL
+  run_exports:
+    weak:
+    - libpq >=18.6,<19.0a0
+  size: 2719680
+  timestamp: 1786641133110
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+  sha256: ab3ccb9fd5816f76b18ee8974d359cd2605ca87d8ddef55369dc461b9986f95c
+  md5: 3ac89a48d224409739dbf6200e524373
+  depends:
+  - libgcc >=14
+  - __glibc >=2.28,<3.0.a0
+  - fribidi >=1.0.16,<2.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libharfbuzz >=14.2.1
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libraqm >=0.11.0,<0.12.0a0
+  size: 33983
+  timestamp: 1784850267262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+  sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
+  md5: 965e4d531b588b2e42f66fd8e48b056c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: ISC
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 269272
+  timestamp: 1779163468406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 964200
+  timestamp: 1785016112246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 6631744
+  timestamp: 1785375462643
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.1.0-hdf11a46_1.conda
+  sha256: 2876ca4463d1b394eb969ce4a84d1620aa63fb8202a6397837d1e45ec76c1208
+  md5: c94f06123272d8e129d4acf3a25ffb35
+  depends:
+  - libstdcxx 16.1.0 h934c35e_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - libstdcxx
+  size: 28253
+  timestamp: 1785375500257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+  sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+  md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.1.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  run_exports:
+    weak:
+    - libtiff >=4.7.2,<4.8.0a0
+  size: 452337
+  timestamp: 1783084902636
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.7.2-he02047a_0.conda
+  sha256: eadbf53f2f91ac7417841c1507438709cacf8123d491c27065334390ea4a7521
+  md5: 8a40038798ac6b369544e8980ed9deb1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libunwind >=1.7.2,<1.8.0a0
+  size: 71485
+  timestamp: 1720631665167
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libuuid >=2.42.2,<3.0a0
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h5279c79_0.conda
+  sha256: 1e30138cff1e6ba5739ce3ec787b24ef22ac6e2008d8a2073df334e9e5f8690b
+  md5: 9d8c72f797f6f2d1c32897603d70824c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  constrains:
+  - libvulkan-headers 1.4.357.0.*
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libvulkan-loader >=1.4.357.0,<2.0a0
+  size: 203456
+  timestamp: 1785311377294
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+  sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+  md5: 9332b53d0ea93c5d39e33be03a0c611a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
+  size: 428430
+  timestamp: 1785954557217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxcb >=1.17.0,<2.0a0
+  size: 395888
+  timestamp: 1727278577118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+  sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+  md5: f7a7ff5a6ab331e037abd34f379a631d
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: LGPL-2.1-or-later
+  run_exports:
+    weak:
+    - libxcrypt >=4.4.38
+  size: 101957
+  timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+  sha256: 046f2ff4acebd8729fac03e99c8c307dfb48b6a32894ba8c11576e78f6e76e43
+  md5: dc8b067e22b414172bedd8e3f03f3c95
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxkbcommon >=1.13.2,<2.0a0
+  size: 851166
+  timestamp: 1780213397575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+  sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
+  md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - libxml2 2.15.3
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 559775
+  timestamp: 1776376739004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+  sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
+  md5: 995d8c8bad2a3cc8db14675a153dec2b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2-16 2.15.3 hca6bf5a_0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxml2
+    - libxml2-16 >=2.15.3
+  size: 46810
+  timestamp: 1776376751152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
+  sha256: 0694760a3e62bdc659d90a14ae9c6e132b525a7900e59785b18a08bb52a5d7e5
+  md5: 87e6096ec6d542d1c1f8b33245fe8300
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libxslt >=1.1.43,<2.0a0
+  size: 245434
+  timestamp: 1757963724977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
+  sha256: a37aba21b85800af1e7c5b04ba76abab96b6e591eedf99dc6e4df83b0fefd7a5
+  md5: 7bbfdc5a6eca997d3b0873a575c3e155
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.8|22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    strong:
+    - llvm-openmp >=22.1.8
+    - _openmp_mutex >=4.5
+    - _openmp_mutex * *_llvm
+  size: 6123597
+  timestamp: 1781736521736
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.11.1-py314h815e797_2.conda
+  sha256: 5dc6c469ed94cba223272ba70be250b5820e88640c8fdfe4ae85b2966b8d4b67
+  md5: 19db05d03d18c1746c2212bc83e9c4c2
+  depends:
+  - matplotlib-base >=3.11.1,<3.11.2.0a0
+  - pyside6 >=6.7.2
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - tornado >=5
+  license: PSF-2.0
+  license_family: PSF
+  run_exports: {}
+  size: 15007
+  timestamp: 1785211130117
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py314h9a9c090_2.conda
+  sha256: d76657ece6fef30e44fca988a0a884cf5744f2fb1611814c5c993700148fbefa
+  md5: 57f668cbc4b70c11ea9d19ebed67295e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.28.2
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libraqm >=0.11.0,<0.12.0a0
+  - libstdcxx >=14
+  - numpy >=1.25
+  - numpy >=1.25,<3
+  - packaging >=20.0
+  - pillow >=9
+  - pyparsing >=3
+  - python >=3.14,<3.15.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.14.* *_cp314
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  run_exports: {}
+  size: 9068707
+  timestamp: 1785211110030
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py314h2b28147_0.conda
+  sha256: 124b753583ea9c157301fe78de3e88aa5fa8806bd2da8abaa8808065d1b93d51
+  md5: d77631addad93399a90157d2c597e7f3
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 9119694
+  timestamp: 1786330625923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+  sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
+  md5: 11b3379b191f63139e29c0d19dee24cd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.1,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - openjpeg >=2.5.4,<3.0a0
+  size: 355400
+  timestamp: 1758489294972
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+  md5: 680608784722880fbfe1745067570b00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.6,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  run_exports:
+    weak:
+    - openldap >=2.6.13,<2.7.0a0
+  size: 786149
+  timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3182423
+  timestamp: 1785913583650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+  md5: 7a3bff861a6583f1889021facefc08b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - pcre2 >=10.47,<10.48.0a0
+  size: 1222481
+  timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py314h8ec4b1a_0.conda
+  sha256: bcab128df8980514061a78b9c67f5004954048f584da20df8c5a78de9e3f5abb
+  md5: 233e62a8eb894b79b5c93f4f8dec4dcd
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libtiff >=4.7.1,<4.8.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - python_abi 3.14.* *_cp314
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lcms2 >=2.19.1,<3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  run_exports: {}
+  size: 1108174
+  timestamp: 1782912080163
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+  sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+  md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
+  size: 376704
+  timestamp: 1786106621354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+  sha256: afc3b27b2cbb0487c1d0e963f96e71181ecfb623a24fb393bb19ff974a6382a1
+  md5: df2c27f36bdb0dde779f55b5df76a352
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 9115
+  timestamp: 1786067714761
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py314h3987850_1.conda
+  sha256: e410d0d4151f418dc75ea2dc38dfb0e7a136090b6874e5ca1c699fa840b4994d
+  md5: 5d2051f0630a568926943fc53c0aaa4c
+  depends:
+  - python
+  - qt6-main 6.11.1.*
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libxslt >=1.1.43,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - python_abi 3.14.* *_cp314
+  - qt6-main >=6.11.1,<6.12.0a0
+  - libclang13 >=22.1.5
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports: {}
+  size: 13821776
+  timestamp: 1778933872780
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+  build_number: 102
+  sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+  md5: 9b6c336ef7195fbee1c10c09bfcf901b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  run_exports:
+    weak:
+    - python_abi 3.14.* *_cp314
+    noarch:
+    - python
+  size: 36866750
+  timestamp: 1786444737142
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+  sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+  md5: 353823361b1d27eb3960efb076dfcaf6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LicenseRef-Qhull
+  run_exports:
+    weak:
+    - qhull >=2020.2,<2020.3.0a0
+  size: 552937
+  timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.1-pl5321h16c4a6b_1.conda
+  sha256: aefbc43bde188ff4027d480da99c7fa9e8e6341e9762e065190239cb9b99bb1c
+  md5: 331d660aef48fec733a878dd1f8f4206
+  depends:
+  - libxcb
+  - xcb-util
+  - xcb-util-wm
+  - xcb-util-keysyms
+  - xcb-util-image
+  - xcb-util-renderutil
+  - xcb-util-cursor
+  - libgl-devel
+  - libegl-devel
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - fontconfig >=2.18.1,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libpq >=18.4,<19.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - wayland >=1.25.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - harfbuzz >=14.2.1
+  - xcb-util-cursor >=0.1.6,<0.2.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libdrm >=2.4.127,<2.5.0a0
+  - xorg-libxcomposite >=0.4.7,<1.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - icu >=78.3,<79.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - alsa-lib >=1.2.16,<1.3.0a0
+  - openssl >=3.5.6,<4.0a0
+  - libglib >=2.88.1,<3.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libxkbcommon >=1.13.2,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - double-conversion >=3.4.0,<3.5.0a0
+  - dbus >=1.16.2,<2.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  constrains:
+  - qt ==6.11.1
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports:
+    weak:
+    - qt6-main >=6.11.1,<7.0a0
+  size: 60185421
+  timestamp: 1780593127053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  run_exports:
+    weak:
+    - readline >=8.3,<9.0a0
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
+  sha256: ebec0d90f99fa7bbe91eabab41ee77d3f36dbd58ec2f08aa4220fdd713610b6d
+  md5: faea84d2f2ccadf70cf9e55381d75b3e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: Apache
+  run_exports: {}
+  size: 923237
+  timestamp: 1786226770518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
+  sha256: ff1c1d7c23b91c9b0eb93a3e1380f4e2ac6c37ea2bba4f932a5484e9a55bba30
+  md5: 494fdf358c152f9fdd0673c128c2f3dd
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: Apache
+  run_exports: {}
+  size: 409562
+  timestamp: 1770909102180
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
+  sha256: a8f1333274382d23721d6f72483ece364631231f8ac3f74389951b1ff2820148
+  md5: 47e3c5d0b1e968ee49efc7c3fa8ebc0c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - wayland >=1.26.0,<2.0a0
+  size: 339462
+  timestamp: 1786151675802
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+  md5: fdc27cb255a7a2cc73b7919a968b48f0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util >=0.4.1,<0.5.0a0
+  size: 20772
+  timestamp: 1750436796633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+  sha256: c2be9cae786fdb2df7c2387d2db31b285cf90ab3bfabda8fa75a596c3d20fc67
+  md5: 4d1fc190b99912ed557a8236e958c559
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.13
+  - libxcb >=1.17.0,<2.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-cursor >=0.1.6,<0.2.0a0
+  size: 20829
+  timestamp: 1763366954390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+  sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+  md5: a0901183f08b6c7107aab109733a3c91
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-image >=0.4.0,<0.5.0a0
+  size: 24551
+  timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+  sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+  md5: ad748ccca349aec3e91743e08b5e2b50
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  size: 14314
+  timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+  sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+  md5: 0e0cbe0564d03a99afd5fd7b362feecd
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  size: 16978
+  timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+  sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+  md5: 608e0ef8256b81d04456e8d211eee3e8
+  depends:
+  - libgcc-ng >=12
+  - libxcb >=1.16,<2.0.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xcb-util-wm >=0.4.2,<0.5.0a0
+  size: 51689
+  timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xeus-6.0.5-hbf34205_0.conda
+  sha256: 8ec1b66ae38f285c7ffb189e0f833079c88aee7334223b1cba45a5210b021621
+  md5: de79fb0836ea2840cca7719ec94a9958
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - nlohmann_json-abi ==3.12.0
+  - libuuid >=2.42,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - xeus >=6.0.5,<6.1.0a0
+  size: 411232
+  timestamp: 1776328566268
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xeus-zmq-4.0.0-ha280ed4_0.conda
+  sha256: 440a9c83c432bfc8ffb55f3764d9e31325a8b912acc17ba3bf0ad8e86748c5a3
+  md5: 1d7280c6f786768194eeaa6da2013c74
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - zeromq >=4.3.5,<4.4.0a0
+  - nlohmann_json-abi ==3.12.0
+  - openssl >=3.6.1,<4.0a0
+  - xeus >=6.0.1,<6.1.0a0
+  - libuuid >=2.41.3,<3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - xeus-zmq >=4.0.0,<4.1.0a0
+  size: 508540
+  timestamp: 1772664288344
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+  sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+  md5: b233b41be0bf210989d57160ed39b394
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 441670
+  timestamp: 1782027360439
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+  sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+  md5: 85c9442aec283b4e464fa9ecc484a2f3
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libice >=1.1.2,<2.0a0
+  size: 62517
+  timestamp: 1786474410404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+  sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+  md5: aa7459ed9ad086ba11dda843d764b33d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libice >=1.1.2,<2.0a0
+  - libuuid >=2.42.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libsm >=1.2.6,<2.0a0
+  size: 30739
+  timestamp: 1786545374265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libx11 >=1.8.13,<2.0a0
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+  sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+  md5: f06ef439c280a5f90b8bf62355008dbc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxau >=1.0.12,<2.0a0
+  size: 16419
+  timestamp: 1786381001122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+  sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
+  md5: f2ba4192d38b6cef2bb2c25029071d90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcomposite >=0.4.7,<1.0a0
+  size: 14415
+  timestamp: 1770044404696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxcursor >=1.2.3,<2.0a0
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdamage >=1.1.6,<2.0a0
+  size: 13217
+  timestamp: 1727891438799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+  sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+  md5: 2e66c929f3d879708335b6ea4557c838
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxdmcp >=1.1.5,<2.0a0
+  size: 21120
+  timestamp: 1786381006369
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+  md5: 34e54f03dfea3e7a2dcf1453a85f1085
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxext >=1.3.7,<2.0a0
+  size: 50326
+  timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
+  md5: ba231da7fccf9ea1e768caf5c7099b84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxfixes >=6.0.2,<7.0a0
+  size: 20071
+  timestamp: 1759282564045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+  sha256: 495f99c8eacfa4ae2d8fed2a7f2105777af89acdc204df145d2bbbc380ac631b
+  md5: adba2e334082bb218db806d4c12277c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxi >=1.8.3,<2.0a0
+  size: 47717
+  timestamp: 1779111857071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrandr >=1.5.5,<2.0a0
+  size: 30456
+  timestamp: 1769445263457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  md5: 96d57aba173e878a2089d5638016dc5e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxrender >=0.9.12,<0.10.0a0
+  size: 33005
+  timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxtst >=1.2.5,<2.0a0
+  size: 32808
+  timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+  sha256: 64db17baaf36fa03ed8fae105e2e671a7383e22df4077486646f7dbf12842c9f
+  md5: 665d152b9c6e78da404086088077c844
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - xorg-libxxf86vm >=1.1.7,<2.0a0
+  size: 18701
+  timestamp: 1769434732453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
+  sha256: 051c6088bf2381840fcf8764737b829cc6c5f793718d2417d097d6e3b153eba9
+  md5: 3b51576511038b50fdbd05245e22e4b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 594844
+  timestamp: 1786114408394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+  sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
+  md5: 96b08867e21d4694fa5c2c226e6581b0
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.22,<1.0.23.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  run_exports:
+    weak:
+    - zeromq >=4.3.5,<4.4.0a0
+  size: 311184
+  timestamp: 1779123989774
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+  sha256: 8b786bb4380fa69a718b08a400040b865bc9207eda337e0a1955717c3c3a9403
+  md5: 1726acec19beeed1c764385cd8622405
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libstdcxx >=15
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - zlib-ng >=2.3.3,<2.4.0a0
+  size: 123959
+  timestamp: 1786736890973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601301
+  timestamp: 1786599621503
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
   md5: 0f51e2391ade309db462a55611263e9c
@@ -147,6 +2511,28 @@ packages:
   run_exports: {}
   size: 49147
   timestamp: 1773495431639
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt22_linux-64-22.1.8-hffcefe0_1.conda
+  sha256: c6cd0a10b9b161b0b075a8a78083b23a49d87f0e383d2c199ce11a586fc7d779
+  md5: cbf060078c396f1e6bc5f02d9292ae9f
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 49013140
+  timestamp: 1781741112005
+- conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_linux-64-22.1.8-ha770c72_1.conda
+  sha256: 81bb0835e05ef4c60022aa594e16a870bbf39ed4d4180ef87191f56b795cd86c
+  md5: 552e1d9f624f815bf90262e4cb6cf04c
+  depends:
+  - compiler-rt22_linux-64 22.1.8 hffcefe0_1
+  constrains:
+  - clang 22.1.8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16599
+  timestamp: 1781741197576
 - conda: https://conda.anaconda.org/conda-forge/noarch/cssselect2-0.9.0-pyhd8ed1ab_0.conda
   sha256: 8c0a56ba4f2bd09b31bdb5779bc02e7a3f0976ac5f889c84aac09092d4b22d73
   md5: cd34e01e8eadea7d97d9de01d8345411
@@ -250,6 +2636,26 @@ packages:
   run_exports: {}
   size: 846038
   timestamp: 1778770337113
+- conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+  md5: 86d9cba083cd041bfbf242a01a7a1999
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 1278712
+  timestamp: 1765578681495
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+  sha256: b314251d957b16c71ec241119ac09b9530c5c4ce140026ec98d297f55d6c5e08
+  md5: 19b0151ecb1d122f706ebd2f82f9a017
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 3096495
+  timestamp: 1785375361053
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -277,6 +2683,7 @@ packages:
   - python >=3.9
   - python
   license: Apache-2.0
+  license_family: APACHE
   run_exports: {}
   size: 116363
   timestamp: 1785888127370
@@ -336,6 +2743,20 @@ packages:
   run_exports: {}
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+  md5: 13dc3adbc692664cd3beabd216434749
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-64 4.18.0 he073ed8_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  run_exports:
+    strong:
+    - __glibc >=2.28,<3.0.a0
+  size: 24008591
+  timestamp: 1765578833462
 - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
   sha256: 7c803480dbfb8b536b9bf6287fa2aa0a4f970f8c09075694174eb4550a4524cd
   md5: c0d0b883e97906f7524e2aac94be0e0d

--- a/pixi.lock
+++ b/pixi.lock
@@ -12,7 +12,11 @@ environments:
     packages:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cairocffi-1.7.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cairosvg-2.9.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cssselect2-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -21,17 +25,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.63.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nlohmann_json-abi-3.12.0-h0f90c79_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.2.0-h7d5ae5b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.1-py314h7bede21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py314hf8a3a22_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.2-h2b252f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
@@ -39,8 +48,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-h784d473_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hc7cc350_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.5.0-py314hf8a3a22_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.2.0-h1eee2c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lfortran-0.64.0-h52bc188_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-9_h51639a9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
@@ -48,6 +59,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-9_hb0561ab_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-he7e0567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
@@ -66,6 +78,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.34-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libraqm-0.11.0-h45af499_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.2-h282da08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h202fb40_1.conda
@@ -88,8 +101,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hd3d0363_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py314h6c2aa35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py314h6c2aa35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xeus-6.0.5-h3feff0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xeus-zmq-4.0.0-h5cc99d8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
@@ -102,6 +118,47 @@ packages:
   run_exports: {}
   size: 131780
   timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/cairocffi-1.7.1-pyhcf101f3_2.conda
+  sha256: d9b512f68f9d992b57b5e00975865ab96c41cc19c9796fe7e38dbd1967af379d
+  md5: abbc6f1de8881d826c8128a5d7bb8dec
+  depends:
+  - python >=3.10
+  - cffi >=1.1
+  - cairo >=1.14
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 75507
+  timestamp: 1767293947519
+- conda: https://conda.anaconda.org/conda-forge/noarch/cairosvg-2.9.0-pyhcf101f3_0.conda
+  sha256: b3213e9e13472d61a101323973aafed74c94ce5b6c2455745ab3c4a0bfb529b1
+  md5: 44ba28887af5adccee712125e0c3a2e4
+  depends:
+  - python >=3.10
+  - cairocffi
+  - cssselect2
+  - pillow
+  - tinycss2
+  - defusedxml
+  - python
+  license: LGPL-3.0-only
+  license_family: LGPL
+  run_exports: {}
+  size: 49147
+  timestamp: 1773495431639
+- conda: https://conda.anaconda.org/conda-forge/noarch/cssselect2-0.9.0-pyhd8ed1ab_0.conda
+  sha256: 8c0a56ba4f2bd09b31bdb5779bc02e7a3f0976ac5f889c84aac09092d4b22d73
+  md5: cd34e01e8eadea7d97d9de01d8345411
+  depends:
+  - python >=3.10
+  - tinycss2
+  - webencodings
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 20873
+  timestamp: 1770945592855
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -113,6 +170,16 @@ packages:
   run_exports: {}
   size: 14778
   timestamp: 1764466758386
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  run_exports: {}
+  size: 24062
+  timestamp: 1615232388757
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -193,6 +260,16 @@ packages:
   run_exports: {}
   size: 15851
   timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/noarch/nlohmann_json-abi-3.12.0-h0f90c79_2.conda
+  sha256: 30d271dd63391e053aa3c393c5d93fb622dec5d50a64107171ee28242660608e
+  md5: 849b8852621992c3f3a1901c939a0399
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - nlohmann_json-abi ==3.12.0
+  size: 4365
+  timestamp: 1785920576349
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
   sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
   md5: 936687ed80f295a1f5dbcf8bd34c252c
@@ -203,6 +280,17 @@ packages:
   run_exports: {}
   size: 116363
   timestamp: 1785888127370
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+  sha256: e27e0473fc6723311a0bd48b89b616fa1b996a2f7a2b555338cbbcfb9c640568
+  md5: 9c5491066224083c41b6d5635ed7107b
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 55886
+  timestamp: 1779293633166
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
   sha256: 417fba4783e528ee732afa82999300859b065dc59927344b4859c64aae7182de
   md5: 3687cc0b82a8b4c17e1f0eb7e47163d5
@@ -248,6 +336,18 @@ packages:
   run_exports: {}
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
+  sha256: 7c803480dbfb8b536b9bf6287fa2aa0a4f970f8c09075694174eb4550a4524cd
+  md5: c0d0b883e97906f7524e2aac94be0e0d
+  depends:
+  - python >=3.10
+  - webencodings >=0.4
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 30571
+  timestamp: 1764621508086
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
   sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
   md5: fcb489df604d100968b737f2cb6076c6
@@ -255,6 +355,16 @@ packages:
   run_exports: {}
   size: 118849
   timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+  sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
+  md5: 2841eb5bfc75ce15e9a0054b98dcd64d
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 15496
+  timestamp: 1733236131358
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
   build_number: 7
   sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
@@ -331,6 +441,21 @@ packages:
     - cairo >=1.18.4,<2.0a0
   size: 900035
   timestamp: 1766416416791
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.1-py314h7bede21_0.conda
+  sha256: b6c9358ee7cabfb417e6a8d2758c2241fe6b24f9fd316561a449ccac1959f8e1
+  md5: 4648b9514e3cd095788963779cebcc7a
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 297593
+  timestamp: 1785811327918
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py314hf8a3a22_4.conda
   sha256: 754ab72f1c1ae99ef7c57995f59224dc9632cbd6731fe7e6277437fd01d43156
   md5: cddc851000ce131d757678c2f329eaad
@@ -426,6 +551,22 @@ packages:
   run_exports: {}
   size: 69284
   timestamp: 1773067285911
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+  md5: 8780f41b013d19219faef9c82260744b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1159780
+  timestamp: 1781859501654
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
   sha256: ccb5598fad3694e79bf54f0eb812e3b3c3dd63d1497e631f5978800eadb9bcc4
   md5: d2f2c7c10e2957647d45589b7701a453
@@ -453,6 +594,20 @@ packages:
     - lerc >=4.2.0,<5.0a0
   size: 166477
   timestamp: 1785036480092
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lfortran-0.64.0-h52bc188_0.conda
+  sha256: 4d47b4d2596cc582a7fbbf407f8615b16d4e7503682645d877ee2914d4d8b4ca
+  md5: c01ed86b6be73d335e167a20f5d5d6a9
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libzlib >=1.3.2,<2.0a0
+  - xeus >=6.0.1,<6.1.0a0
+  - xeus-zmq >=4.0.0,<4.1.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 20208350
+  timestamp: 1784360131990
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-9_h51639a9_openblas.conda
   build_number: 9
   sha256: 0437866fe43b4c911470d3e7ddea18d78390bd7062d9563ce6d38c8ba5798405
@@ -547,6 +702,20 @@ packages:
     - libdeflate >=1.25,<1.26.0a0
   size: 55727
   timestamp: 1785909153744
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
+  sha256: 257c926f19e32bdb981fc674c76966049b6fc73f706bae58e9fed8757ad1da70
+  md5: 843ef89082f368cb889305084d3b483c
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 107742
+  timestamp: 1786616721640
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
   sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
   md5: a915151d5d3c5bf039f5ccc8402a436f
@@ -787,6 +956,17 @@ packages:
     - libraqm >=0.11.0,<0.12.0a0
   size: 31333
   timestamp: 1784850348342
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
+  sha256: 202be45db5726757a8ea1f374f85aacc18c504f5ff15b2558496dff4c8779c48
+  md5: 9ed5ab909c449bdcae72322e44875a18
+  depends:
+  - __osx >=11.0
+  license: ISC
+  run_exports:
+    weak:
+    - libsodium >=1.0.22,<1.0.23.0a0
+  size: 247352
+  timestamp: 1779164136206
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-h1ae2325_0.conda
   sha256: 745662565e103f290e9dc4263bbd88285082f8cf699854fe2d5f1e35a4a0d326
   md5: 0e3477c0c3e718dcf2eb74ccc8f68570
@@ -1127,6 +1307,37 @@ packages:
   run_exports: {}
   size: 416130
   timestamp: 1770909728445
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xeus-6.0.5-h3feff0a_0.conda
+  sha256: 28167da09fe43ae1d7c65fd099bb7bd3b4d729336ae06a495a185f0dc34ac1f1
+  md5: 6d7f82d33f7338e785d908bdf308fd25
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - nlohmann_json-abi ==3.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - xeus >=6.0.5,<6.1.0a0
+  size: 319780
+  timestamp: 1776328966204
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xeus-zmq-4.0.0-h5cc99d8_0.conda
+  sha256: f0d101dd79940a0598bd975f34794a9096fbf9003a67133254814dcc22d4e581
+  md5: 33db501dd01c34f5ba00cf0d5cbc869f
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - nlohmann_json-abi ==3.12.0
+  - xeus >=6.0.1,<6.1.0a0
+  - openssl >=3.6.1,<4.0a0
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - xeus-zmq >=4.0.0,<4.1.0a0
+  size: 385074
+  timestamp: 1772664418822
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
   sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
   md5: 78b548eed8227a689f93775d5d23ae09
@@ -1151,6 +1362,21 @@ packages:
     - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 19156
   timestamp: 1762977035194
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+  sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
+  md5: d31c0e54c4f9c51100ec8c812ee925d1
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.22,<1.0.23.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  run_exports:
+    weak:
+    - zeromq >=4.3.5,<4.4.0a0
+  size: 245404
+  timestamp: 1779124076307
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
   sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
   md5: d99c2a23a31b0172e90f456f580b695e

--- a/pixi.lock
+++ b/pixi.lock
@@ -28,7 +28,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py314h77c0f9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22-22.1.8-default_hd70ba2e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-22.1.8-default_cfg_hecfc6a8_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-22-22.1.8-default_h08c5240_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-22.1.8-default_h36682a0_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-scan-deps-22.1.8-default_h08c5240_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-22.1.8-default_h1af49a9_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang_impl_linux-64-22.1.8-default_h50bdbf7_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clangdev-22.1.8-default_ha525f51_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clangxx-22.1.8-default_cfg_h4f05b13_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clangxx_impl_linux-64-22.1.8-default_hb0aa002_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
@@ -36,6 +43,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flang-22.1.8-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flang_impl_linux-64-22.1.8-h0f0ccf8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/flang_linux-64-22.1.8-h2033497_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
@@ -54,6 +63,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-22.1.8-default_h9d0c7ec_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp-22.1.8-default_hd70ba2e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_hd70ba2e_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcompiler-rt-22.1.8-hb700be7_1.conda
@@ -65,6 +76,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflang-rt-22.1.8-ha4b6fd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
@@ -110,6 +122,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.8-h4922eb0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-22-22.1.8-h3b15d91_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-22.1.8-hb700be7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmdev-22.1.8-h3b15d91_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.11.1-py314h815e797_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py314h9a9c090_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
@@ -166,6 +181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cssselect2-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flang-rt_linux-64-22.1.8-he91c749_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -175,6 +191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonttools-4.63.0-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-16.1.0-h59071f9_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nlohmann_json-abi-3.12.0-h0f90c79_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
@@ -463,6 +480,84 @@ packages:
   run_exports: {}
   size: 33910
   timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-22-22.1.8-default_h08c5240_6.conda
+  sha256: 8e0fb4bf20bc89b5de16357e73a8d3344db814aafcab354aecf968571e62fb21
+  md5: 1705e9df386706e6ebb26cc6e4337b64
+  depends:
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 76743
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-22.1.8-default_h36682a0_6.conda
+  sha256: 03a3c632e594375b1416c0baf9131596aa4b11e80a8f557f69162fd1c7aed309
+  md5: 23251f71f96479dd41634c313005199f
+  depends:
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - clang-format-22 ==22.1.8 default_h08c5240_6
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 33491
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-scan-deps-22.1.8-default_h08c5240_6.conda
+  sha256: f41e133972fdd5ae6d72316b629c4c8824b40149afe584df09566689c4fe5b52
+  md5: e76648ddae27c576062a043513f63667
+  depends:
+  - libclang13 >=22.1.8
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 111107
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-22.1.8-default_h1af49a9_6.conda
+  sha256: ce6381b8a5d144d38d092c9cd9bfcf2fc303b9bf5bb45ddf3691767a1b3cdceb
+  md5: af79a61a5dbeb831893f942c924559eb
+  depends:
+  - clang-format ==22.1.8 default_h36682a0_6
+  - libclang13 >=22.1.8
+  - clang-scan-deps ==22.1.8 default_h08c5240_6
+  - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  constrains:
+  - clangdev ==22.1.8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 11711544
+  timestamp: 1786527767794
 - conda: https://conda.anaconda.org/conda-forge/linux-64/clang_impl_linux-64-22.1.8-default_h50bdbf7_6.conda
   sha256: 1899da88b21621d4f155e53ddf30330ae7e1e851920524d0bb28ce9c8f20c8f2
   md5: 28db002a4e4fcbdab5cf70ac2ca1ab26
@@ -484,6 +579,68 @@ packages:
   license_family: APACHE
   run_exports: {}
   size: 33470
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clangdev-22.1.8-default_ha525f51_6.conda
+  sha256: 75cac230a7932ce4704497d3fcc58445db458b49a49b8ced535def82d50eae27
+  md5: 087d4b7169d6872ba86a960bd91b1b31
+  depends:
+  - clang ==22.1.8 default_*_6
+  - clangxx ==22.1.8 default_*_6
+  - clang-tools ==22.1.8 default_h1af49a9_6
+  - libclang ==22.1.8 default_h9d0c7ec_6
+  - libclang-cpp ==22.1.8 default_hd70ba2e_6
+  - llvmdev ==22.1.8
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 61993195
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clangxx-22.1.8-default_cfg_h4f05b13_6.conda
+  sha256: d61d7beea486f43401cf5bcecce83afcd7d9e3543802db471b2efd2ce7cd9602
+  md5: 5cfebd4b8aee9a888bbdf5a00482dc79
+  depends:
+  - clang ==22.1.8 default_cfg_hecfc6a8_6
+  - clangxx_impl_linux-64 ==22.1.8 default_*
+  - libstdcxx-devel_linux-64
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 33938
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/clangxx_impl_linux-64-22.1.8-default_hb0aa002_6.conda
+  sha256: 125a870765d658267b072069e390b47153c23a19dbfe9353840eee2b4a8841c0
+  md5: 216df297860fcb21b1e524c4afd82407
+  depends:
+  - clang-22 ==22.1.8 default_hd70ba2e_6
+  - clang_impl_linux-64 ==22.1.8 default_h50bdbf7_6
+  - clang-scan-deps ==22.1.8 default_h08c5240_6
+  - libstdcxx-devel_linux-64
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 33626
   timestamp: 1786527767794
 - conda: https://conda.anaconda.org/conda-forge/linux-64/compiler-rt-22.1.8-ha770c72_1.conda
   sha256: 7ea97a24a9847f7ec91b959c405a9bc5b9c28d4078175dce2d2f8a2014f74969
@@ -590,6 +747,31 @@ packages:
   run_exports: {}
   size: 71960605
   timestamp: 1781833417650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/flang_impl_linux-64-22.1.8-h0f0ccf8_0.conda
+  sha256: b28039ad0e1f24adae870758c42d5bc17592373ec2ab9f874e19175ec9bbaa03
+  md5: b52a3910c98999684b16548b2b45e96e
+  depends:
+  - compiler-rt_linux-64 22.1.8.*
+  - flang 22.1.8.*
+  - flang-rt_linux-64 22.1.8.*
+  - libflang-rt
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 9279
+  timestamp: 1782114115461
+- conda: https://conda.anaconda.org/conda-forge/linux-64/flang_linux-64-22.1.8-h2033497_0.conda
+  sha256: 28a2bef0d7a3dfa14672b713cbde6aa84c46e6f6b3db70ba945cc24330a1bdc6
+  md5: bf52ef496963fa9866a206d6ff89e1ec
+  depends:
+  - flang_impl_linux-64 22.1.8 h0f0ccf8_0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libflang-rt >=22.1.8
+  size: 9160
+  timestamp: 1782114122526
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
   sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
   md5: 922776b528a470ab5afa81fd42abfa1d
@@ -853,6 +1035,46 @@ packages:
     - libcblas >=3.11.0,<4.0a0
   size: 17998
   timestamp: 1786059041397
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-22.1.8-default_h9d0c7ec_6.conda
+  sha256: 049f89c9ded7971d20eb3863ac596453ee69f6aa1cdc9cfaa4b39af9653021bf
+  md5: f0ad6b4657fd024a4b2cd47ab41cb9d6
+  depends:
+  - libclang13 ==22.1.8 default_hd70ba2e_6
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libclang13 >=22.1.8
+  - libllvm22 >=22.1.8,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang13 >=22.1.8
+  size: 33798
+  timestamp: 1786527767794
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp-22.1.8-default_hd70ba2e_6.conda
+  sha256: 802ffd4f54aaa1fb3df835b425f4af93b799072e1d755b441696056ad232ad76
+  md5: d9e7b232e8bdb2aad8c9c798230733c8
+  depends:
+  - libclang-cpp22.1 ==22.1.8 default_h08c5240_6
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libclang-cpp22.1 >=22.1.8,<22.2.0a0
+  size: 33388
+  timestamp: 1786527767794
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
   sha256: fc2981a8e45dd232ae88cf2580f7e75c258f4dccdc96f879b68ef0a9b45c9a2b
   md5: 4fd9026a57bb45cd15bd08ff8bd0578e
@@ -1016,6 +1238,18 @@ packages:
     - libffi >=3.7.0,<3.8.0a0
   size: 67576
   timestamp: 1783520858222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflang-rt-22.1.8-ha4b6fd6_0.conda
+  sha256: 3e7f3bb3e1dc6abfab68e3b1332f3229a4f27537b5555c803c72d46fb51432c3
+  md5: 637fe3f1ff4ba7dde0429f4ca7193c23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - libflang <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 2621537
+  timestamp: 1782100420199
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
   sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
   md5: f8054e759d0ddddaf34a5c8fedc900a1
@@ -1665,6 +1899,61 @@ packages:
     - _openmp_mutex * *_llvm
   size: 6123597
   timestamp: 1781736521736
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-22-22.1.8-h3b15d91_1.conda
+  sha256: 4254fd20ade5805fa8077ed3e55ad41ded5a55664eebb481ed9fb14fd2160096
+  md5: 03d4efdf67c10aeee6421fa06718f460
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm22 22.1.8 hf7376ad_1
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 25423925
+  timestamp: 1781788869565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-tools-22.1.8-hb700be7_1.conda
+  sha256: 42941d4444053ebbfbf75b9005b54146299bc2238357f804b3cb3ff70f735207
+  md5: f53bc74f933396d55b62e84829f28975
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm22 22.1.8 hf7376ad_1
+  - libstdcxx >=14
+  - llvm-tools-22 22.1.8 h3b15d91_1
+  constrains:
+  - clang       22.1.8
+  - clang-tools 22.1.8
+  - llvm        22.1.8
+  - llvmdev     22.1.8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 51645
+  timestamp: 1781788934766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmdev-22.1.8-h3b15d91_1.conda
+  sha256: f03a3e4b7bf512adc0888892fe6c9686535356232d6024ecf4b0535115706c95
+  md5: ab54d862ee3e7958c73b4ddb6d9a92f3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libllvm22 22.1.8 hf7376ad_1
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - llvm-tools 22.1.8 hb700be7_1
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - llvm-tools  22.1.8
+  - clang       22.1.8
+  - clang-tools 22.1.8
+  - llvm        22.1.8
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 61171584
+  timestamp: 1781789013543
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.11.1-py314h815e797_2.conda
   sha256: 5dc6c469ed94cba223272ba70be250b5820e88640c8fdfe4ae85b2966b8d4b67
   md5: 19db05d03d18c1746c2212bc83e9c4c2
@@ -2566,6 +2855,17 @@ packages:
   run_exports: {}
   size: 24062
   timestamp: 1615232388757
+- conda: https://conda.anaconda.org/conda-forge/noarch/flang-rt_linux-64-22.1.8-he91c749_0.conda
+  sha256: ba1c0ce72d9ffaefa192a141579ba852a612c30d8e4839eefe15a3634f7fb6fd
+  md5: 8ecee24d8e7410ba9f6808e32063af05
+  depends:
+  - clangdev 22.1.8
+  - flang 22.1.8
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports: {}
+  size: 4981543
+  timestamp: 1782100403388
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -2656,6 +2956,16 @@ packages:
   run_exports: {}
   size: 3096495
   timestamp: 1785375361053
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-16.1.0-h41cdd0d_101.conda
+  sha256: c1521172f2fdf5510d79b621ea835064209fe3131518e0d8b2b43362a75e7b4c
+  md5: 8593636203272a748b63d56cbd674753
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 22519609
+  timestamp: 1785375386152
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609

--- a/pixi.toml
+++ b/pixi.toml
@@ -22,3 +22,6 @@ compare = "python tests/gen_mpl_refs.py && bash scripts/build_flang.sh && mkdir 
 python = ">=3.14.6,<3.15"
 matplotlib = ">=3.11.1,<4"
 numpy = ">=2.5.1,<3"
+cairosvg = ">=2.9.0,<3"
+pillow = ">=12.3.0,<13"
+lfortran = ">=0.64.0,<0.65"

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,4 +27,4 @@ pillow = ">=12.3.0,<13"
 lfortran = ">=0.64.0,<0.65"
 
 [target.linux-64.dependencies]
-flang = ">=22,<23"
+flang_linux-64 = ">=22,<23"

--- a/pixi.toml
+++ b/pixi.toml
@@ -2,7 +2,7 @@
 authors = ["Ondřej Čertík <ondrej@certik.us>"]
 channels = ["conda-forge"]
 name = "fplot"
-platforms = ["osx-arm64"]
+platforms = ["osx-arm64", "linux-64"]
 version = "0.1.0"
 
 [tasks]
@@ -25,3 +25,6 @@ numpy = ">=2.5.1,<3"
 cairosvg = ">=2.9.0,<3"
 pillow = ">=12.3.0,<13"
 lfortran = ">=0.64.0,<0.65"
+
+[target.linux-64.dependencies]
+flang = ">=22,<23"

--- a/scripts/build_flang.sh
+++ b/scripts/build_flang.sh
@@ -4,8 +4,12 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="$ROOT/build/flang"
 mkdir -p "$BUILD" "$ROOT/tests/out"
 
-# conda-forge's flang_linux-64 activation sets FC to the target wrapper.
-FLANG="${FLANG:-${FC:-flang}}"
+# Use the `flang` frontend on PATH. Do not honor $FC: conda-forge's
+# flang_linux-64 activation sets FC="${CHOST}-flang", which becomes
+# "-flang" under pixi because CHOST is unset.
+case "${FLANG:-}" in
+    ""|-*) FLANG=flang ;;
+esac
 echo "Using compiler: $FLANG"
 
 cd "$BUILD"

--- a/scripts/build_flang.sh
+++ b/scripts/build_flang.sh
@@ -4,7 +4,8 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD="$ROOT/build/flang"
 mkdir -p "$BUILD" "$ROOT/tests/out"
 
-FLANG="${FLANG:-flang}"
+# conda-forge's flang_linux-64 activation sets FC to the target wrapper.
+FLANG="${FLANG:-${FC:-flang}}"
 echo "Using compiler: $FLANG"
 
 cd "$BUILD"

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -498,7 +498,7 @@ contains
         type(axes_t), intent(in) :: a
         integer, intent(in) :: idx
         real(dp), intent(in) :: W, H
-        real(dp) :: axl, axr, axb, axt, axw, axh
+        real(dp) :: ax_l, ax_r, ax_b, ax_t, ax_w, ax_h
         real(dp) :: xmin, xmax, ymin, ymax
         real(dp) :: xticks(MAX_TICKS), yticks(MAX_TICKS)
         integer :: nxt, nyt, i, j, n, nl
@@ -510,12 +510,12 @@ contains
         integer :: n_leg, k, max_lbl
         real(dp) :: leg_x, leg_y, leg_w, leg_h, row_h
 
-        axl = a%left * W
-        axr = a%right * W
-        axb = (1.0_dp - a%bottom) * H
-        axt = (1.0_dp - a%top) * H
-        axw = axr - axl
-        axh = axb - axt
+        ax_l = a%left * W
+        ax_r = a%right * W
+        ax_b = (1.0_dp - a%bottom) * H
+        ax_t = (1.0_dp - a%top) * H
+        ax_w = ax_r - ax_l
+        ax_h = ax_b - ax_t
 
         call compute_limits(a, xmin, xmax, ymin, ymax)
         xlog = a%xscale == SCALE_LOG
@@ -536,51 +536,51 @@ contains
         call builder_append(b, '<defs><clipPath id="axclip')
         call builder_append(b, int_to_str(idx))
         call builder_append(b, '"><rect x="')
-        call append_num(b, axl)
+        call append_num(b, ax_l)
         call builder_append(b, '" y="')
-        call append_num(b, axt)
+        call append_num(b, ax_t)
         call builder_append(b, '" width="')
-        call append_num(b, axw)
+        call append_num(b, ax_w)
         call builder_append(b, '" height="')
-        call append_num(b, axh)
+        call append_num(b, ax_h)
         call builder_append(b, '"/></clipPath></defs>')
         call builder_append(b, new_line("a"))
 
         ! axes face
         call builder_append(b, '<rect x="')
-        call append_num(b, axl)
+        call append_num(b, ax_l)
         call builder_append(b, '" y="')
-        call append_num(b, axt)
+        call append_num(b, ax_t)
         call builder_append(b, '" width="')
-        call append_num(b, axw)
+        call append_num(b, ax_w)
         call builder_append(b, '" height="')
-        call append_num(b, axh)
+        call append_num(b, ax_h)
         call builder_append(b, '" fill="#ffffff"/>')
         call builder_append(b, new_line("a"))
 
         ! grid
         if (a%grid_on) then
             do i = 1, nxt
-                px = map_x(xticks(i), xmin, xmax, axl, axw, xlog)
+                px = map_x(xticks(i), xmin, xmax, ax_l, ax_w, xlog)
                 call builder_append(b, '<line x1="')
                 call append_num(b, px)
                 call builder_append(b, '" y1="')
-                call append_num(b, axt)
+                call append_num(b, ax_t)
                 call builder_append(b, '" x2="')
                 call append_num(b, px)
                 call builder_append(b, '" y2="')
-                call append_num(b, axb)
+                call append_num(b, ax_b)
                 call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
                 call builder_append(b, new_line("a"))
             end do
             do i = 1, nyt
-                py = map_y(yticks(i), ymin, ymax, axb, axh, ylog)
+                py = map_y(yticks(i), ymin, ymax, ax_b, ax_h, ylog)
                 call builder_append(b, '<line x1="')
-                call append_num(b, axl)
+                call append_num(b, ax_l)
                 call builder_append(b, '" y1="')
                 call append_num(b, py)
                 call builder_append(b, '" x2="')
-                call append_num(b, axr)
+                call append_num(b, ax_r)
                 call builder_append(b, '" y2="')
                 call append_num(b, py)
                 call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
@@ -609,8 +609,8 @@ contains
                 do j = 1, n
                     if (a%xscale == SCALE_LOG .and. a%series(i)%x(j) <= 0.0_dp) cycle
                     if (a%yscale == SCALE_LOG .and. a%series(i)%y(j) <= 0.0_dp) cycle
-                    px = map_x(a%series(i)%x(j), xmin, xmax, axl, axw, xlog)
-                    py = map_y(a%series(i)%y(j), ymin, ymax, axb, axh, ylog)
+                    px = map_x(a%series(i)%x(j), xmin, xmax, ax_l, ax_w, xlog)
+                    py = map_y(a%series(i)%y(j), ymin, ymax, ax_b, ax_h, ylog)
                     if (nl > 0) call builder_append(b, " ")
                     call append_num(b, px)
                     call builder_append(b, ",")
@@ -626,8 +626,8 @@ contains
                 do j = 1, n
                     if (a%xscale == SCALE_LOG .and. a%series(i)%x(j) <= 0.0_dp) cycle
                     if (a%yscale == SCALE_LOG .and. a%series(i)%y(j) <= 0.0_dp) cycle
-                    px = map_x(a%series(i)%x(j), xmin, xmax, axl, axw, xlog)
-                    py = map_y(a%series(i)%y(j), ymin, ymax, axb, axh, ylog)
+                    px = map_x(a%series(i)%x(j), xmin, xmax, ax_l, ax_w, xlog)
+                    py = map_y(a%series(i)%y(j), ymin, ymax, ax_b, ax_h, ylog)
                     select case (a%series(i)%marker)
                     case (MARKER_CIRCLE)
                         r = 0.5_dp * ms * 0.75_dp
@@ -686,34 +686,34 @@ contains
 
         ! spines
         call builder_append(b, '<rect x="')
-        call append_num(b, axl)
+        call append_num(b, ax_l)
         call builder_append(b, '" y="')
-        call append_num(b, axt)
+        call append_num(b, ax_t)
         call builder_append(b, '" width="')
-        call append_num(b, axw)
+        call append_num(b, ax_w)
         call builder_append(b, '" height="')
-        call append_num(b, axh)
+        call append_num(b, ax_h)
         call builder_append(b, '" fill="none" stroke="#000000" stroke-width="0.8"/>')
         call builder_append(b, new_line("a"))
 
         ! x ticks
         do i = 1, nxt
-            px = map_x(xticks(i), xmin, xmax, axl, axw, xlog)
+            px = map_x(xticks(i), xmin, xmax, ax_l, ax_w, xlog)
             call builder_append(b, '<line x1="')
             call append_num(b, px)
             call builder_append(b, '" y1="')
-            call append_num(b, axb)
+            call append_num(b, ax_b)
             call builder_append(b, '" x2="')
             call append_num(b, px)
             call builder_append(b, '" y2="')
-            call append_num(b, axb + 3.5_dp)
+            call append_num(b, ax_b + 3.5_dp)
             call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
             call builder_append(b, new_line("a"))
             call format_tick_to(xticks(i), xlog, lbl, ln)
             call builder_append(b, '<text x="')
             call append_num(b, px)
             call builder_append(b, '" y="')
-            call append_num(b, axb + 16.0_dp)
+            call append_num(b, ax_b + 16.0_dp)
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="10" fill="#000000">')
             call builder_append(b, lbl(1:ln))
@@ -723,20 +723,20 @@ contains
 
         ! y ticks
         do i = 1, nyt
-            py = map_y(yticks(i), ymin, ymax, axb, axh, ylog)
+            py = map_y(yticks(i), ymin, ymax, ax_b, ax_h, ylog)
             call builder_append(b, '<line x1="')
-            call append_num(b, axl)
+            call append_num(b, ax_l)
             call builder_append(b, '" y1="')
             call append_num(b, py)
             call builder_append(b, '" x2="')
-            call append_num(b, axl - 3.5_dp)
+            call append_num(b, ax_l - 3.5_dp)
             call builder_append(b, '" y2="')
             call append_num(b, py)
             call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
             call builder_append(b, new_line("a"))
             call format_tick_to(yticks(i), ylog, lbl, ln)
             call builder_append(b, '<text x="')
-            call append_num(b, axl - 7.0_dp)
+            call append_num(b, ax_l - 7.0_dp)
             call builder_append(b, '" y="')
             call append_num(b, py + 3.5_dp)
             call builder_append(b, '" text-anchor="end" font-family="DejaVu Sans, sans-serif" ')
@@ -749,9 +749,9 @@ contains
         if (len_trim(a%xlabel) > 0) then
             call xml_escape_to(a%xlabel, esc, en)
             call builder_append(b, '<text x="')
-            call append_num(b, 0.5_dp * (axl + axr))
+            call append_num(b, 0.5_dp * (ax_l + ax_r))
             call builder_append(b, '" y="')
-            call append_num(b, axb + 28.6_dp)
+            call append_num(b, ax_b + 28.6_dp)
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="11" fill="#000000">')
             call builder_append(b, esc(1:en))
@@ -762,14 +762,14 @@ contains
         if (len_trim(a%ylabel) > 0) then
             call xml_escape_to(a%ylabel, esc, en)
             call builder_append(b, '<text x="')
-            call append_num(b, axl - 34.0_dp)
+            call append_num(b, ax_l - 34.0_dp)
             call builder_append(b, '" y="')
-            call append_num(b, 0.5_dp * (axt + axb))
+            call append_num(b, 0.5_dp * (ax_t + ax_b))
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="11" fill="#000000" transform="rotate(-90 ')
-            call append_num(b, axl - 34.0_dp)
+            call append_num(b, ax_l - 34.0_dp)
             call builder_append(b, " ")
-            call append_num(b, 0.5_dp * (axt + axb))
+            call append_num(b, 0.5_dp * (ax_t + ax_b))
             call builder_append(b, ')">')
             call builder_append(b, esc(1:en))
             call builder_append(b, "</text>")
@@ -780,9 +780,9 @@ contains
         if (len_trim(a%title) > 0) then
             call xml_escape_to(a%title, esc, en)
             call builder_append(b, '<text x="')
-            call append_num(b, 0.5_dp * (axl + axr))
+            call append_num(b, 0.5_dp * (ax_l + ax_r))
             call builder_append(b, '" y="')
-            call append_num(b, axt - 6.0_dp)
+            call append_num(b, ax_t - 6.0_dp)
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="12" fill="#000000">')
             call builder_append(b, esc(1:en))
@@ -805,10 +805,10 @@ contains
                 ! Sample line (leg_x+8 .. leg_x+28), gap to the text at
                 ! leg_x+34, the label itself, and a trailing pad.
                 leg_w = 34.0_dp + real(max_lbl, dp) * LEGEND_CHAR_W + 8.0_dp
-                leg_w = min(leg_w, axw - 16.0_dp)
+                leg_w = min(leg_w, ax_w - 16.0_dp)
                 leg_h = 8.0_dp + real(n_leg, dp) * row_h
-                leg_x = axr - leg_w - 8.0_dp
-                leg_y = axt + 8.0_dp
+                leg_x = ax_r - leg_w - 8.0_dp
+                leg_y = ax_t + 8.0_dp
                 call builder_append(b, '<rect x="')
                 call append_num(b, leg_x)
                 call builder_append(b, '" y="')

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -65,9 +65,9 @@ module fplot
     real(dp), save :: fig_w_in = 6.4_dp
     real(dp), save :: fig_h_in = 4.8_dp
     character(len=256), save :: fig_suptitle = ""
-    type(axes_t), allocatable, save, target :: ax(:)
+    type(axes_t), allocatable, save :: ax(:)
     integer, save :: n_ax = 0
-    type(axes_t), pointer, save :: cur => null()
+    integer, save :: cur_i = 0
     integer, save :: grid_m = 0, grid_n = 0
     logical, save :: fig_initialized = .false.
 
@@ -76,9 +76,9 @@ contains
     subroutine ensure_fig()
         if (.not. fig_initialized) call clf()
         ! No axes yet: create a single full-figure axes (pylab default).
-        if (.not. associated(cur)) then
+        if (cur_i < 1 .or. cur_i > n_ax) then
             call new_axes_grid(1, 1)
-            cur => ax(1)
+            cur_i = 1
         end if
     end subroutine ensure_fig
 
@@ -125,7 +125,7 @@ contains
 
     subroutine clf()
         integer :: i
-        cur => null()
+        cur_i = 0
         if (n_ax > 0 .and. allocated(ax)) then
             do i = 1, n_ax
                 call clear_axes(ax(i))
@@ -148,7 +148,7 @@ contains
         integer :: i, r, c
         real(dp) :: w, h
 
-        cur => null()
+        cur_i = 0
         if (n_ax > 0 .and. allocated(ax)) then
             do i = 1, n_ax
                 call clear_axes(ax(i))
@@ -227,10 +227,10 @@ contains
         if (.not. fig_initialized) call clf()
 
         if (n_ax == mm * nn .and. grid_m == mm .and. grid_n == nn) then
-            cur => ax(ii)
+            cur_i = ii
         else
             call new_axes_grid(mm, nn)
-            cur => ax(ii)
+            cur_i = ii
         end if
     end subroutine subplot
 
@@ -243,46 +243,46 @@ contains
     subroutine title(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        cur%title = s
+        ax(cur_i)%title = s
     end subroutine title
 
     subroutine xlabel(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        cur%xlabel = s
+        ax(cur_i)%xlabel = s
     end subroutine xlabel
 
     subroutine ylabel(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        cur%ylabel = s
+        ax(cur_i)%ylabel = s
     end subroutine ylabel
 
     subroutine grid(on)
         logical, intent(in) :: on
         call ensure_fig()
-        cur%grid_on = on
+        ax(cur_i)%grid_on = on
     end subroutine grid
 
     subroutine legend()
         call ensure_fig()
-        cur%legend_on = .true.
+        ax(cur_i)%legend_on = .true.
     end subroutine legend
 
     subroutine xlim(xmin, xmax)
         real(dp), intent(in) :: xmin, xmax
         call ensure_fig()
-        cur%xmin_user = xmin
-        cur%xmax_user = xmax
-        cur%xlim_set = .true.
+        ax(cur_i)%xmin_user = xmin
+        ax(cur_i)%xmax_user = xmax
+        ax(cur_i)%xlim_set = .true.
     end subroutine xlim
 
     subroutine ylim(ymin, ymax)
         real(dp), intent(in) :: ymin, ymax
         call ensure_fig()
-        cur%ymin_user = ymin
-        cur%ymax_user = ymax
-        cur%ylim_set = .true.
+        ax(cur_i)%ymin_user = ymin
+        ax(cur_i)%ymax_user = ymax
+        ax(cur_i)%ylim_set = .true.
     end subroutine ylim
 
     subroutine plot(x, y, fmt, label, lw, color, marker, linestyle)
@@ -290,7 +290,7 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color, marker, linestyle
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        call add_series(cur, x, y, fmt, label, lw, color, marker, linestyle)
+        call add_series(cur_i, x, y, fmt, label, lw, color, marker, linestyle)
     end subroutine plot
 
     subroutine semilogx(x, y, fmt, label, lw, color)
@@ -298,8 +298,8 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        cur%xscale = SCALE_LOG
-        call add_series(cur, x, y, fmt, label, lw, color)
+        ax(cur_i)%xscale = SCALE_LOG
+        call add_series(cur_i, x, y, fmt, label, lw, color)
     end subroutine semilogx
 
     subroutine semilogy(x, y, fmt, label, lw, color)
@@ -307,8 +307,8 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        cur%yscale = SCALE_LOG
-        call add_series(cur, x, y, fmt, label, lw, color)
+        ax(cur_i)%yscale = SCALE_LOG
+        call add_series(cur_i, x, y, fmt, label, lw, color)
     end subroutine semilogy
 
     subroutine loglog(x, y, fmt, label, lw, color)
@@ -316,13 +316,13 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        cur%xscale = SCALE_LOG
-        cur%yscale = SCALE_LOG
-        call add_series(cur, x, y, fmt, label, lw, color)
+        ax(cur_i)%xscale = SCALE_LOG
+        ax(cur_i)%yscale = SCALE_LOG
+        call add_series(cur_i, x, y, fmt, label, lw, color)
     end subroutine loglog
 
-    subroutine add_series(a, x, y, fmt, label, lw, color, marker, linestyle)
-        type(axes_t), intent(inout) :: a
+    subroutine add_series(ia, x, y, fmt, label, lw, color, marker, linestyle)
+        integer, intent(in) :: ia
         real(dp), intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: fmt, label, color, marker, linestyle
         real(dp), intent(in), optional :: lw
@@ -334,22 +334,22 @@ contains
         n = min(size(x), size(y))
         if (n <= 0) return
         if (n > MAX_POINTS) n = MAX_POINTS
-        if (a%n_series >= MAX_SERIES) return
+        if (ax(ia)%n_series >= MAX_SERIES) return
 
-        a%n_series = a%n_series + 1
-        is = a%n_series
-        call free_series(a, is)
+        ax(ia)%n_series = ax(ia)%n_series + 1
+        is = ax(ia)%n_series
+        call free_series(ax(ia), is)
 
-        allocate (a%series(is)%x(n), a%series(is)%y(n))
-        a%series(is)%x(1:n) = x(1:n)
-        a%series(is)%y(1:n) = y(1:n)
-        a%series(is)%n = n
-        a%series(is)%linewidth = default_linewidth
-        a%series(is)%markersize = default_markersize
-        a%series(is)%label = ""
-        a%series(is)%marker = MARKER_NONE
-        a%series(is)%linestyle = LINE_SOLID
-        a%series(is)%color = ""
+        allocate (ax(ia)%series(is)%x(n), ax(ia)%series(is)%y(n))
+        ax(ia)%series(is)%x(1:n) = x(1:n)
+        ax(ia)%series(is)%y(1:n) = y(1:n)
+        ax(ia)%series(is)%n = n
+        ax(ia)%series(is)%linewidth = default_linewidth
+        ax(ia)%series(is)%markersize = default_markersize
+        ax(ia)%series(is)%label = ""
+        ax(ia)%series(is)%marker = MARKER_NONE
+        ax(ia)%series(is)%linestyle = LINE_SOLID
+        ax(ia)%series(is)%color = ""
 
         have_fmt = .false.
         f = ""
@@ -365,61 +365,61 @@ contains
         ls = LINE_NONE
         if (have_fmt) then
             call parse_fmt(trim(f), col, m, ls)
-            a%series(is)%marker = m
+            ax(ia)%series(is)%marker = m
             if (ls == LINE_NONE .and. m == MARKER_NONE) then
-                a%series(is)%linestyle = LINE_SOLID
+                ax(ia)%series(is)%linestyle = LINE_SOLID
             else if (ls == LINE_NONE .and. m /= MARKER_NONE) then
-                a%series(is)%linestyle = LINE_NONE
+                ax(ia)%series(is)%linestyle = LINE_NONE
             else
-                a%series(is)%linestyle = ls
+                ax(ia)%series(is)%linestyle = ls
             end if
-            if (len_trim(col) > 0) a%series(is)%color = col
+            if (len_trim(col) > 0) ax(ia)%series(is)%color = col
         end if
 
         if (present(color)) then
             if (len_trim(color) > 0) then
                 if (is_hex_color(trim(color))) then
-                    a%series(is)%color = color(1:7)
+                    ax(ia)%series(is)%color = color(1:7)
                 else if (len_trim(color) == 1) then
-                    a%series(is)%color = color_from_char(color(1:1))
+                    ax(ia)%series(is)%color = color_from_char(color(1:1))
                 else if (len_trim(color) >= 2 .and. color(1:1) == "C") then
                     read (color(2:2), *) m
-                    a%series(is)%color = color_from_C(m)
+                    ax(ia)%series(is)%color = color_from_C(m)
                 end if
             end if
         end if
 
         if (present(marker)) then
             select case (trim(marker))
-            case ("o"); a%series(is)%marker = MARKER_CIRCLE
-            case ("x"); a%series(is)%marker = MARKER_X
-            case ("."); a%series(is)%marker = MARKER_POINT
-            case ("None", "none", ""); a%series(is)%marker = MARKER_NONE
+            case ("o"); ax(ia)%series(is)%marker = MARKER_CIRCLE
+            case ("x"); ax(ia)%series(is)%marker = MARKER_X
+            case ("."); ax(ia)%series(is)%marker = MARKER_POINT
+            case ("None", "none", ""); ax(ia)%series(is)%marker = MARKER_NONE
             end select
         end if
 
         if (present(linestyle)) then
             select case (trim(linestyle))
-            case ("-"); a%series(is)%linestyle = LINE_SOLID
-            case ("--"); a%series(is)%linestyle = LINE_DASHED
-            case (":"); a%series(is)%linestyle = LINE_DOTTED
-            case ("-."); a%series(is)%linestyle = LINE_DASHDOT
-            case ("None", "none", ""); a%series(is)%linestyle = LINE_NONE
+            case ("-"); ax(ia)%series(is)%linestyle = LINE_SOLID
+            case ("--"); ax(ia)%series(is)%linestyle = LINE_DASHED
+            case (":"); ax(ia)%series(is)%linestyle = LINE_DOTTED
+            case ("-."); ax(ia)%series(is)%linestyle = LINE_DASHDOT
+            case ("None", "none", ""); ax(ia)%series(is)%linestyle = LINE_NONE
             end select
         end if
 
-        if (present(lw)) a%series(is)%linewidth = lw
-        if (present(label)) a%series(is)%label = label
+        if (present(lw)) ax(ia)%series(is)%linewidth = lw
+        if (present(label)) ax(ia)%series(is)%label = label
 
-        if (len_trim(a%series(is)%color) == 0) then
-            a%series(is)%color = color_from_C(a%color_cycle)
-            a%color_cycle = a%color_cycle + 1
+        if (len_trim(ax(ia)%series(is)%color) == 0) then
+            ax(ia)%series(is)%color = color_from_C(ax(ia)%color_cycle)
+            ax(ia)%color_cycle = ax(ia)%color_cycle + 1
         end if
 
         ! marker-only format string => no line
-        if (have_fmt .and. a%series(is)%marker /= MARKER_NONE) then
+        if (have_fmt .and. ax(ia)%series(is)%marker /= MARKER_NONE) then
             if (index(f, "-") == 0 .and. index(f, ":") == 0) then
-                a%series(is)%linestyle = LINE_NONE
+                ax(ia)%series(is)%linestyle = LINE_NONE
             end if
         end if
     end subroutine add_series

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -467,7 +467,7 @@ contains
     pure function int_to_str(i) result(s)
         integer, intent(in) :: i
         character(len=:), allocatable :: s
-        character(len=8) :: tmp
+        character(len=12) :: tmp
         write (tmp, "(I0)") i
         s = trim(tmp)
     end function int_to_str
@@ -523,6 +523,20 @@ contains
         else
             call linear_ticks(ymin, ymax, 6, yticks, nyt)
         end if
+
+        ! clip path for this axes' data
+        call builder_append(b, '<defs><clipPath id="axclip')
+        call builder_append(b, int_to_str(idx))
+        call builder_append(b, '"><rect x="')
+        call append_num(b, axl)
+        call builder_append(b, '" y="')
+        call append_num(b, axt)
+        call builder_append(b, '" width="')
+        call append_num(b, axw)
+        call builder_append(b, '" height="')
+        call append_num(b, axh)
+        call builder_append(b, '"/></clipPath></defs>')
+        call builder_append(b, new_line("a"))
 
         ! axes face
         call builder_append(b, '<rect x="')
@@ -902,24 +916,6 @@ contains
         call builder_append(b, '" height="')
         call append_num(b, H)
         call builder_append(b, '" fill="#ffffff"/>')
-        call builder_append(b, new_line("a"))
-
-        ! clip paths (one per axes)
-        call builder_append(b, "<defs>")
-        do i = 1, n_ax
-            call builder_append(b, '<clipPath id="axclip')
-            call builder_append(b, int_to_str(i))
-            call builder_append(b, '"><rect x="')
-            call append_num(b, ax(i)%left * W)
-            call builder_append(b, '" y="')
-            call append_num(b, (1.0_dp - ax(i)%top) * H)
-            call builder_append(b, '" width="')
-            call append_num(b, (ax(i)%right - ax(i)%left) * W)
-            call builder_append(b, '" height="')
-            call append_num(b, (ax(i)%top - ax(i)%bottom) * H)
-            call builder_append(b, '"/></clipPath>')
-        end do
-        call builder_append(b, "</defs>")
         call builder_append(b, new_line("a"))
 
         ! axes (subplots)

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -40,7 +40,6 @@ module fplot
         character(len=128) :: label = ""
     end type series_t
 
-    ! One set of axes (a subplot).
     type :: axes_t
         integer :: n_series = 0
         type(series_t) :: series(MAX_SERIES)
@@ -141,8 +140,7 @@ contains
         fig_initialized = .true.
     end subroutine clf
 
-    ! Create an m x n grid of axes with matplotlib's default spacing and
-    ! position them in figure fractions. Replaces any existing grid.
+    ! Replacing the grid discards existing axes.
     subroutine new_axes_grid(m, n)
         integer, intent(in) :: m, n
         integer :: i, r, c
@@ -574,8 +572,6 @@ contains
         end select
     end subroutine append_dash
 
-    ! Render one set of axes (face, grid, data, spines, ticks, labels,
-    ! title, legend) into the builder. Geometry is in points.
     subroutine render_axes(b, a, idx, W, H)
         type(svg_builder), intent(inout) :: b
         type(axes_t), intent(in) :: a
@@ -815,7 +811,6 @@ contains
             call builder_append(b, new_line("a"))
         end do
 
-        ! xlabel (below this axes, centered on it)
         if (len_trim(a%xlabel) > 0) then
             call xml_escape_to(a%xlabel, esc, en)
             call builder_append(b, '<text x="')
@@ -829,7 +824,6 @@ contains
             call builder_append(b, new_line("a"))
         end if
 
-        ! ylabel (left of this axes, centered on it)
         if (len_trim(a%ylabel) > 0) then
             call xml_escape_to(a%ylabel, esc, en)
             call builder_append(b, '<text x="')

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -26,6 +26,9 @@ module fplot
     ! Default subplot spacing (matplotlib rcParams), relative to axes size.
     real(dp), parameter :: WSPACE = 0.2_dp
     real(dp), parameter :: HSPACE = 0.2_dp
+    ! Suptitle baseline (matplotlib figure.suptitle default y), in figure
+    ! fractions measured from the bottom.
+    real(dp), parameter :: SUPTITLE_Y = 0.98_dp
 
     type :: series_t
         integer :: n = 0
@@ -100,7 +103,7 @@ contains
     subroutine new_axes_grid(m, n)
         integer, intent(in) :: m, n
         integer :: i, r, c
-        real(dp) :: w, h
+        real(dp) :: w, h, dx, dy
 
         cur_i = 0
         if (allocated(ax)) deallocate (ax)
@@ -108,18 +111,20 @@ contains
         n_ax = m * n
         allocate (ax(n_ax))
 
-        ! Total span available for the grid, in figure fractions.
+        ! Cell size and cell pitch (cell plus gap), in figure fractions.
         w = (MARGIN_RIGHT - MARGIN_LEFT) / &
             (real(n, dp) + WSPACE * real(n - 1, dp))
         h = (MARGIN_TOP - MARGIN_BOTTOM) / &
             (real(m, dp) + HSPACE * real(m - 1, dp))
+        dx = w * (1.0_dp + WSPACE)
+        dy = h * (1.0_dp + HSPACE)
 
         do i = 1, n_ax
             r = (i - 1) / n          ! row from the top
             c = mod(i - 1, n)        ! column from the left
-            ax(i)%left = MARGIN_LEFT + real(c, dp) * (w + WSPACE * w)
+            ax(i)%left = MARGIN_LEFT + real(c, dp) * dx
             ax(i)%right = ax(i)%left + w
-            ax(i)%bottom = MARGIN_BOTTOM + real(m - 1 - r, dp) * (h + HSPACE * h)
+            ax(i)%bottom = MARGIN_BOTTOM + real(m - 1 - r, dp) * dy
             ax(i)%top = ax(i)%bottom + h
         end do
 
@@ -929,7 +934,7 @@ contains
             call builder_append(b, '<text x="')
             call append_num(b, 0.5_dp * W)
             call builder_append(b, '" y="')
-            call append_num(b, (1.0_dp - 0.98_dp) * H + 4.2_dp)
+            call append_num(b, (1.0_dp - SUPTITLE_Y) * H + 4.2_dp)
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="12" fill="#000000">')
             call builder_append(b, esc(1:en))

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -11,11 +11,22 @@ module fplot
     public :: title, xlabel, ylabel, grid, legend
     public :: xlim, ylim, clf, savefig, show, figure
     public :: render_svg
+    public :: subplot, suptitle
 
     integer, parameter :: SCALE_LINEAR = 0
     integer, parameter :: SCALE_LOG = 1
     integer, parameter :: MAX_SERIES = 32
     integer, parameter :: MAX_POINTS = 100000
+    integer, parameter :: MAX_AXES = 16
+
+    ! Default figure margins (matplotlib rcParams), in figure fractions.
+    real(dp), parameter :: MARGIN_LEFT = 0.125_dp
+    real(dp), parameter :: MARGIN_RIGHT = 0.9_dp
+    real(dp), parameter :: MARGIN_BOTTOM = 0.11_dp
+    real(dp), parameter :: MARGIN_TOP = 0.88_dp
+    ! Default subplot spacing (matplotlib rcParams), relative to axes size.
+    real(dp), parameter :: WSPACE = 0.2_dp
+    real(dp), parameter :: HSPACE = 0.2_dp
 
     type :: series_t
         integer :: n = 0
@@ -29,124 +40,249 @@ module fplot
         character(len=128) :: label = ""
     end type series_t
 
+    ! One set of axes (a subplot).
+    type :: axes_t
+        integer :: n_series = 0
+        type(series_t) :: series(MAX_SERIES)
+        character(len=256) :: title = ""
+        character(len=256) :: xlabel = ""
+        character(len=256) :: ylabel = ""
+        logical :: grid_on = .false.
+        logical :: legend_on = .false.
+        integer :: xscale = SCALE_LINEAR
+        integer :: yscale = SCALE_LINEAR
+        logical :: xlim_set = .false.
+        logical :: ylim_set = .false.
+        real(dp) :: xmin_user = 0.0_dp, xmax_user = 1.0_dp
+        real(dp) :: ymin_user = 0.0_dp, ymax_user = 1.0_dp
+        integer :: color_cycle = 0
+        ! Axes position in figure fractions (matplotlib convention).
+        real(dp) :: left = MARGIN_LEFT, right = MARGIN_RIGHT
+        real(dp) :: bottom = MARGIN_BOTTOM, top = MARGIN_TOP
+    end type axes_t
+
     ! Figure state (pylab current figure)
     real(dp), save :: fig_w_in = 6.4_dp
     real(dp), save :: fig_h_in = 4.8_dp
-    real(dp), save :: sub_left = 0.125_dp
-    real(dp), save :: sub_right = 0.9_dp
-    real(dp), save :: sub_bottom = 0.11_dp
-    real(dp), save :: sub_top = 0.88_dp
-    integer, save :: n_series = 0
-    type(series_t), save :: series(MAX_SERIES)
-    character(len=256), save :: fig_title = ""
-    character(len=256), save :: fig_xlabel = ""
-    character(len=256), save :: fig_ylabel = ""
-    logical, save :: grid_on = .false.
-    logical, save :: legend_on = .false.
-    integer, save :: xscale = SCALE_LINEAR
-    integer, save :: yscale = SCALE_LINEAR
-    logical, save :: xlim_set = .false.
-    logical, save :: ylim_set = .false.
-    real(dp), save :: xmin_user = 0.0_dp, xmax_user = 1.0_dp
-    real(dp), save :: ymin_user = 0.0_dp, ymax_user = 1.0_dp
-    integer, save :: color_cycle = 0
+    character(len=256), save :: fig_suptitle = ""
+    type(axes_t), allocatable, save, target :: ax(:)
+    integer, save :: n_ax = 0
+    type(axes_t), pointer, save :: cur => null()
+    integer, save :: grid_m = 0, grid_n = 0
     logical, save :: fig_initialized = .false.
 
 contains
 
     subroutine ensure_fig()
         if (.not. fig_initialized) call clf()
+        ! No axes yet: create a single full-figure axes (pylab default).
+        if (.not. associated(cur)) then
+            call new_axes_grid(1, 1)
+            cur => ax(1)
+        end if
     end subroutine ensure_fig
 
     subroutine figure()
         call clf()
     end subroutine figure
 
-    subroutine free_series(i)
+    subroutine free_series(a, i)
+        type(axes_t), intent(inout) :: a
         integer, intent(in) :: i
-        if (allocated(series(i)%x)) deallocate (series(i)%x)
-        if (allocated(series(i)%y)) deallocate (series(i)%y)
-        series(i)%n = 0
-        series(i)%label = ""
-        series(i)%color = "#1f77b4"
-        series(i)%marker = MARKER_NONE
-        series(i)%linestyle = LINE_SOLID
-        series(i)%linewidth = default_linewidth
-        series(i)%markersize = default_markersize
+        if (allocated(a%series(i)%x)) deallocate (a%series(i)%x)
+        if (allocated(a%series(i)%y)) deallocate (a%series(i)%y)
+        a%series(i)%n = 0
+        a%series(i)%label = ""
+        a%series(i)%color = "#1f77b4"
+        a%series(i)%marker = MARKER_NONE
+        a%series(i)%linestyle = LINE_SOLID
+        a%series(i)%linewidth = default_linewidth
+        a%series(i)%markersize = default_markersize
     end subroutine free_series
+
+    subroutine clear_axes(a)
+        type(axes_t), intent(inout) :: a
+        integer :: i
+        do i = 1, MAX_SERIES
+            call free_series(a, i)
+        end do
+        a%n_series = 0
+        a%title = ""
+        a%xlabel = ""
+        a%ylabel = ""
+        a%grid_on = .false.
+        a%legend_on = .false.
+        a%xscale = SCALE_LINEAR
+        a%yscale = SCALE_LINEAR
+        a%xlim_set = .false.
+        a%ylim_set = .false.
+        a%xmin_user = 0.0_dp
+        a%xmax_user = 1.0_dp
+        a%ymin_user = 0.0_dp
+        a%ymax_user = 1.0_dp
+        a%color_cycle = 0
+    end subroutine clear_axes
 
     subroutine clf()
         integer :: i
-        do i = 1, MAX_SERIES
-            call free_series(i)
-        end do
-        n_series = 0
+        cur => null()
+        if (n_ax > 0 .and. allocated(ax)) then
+            do i = 1, n_ax
+                call clear_axes(ax(i))
+            end do
+            deallocate (ax)
+        end if
+        n_ax = 0
+        grid_m = 0
+        grid_n = 0
         fig_w_in = 6.4_dp
         fig_h_in = 4.8_dp
-        sub_left = 0.125_dp
-        sub_right = 0.9_dp
-        sub_bottom = 0.11_dp
-        sub_top = 0.88_dp
-        fig_title = ""
-        fig_xlabel = ""
-        fig_ylabel = ""
-        grid_on = .false.
-        legend_on = .false.
-        xscale = SCALE_LINEAR
-        yscale = SCALE_LINEAR
-        xlim_set = .false.
-        ylim_set = .false.
-        xmin_user = 0.0_dp
-        xmax_user = 1.0_dp
-        ymin_user = 0.0_dp
-        ymax_user = 1.0_dp
-        color_cycle = 0
+        fig_suptitle = ""
         fig_initialized = .true.
     end subroutine clf
+
+    ! Create an m x n grid of axes with matplotlib's default spacing and
+    ! position them in figure fractions. Replaces any existing grid.
+    subroutine new_axes_grid(m, n)
+        integer, intent(in) :: m, n
+        integer :: i, r, c
+        real(dp) :: w, h
+
+        cur => null()
+        if (n_ax > 0 .and. allocated(ax)) then
+            do i = 1, n_ax
+                call clear_axes(ax(i))
+            end do
+            deallocate (ax)
+        end if
+
+        n_ax = m * n
+        allocate (ax(n_ax))
+
+        ! Total span available for the grid, in figure fractions.
+        w = (MARGIN_RIGHT - MARGIN_LEFT) / &
+            (real(n, dp) + WSPACE * real(n - 1, dp))
+        h = (MARGIN_TOP - MARGIN_BOTTOM) / &
+            (real(m, dp) + HSPACE * real(m - 1, dp))
+
+        do i = 1, n_ax
+            r = (i - 1) / n          ! row from the top
+            c = mod(i - 1, n)        ! column from the left
+            ax(i)%left = MARGIN_LEFT + real(c, dp) * (w + WSPACE * w)
+            ax(i)%right = ax(i)%left + w
+            ax(i)%bottom = MARGIN_BOTTOM + real(m - 1 - r, dp) * (h + HSPACE * h)
+            ax(i)%top = ax(i)%bottom + h
+        end do
+
+        grid_m = m
+        grid_n = n
+    end subroutine new_axes_grid
+
+    ! Select (or create) the i-th axes of an m x n grid.
+    ! Forms: subplot(m, n, i), subplot(m, n) [i=1], subplot(231) [code].
+    subroutine subplot(m, n, i)
+        integer, intent(in), optional :: m, n, i
+        integer :: mm, nn, ii
+
+        if (.not. present(m)) then
+            print *, "fplot: subplot requires at least one argument"
+            return
+        end if
+
+        if (present(n)) then
+            ! subplot(m, n[, i]) form
+            mm = m
+            nn = n
+            if (present(i)) then
+                ii = i
+            else
+                ii = 1
+            end if
+        else
+            ! Single-integer form: subplot(1) or a 3-digit code like 231.
+            mm = m
+            if (mm == 1) then
+                nn = 1
+                ii = 1
+            else if (mm >= 100 .and. mm <= 999) then
+                ii = mod(mm, 10)
+                nn = (mm / 10) - 10 * (mm / 100)
+                mm = mm / 100
+            else
+                print *, "fplot: subplot single argument must be 1 or a 3-digit code (e.g. 231)"
+                return
+            end if
+        end if
+
+        if (mm < 1 .or. nn < 1 .or. ii < 1 .or. ii > mm * nn) then
+            print *, "fplot: invalid subplot indices (m=", mm, ", n=", nn, &
+                     ", i=", ii, ")"
+            return
+        end if
+        if (mm * nn > MAX_AXES) then
+            print *, "fplot: too many subplots (max ", MAX_AXES, ")"
+            return
+        end if
+
+        if (.not. fig_initialized) call clf()
+
+        if (n_ax == mm * nn .and. grid_m == mm .and. grid_n == nn) then
+            cur => ax(ii)
+        else
+            call new_axes_grid(mm, nn)
+            cur => ax(ii)
+        end if
+    end subroutine subplot
+
+    subroutine suptitle(s)
+        character(len=*), intent(in) :: s
+        call ensure_fig()
+        fig_suptitle = s
+    end subroutine suptitle
 
     subroutine title(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        fig_title = s
+        cur%title = s
     end subroutine title
 
     subroutine xlabel(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        fig_xlabel = s
+        cur%xlabel = s
     end subroutine xlabel
 
     subroutine ylabel(s)
         character(len=*), intent(in) :: s
         call ensure_fig()
-        fig_ylabel = s
+        cur%ylabel = s
     end subroutine ylabel
 
     subroutine grid(on)
         logical, intent(in) :: on
         call ensure_fig()
-        grid_on = on
+        cur%grid_on = on
     end subroutine grid
 
     subroutine legend()
         call ensure_fig()
-        legend_on = .true.
+        cur%legend_on = .true.
     end subroutine legend
 
     subroutine xlim(xmin, xmax)
         real(dp), intent(in) :: xmin, xmax
         call ensure_fig()
-        xmin_user = xmin
-        xmax_user = xmax
-        xlim_set = .true.
+        cur%xmin_user = xmin
+        cur%xmax_user = xmax
+        cur%xlim_set = .true.
     end subroutine xlim
 
     subroutine ylim(ymin, ymax)
         real(dp), intent(in) :: ymin, ymax
         call ensure_fig()
-        ymin_user = ymin
-        ymax_user = ymax
-        ylim_set = .true.
+        cur%ymin_user = ymin
+        cur%ymax_user = ymax
+        cur%ylim_set = .true.
     end subroutine ylim
 
     subroutine plot(x, y, fmt, label, lw, color, marker, linestyle)
@@ -154,7 +290,7 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color, marker, linestyle
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        call add_series(x, y, fmt, label, lw, color, marker, linestyle)
+        call add_series(cur, x, y, fmt, label, lw, color, marker, linestyle)
     end subroutine plot
 
     subroutine semilogx(x, y, fmt, label, lw, color)
@@ -162,8 +298,8 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        xscale = SCALE_LOG
-        call add_series(x, y, fmt, label, lw, color)
+        cur%xscale = SCALE_LOG
+        call add_series(cur, x, y, fmt, label, lw, color)
     end subroutine semilogx
 
     subroutine semilogy(x, y, fmt, label, lw, color)
@@ -171,8 +307,8 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        yscale = SCALE_LOG
-        call add_series(x, y, fmt, label, lw, color)
+        cur%yscale = SCALE_LOG
+        call add_series(cur, x, y, fmt, label, lw, color)
     end subroutine semilogy
 
     subroutine loglog(x, y, fmt, label, lw, color)
@@ -180,12 +316,13 @@ contains
         character(len=*), intent(in), optional :: fmt, label, color
         real(dp), intent(in), optional :: lw
         call ensure_fig()
-        xscale = SCALE_LOG
-        yscale = SCALE_LOG
-        call add_series(x, y, fmt, label, lw, color)
+        cur%xscale = SCALE_LOG
+        cur%yscale = SCALE_LOG
+        call add_series(cur, x, y, fmt, label, lw, color)
     end subroutine loglog
 
-    subroutine add_series(x, y, fmt, label, lw, color, marker, linestyle)
+    subroutine add_series(a, x, y, fmt, label, lw, color, marker, linestyle)
+        type(axes_t), intent(inout) :: a
         real(dp), intent(in) :: x(:), y(:)
         character(len=*), intent(in), optional :: fmt, label, color, marker, linestyle
         real(dp), intent(in), optional :: lw
@@ -197,22 +334,22 @@ contains
         n = min(size(x), size(y))
         if (n <= 0) return
         if (n > MAX_POINTS) n = MAX_POINTS
-        if (n_series >= MAX_SERIES) return
+        if (a%n_series >= MAX_SERIES) return
 
-        n_series = n_series + 1
-        is = n_series
-        call free_series(is)
+        a%n_series = a%n_series + 1
+        is = a%n_series
+        call free_series(a, is)
 
-        allocate (series(is)%x(n), series(is)%y(n))
-        series(is)%x(1:n) = x(1:n)
-        series(is)%y(1:n) = y(1:n)
-        series(is)%n = n
-        series(is)%linewidth = default_linewidth
-        series(is)%markersize = default_markersize
-        series(is)%label = ""
-        series(is)%marker = MARKER_NONE
-        series(is)%linestyle = LINE_SOLID
-        series(is)%color = ""
+        allocate (a%series(is)%x(n), a%series(is)%y(n))
+        a%series(is)%x(1:n) = x(1:n)
+        a%series(is)%y(1:n) = y(1:n)
+        a%series(is)%n = n
+        a%series(is)%linewidth = default_linewidth
+        a%series(is)%markersize = default_markersize
+        a%series(is)%label = ""
+        a%series(is)%marker = MARKER_NONE
+        a%series(is)%linestyle = LINE_SOLID
+        a%series(is)%color = ""
 
         have_fmt = .false.
         f = ""
@@ -228,82 +365,83 @@ contains
         ls = LINE_NONE
         if (have_fmt) then
             call parse_fmt(trim(f), col, m, ls)
-            series(is)%marker = m
+            a%series(is)%marker = m
             if (ls == LINE_NONE .and. m == MARKER_NONE) then
-                series(is)%linestyle = LINE_SOLID
+                a%series(is)%linestyle = LINE_SOLID
             else if (ls == LINE_NONE .and. m /= MARKER_NONE) then
-                series(is)%linestyle = LINE_NONE
+                a%series(is)%linestyle = LINE_NONE
             else
-                series(is)%linestyle = ls
+                a%series(is)%linestyle = ls
             end if
-            if (len_trim(col) > 0) series(is)%color = col
+            if (len_trim(col) > 0) a%series(is)%color = col
         end if
 
         if (present(color)) then
             if (len_trim(color) > 0) then
                 if (is_hex_color(trim(color))) then
-                    series(is)%color = color(1:7)
+                    a%series(is)%color = color(1:7)
                 else if (len_trim(color) == 1) then
-                    series(is)%color = color_from_char(color(1:1))
+                    a%series(is)%color = color_from_char(color(1:1))
                 else if (len_trim(color) >= 2 .and. color(1:1) == "C") then
                     read (color(2:2), *) m
-                    series(is)%color = color_from_C(m)
+                    a%series(is)%color = color_from_C(m)
                 end if
             end if
         end if
 
         if (present(marker)) then
             select case (trim(marker))
-            case ("o"); series(is)%marker = MARKER_CIRCLE
-            case ("x"); series(is)%marker = MARKER_X
-            case ("."); series(is)%marker = MARKER_POINT
-            case ("None", "none", ""); series(is)%marker = MARKER_NONE
+            case ("o"); a%series(is)%marker = MARKER_CIRCLE
+            case ("x"); a%series(is)%marker = MARKER_X
+            case ("."); a%series(is)%marker = MARKER_POINT
+            case ("None", "none", ""); a%series(is)%marker = MARKER_NONE
             end select
         end if
 
         if (present(linestyle)) then
             select case (trim(linestyle))
-            case ("-"); series(is)%linestyle = LINE_SOLID
-            case ("--"); series(is)%linestyle = LINE_DASHED
-            case (":"); series(is)%linestyle = LINE_DOTTED
-            case ("-."); series(is)%linestyle = LINE_DASHDOT
-            case ("None", "none", ""); series(is)%linestyle = LINE_NONE
+            case ("-"); a%series(is)%linestyle = LINE_SOLID
+            case ("--"); a%series(is)%linestyle = LINE_DASHED
+            case (":"); a%series(is)%linestyle = LINE_DOTTED
+            case ("-."); a%series(is)%linestyle = LINE_DASHDOT
+            case ("None", "none", ""); a%series(is)%linestyle = LINE_NONE
             end select
         end if
 
-        if (present(lw)) series(is)%linewidth = lw
-        if (present(label)) series(is)%label = label
+        if (present(lw)) a%series(is)%linewidth = lw
+        if (present(label)) a%series(is)%label = label
 
-        if (len_trim(series(is)%color) == 0) then
-            series(is)%color = color_from_C(color_cycle)
-            color_cycle = color_cycle + 1
+        if (len_trim(a%series(is)%color) == 0) then
+            a%series(is)%color = color_from_C(a%color_cycle)
+            a%color_cycle = a%color_cycle + 1
         end if
 
         ! marker-only format string => no line
-        if (have_fmt .and. series(is)%marker /= MARKER_NONE) then
+        if (have_fmt .and. a%series(is)%marker /= MARKER_NONE) then
             if (index(f, "-") == 0 .and. index(f, ":") == 0) then
-                series(is)%linestyle = LINE_NONE
+                a%series(is)%linestyle = LINE_NONE
             end if
         end if
     end subroutine add_series
 
-    subroutine compute_limits(xmin, xmax, ymin, ymax)
+    subroutine compute_limits(a, xmin, xmax, ymin, ymax)
+        type(axes_t), intent(in) :: a
         real(dp), intent(out) :: xmin, xmax, ymin, ymax
         integer :: i, j
         real(dp) :: xv, yv, dx, dy
         logical :: any
 
-        if (xlim_set) then
-            xmin = xmin_user
-            xmax = xmax_user
+        if (a%xlim_set) then
+            xmin = a%xmin_user
+            xmax = a%xmax_user
         else
             any = .false.
             xmin = huge(1.0_dp)
             xmax = -huge(1.0_dp)
-            do i = 1, n_series
-                do j = 1, series(i)%n
-                    xv = series(i)%x(j)
-                    if (xscale == SCALE_LOG .and. xv <= 0.0_dp) cycle
+            do i = 1, a%n_series
+                do j = 1, a%series(i)%n
+                    xv = a%series(i)%x(j)
+                    if (a%xscale == SCALE_LOG .and. xv <= 0.0_dp) cycle
                     any = .true.
                     if (xv < xmin) xmin = xv
                     if (xv > xmax) xmax = xv
@@ -315,17 +453,17 @@ contains
             end if
         end if
 
-        if (ylim_set) then
-            ymin = ymin_user
-            ymax = ymax_user
+        if (a%ylim_set) then
+            ymin = a%ymin_user
+            ymax = a%ymax_user
         else
             any = .false.
             ymin = huge(1.0_dp)
             ymax = -huge(1.0_dp)
-            do i = 1, n_series
-                do j = 1, series(i)%n
-                    yv = series(i)%y(j)
-                    if (yscale == SCALE_LOG .and. yv <= 0.0_dp) cycle
+            do i = 1, a%n_series
+                do j = 1, a%series(i)%n
+                    yv = a%series(i)%y(j)
+                    if (a%yscale == SCALE_LOG .and. yv <= 0.0_dp) cycle
                     any = .true.
                     if (yv < ymin) ymin = yv
                     if (yv > ymax) ymax = yv
@@ -337,8 +475,8 @@ contains
             end if
         end if
 
-        if (.not. xlim_set) then
-            if (xscale == SCALE_LOG) then
+        if (.not. a%xlim_set) then
+            if (a%xscale == SCALE_LOG) then
                 if (xmin <= 0.0_dp) xmin = tiny(1.0_dp)
                 if (xmax <= xmin) xmax = xmin * 10.0_dp
                 dx = log10(xmax / xmin)
@@ -353,8 +491,8 @@ contains
             end if
         end if
 
-        if (.not. ylim_set) then
-            if (yscale == SCALE_LOG) then
+        if (.not. a%ylim_set) then
+            if (a%yscale == SCALE_LOG) then
                 if (ymin <= 0.0_dp) ymin = tiny(1.0_dp)
                 if (ymax <= ymin) ymax = ymin * 10.0_dp
                 dy = log10(ymax / ymin)
@@ -419,6 +557,14 @@ contains
         call builder_append(b, s(1:n))
     end subroutine append_num
 
+    pure function int_to_str(i) result(s)
+        integer, intent(in) :: i
+        character(len=:), allocatable :: s
+        character(len=8) :: tmp
+        write (tmp, "(I0)") i
+        s = trim(tmp)
+    end function int_to_str
+
     subroutine append_dash(b, ls)
         type(svg_builder), intent(inout) :: b
         integer, intent(in) :: ls
@@ -432,10 +578,14 @@ contains
         end select
     end subroutine append_dash
 
-    function render_svg() result(svg)
-        character(len=:), allocatable :: svg
-        type(svg_builder) :: b
-        real(dp) :: W, H, ax_l, ax_r, ax_b, ax_t, ax_w, ax_h
+    ! Render one set of axes (face, grid, data, spines, ticks, labels,
+    ! title, legend) into the builder. Geometry is in points.
+    subroutine render_axes(b, a, idx, W, H)
+        type(svg_builder), intent(inout) :: b
+        type(axes_t), intent(in) :: a
+        integer, intent(in) :: idx
+        real(dp), intent(in) :: W, H
+        real(dp) :: axl, axr, axb, axt, axw, axh
         real(dp) :: xmin, xmax, ymin, ymax
         real(dp) :: xticks(MAX_TICKS), yticks(MAX_TICKS)
         integer :: nxt, nyt, i, j, n, nl
@@ -444,24 +594,19 @@ contains
         character(len=512) :: esc
         integer :: ln, en
         logical :: xlog, ylog
-        integer :: n_leg
+        integer :: n_leg, k
         real(dp) :: leg_x, leg_y, leg_w, leg_h, row_h
 
-        call ensure_fig()
-        call builder_init(b)
+        axl = a%left * W
+        axr = a%right * W
+        axb = (1.0_dp - a%bottom) * H
+        axt = (1.0_dp - a%top) * H
+        axw = axr - axl
+        axh = axb - axt
 
-        W = fig_w_in * 72.0_dp
-        H = fig_h_in * 72.0_dp
-        ax_l = sub_left * W
-        ax_r = sub_right * W
-        ax_b = (1.0_dp - sub_bottom) * H
-        ax_t = (1.0_dp - sub_top) * H
-        ax_w = ax_r - ax_l
-        ax_h = ax_b - ax_t
-
-        call compute_limits(xmin, xmax, ymin, ymax)
-        xlog = xscale == SCALE_LOG
-        ylog = yscale == SCALE_LOG
+        call compute_limits(a, xmin, xmax, ymin, ymax)
+        xlog = a%xscale == SCALE_LOG
+        ylog = a%yscale == SCALE_LOG
 
         if (xlog) then
             call log_ticks(xmin, xmax, xticks, nxt)
@@ -473,6 +618,366 @@ contains
         else
             call linear_ticks(ymin, ymax, 6, yticks, nyt)
         end if
+
+        ! axes face
+        call builder_append(b, '<rect x="')
+        call append_num(b, axl)
+        call builder_append(b, '" y="')
+        call append_num(b, axt)
+        call builder_append(b, '" width="')
+        call append_num(b, axw)
+        call builder_append(b, '" height="')
+        call append_num(b, axh)
+        call builder_append(b, '" fill="#ffffff"/>')
+        call builder_append(b, new_line("a"))
+
+        ! grid
+        if (a%grid_on) then
+            do i = 1, nxt
+                px = map_x(xticks(i), xmin, xmax, axl, axw, xlog)
+                call builder_append(b, '<line x1="')
+                call append_num(b, px)
+                call builder_append(b, '" y1="')
+                call append_num(b, axt)
+                call builder_append(b, '" x2="')
+                call append_num(b, px)
+                call builder_append(b, '" y2="')
+                call append_num(b, axb)
+                call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
+                call builder_append(b, new_line("a"))
+            end do
+            do i = 1, nyt
+                py = map_y(yticks(i), ymin, ymax, axb, axh, ylog)
+                call builder_append(b, '<line x1="')
+                call append_num(b, axl)
+                call builder_append(b, '" y1="')
+                call append_num(b, py)
+                call builder_append(b, '" x2="')
+                call append_num(b, axr)
+                call builder_append(b, '" y2="')
+                call append_num(b, py)
+                call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
+                call builder_append(b, new_line("a"))
+            end do
+        end if
+
+        ! data
+        call builder_append(b, '<g clip-path="url(#axclip')
+        call builder_append(b, int_to_str(idx))
+        call builder_append(b, ')">')
+        call builder_append(b, new_line("a"))
+        do i = 1, a%n_series
+            n = a%series(i)%n
+            if (n <= 0) cycle
+
+            if (a%series(i)%linestyle /= LINE_NONE .and. n >= 2) then
+                call builder_append(b, '<polyline fill="none" stroke="')
+                call builder_append(b, trim(a%series(i)%color))
+                call builder_append(b, '" stroke-width="')
+                call append_num(b, a%series(i)%linewidth)
+                call builder_append(b, '" stroke-linejoin="round" stroke-linecap="butt"')
+                call append_dash(b, a%series(i)%linestyle)
+                call builder_append(b, ' points="')
+                nl = 0
+                do j = 1, n
+                    if (a%xscale == SCALE_LOG .and. a%series(i)%x(j) <= 0.0_dp) cycle
+                    if (a%yscale == SCALE_LOG .and. a%series(i)%y(j) <= 0.0_dp) cycle
+                    px = map_x(a%series(i)%x(j), xmin, xmax, axl, axw, xlog)
+                    py = map_y(a%series(i)%y(j), ymin, ymax, axb, axh, ylog)
+                    if (nl > 0) call builder_append(b, " ")
+                    call append_num(b, px)
+                    call builder_append(b, ",")
+                    call append_num(b, py)
+                    nl = nl + 1
+                end do
+                call builder_append(b, '"/>')
+                call builder_append(b, new_line("a"))
+            end if
+
+            if (a%series(i)%marker /= MARKER_NONE) then
+                ms = a%series(i)%markersize
+                do j = 1, n
+                    if (a%xscale == SCALE_LOG .and. a%series(i)%x(j) <= 0.0_dp) cycle
+                    if (a%yscale == SCALE_LOG .and. a%series(i)%y(j) <= 0.0_dp) cycle
+                    px = map_x(a%series(i)%x(j), xmin, xmax, axl, axw, xlog)
+                    py = map_y(a%series(i)%y(j), ymin, ymax, axb, axh, ylog)
+                    select case (a%series(i)%marker)
+                    case (MARKER_CIRCLE)
+                        r = 0.5_dp * ms * 0.75_dp
+                        call builder_append(b, '<circle cx="')
+                        call append_num(b, px)
+                        call builder_append(b, '" cy="')
+                        call append_num(b, py)
+                        call builder_append(b, '" r="')
+                        call append_num(b, r)
+                        call builder_append(b, '" fill="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '" stroke="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '" stroke-width="1"/>')
+                        call builder_append(b, new_line("a"))
+                    case (MARKER_POINT)
+                        r = 0.5_dp * ms * 0.35_dp
+                        call builder_append(b, '<circle cx="')
+                        call append_num(b, px)
+                        call builder_append(b, '" cy="')
+                        call append_num(b, py)
+                        call builder_append(b, '" r="')
+                        call append_num(b, r)
+                        call builder_append(b, '" fill="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '"/>')
+                        call builder_append(b, new_line("a"))
+                    case (MARKER_X)
+                        r = 0.5_dp * ms * 0.7_dp
+                        call builder_append(b, '<path d="M ')
+                        call append_num(b, px - r)
+                        call builder_append(b, " ")
+                        call append_num(b, py - r)
+                        call builder_append(b, " L ")
+                        call append_num(b, px + r)
+                        call builder_append(b, " ")
+                        call append_num(b, py + r)
+                        call builder_append(b, " M ")
+                        call append_num(b, px - r)
+                        call builder_append(b, " ")
+                        call append_num(b, py + r)
+                        call builder_append(b, " L ")
+                        call append_num(b, px + r)
+                        call builder_append(b, " ")
+                        call append_num(b, py - r)
+                        call builder_append(b, '" stroke="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '" stroke-width="1.5" fill="none"/>')
+                        call builder_append(b, new_line("a"))
+                    end select
+                end do
+            end if
+        end do
+        call builder_append(b, "</g>")
+        call builder_append(b, new_line("a"))
+
+        ! spines
+        call builder_append(b, '<rect x="')
+        call append_num(b, axl)
+        call builder_append(b, '" y="')
+        call append_num(b, axt)
+        call builder_append(b, '" width="')
+        call append_num(b, axw)
+        call builder_append(b, '" height="')
+        call append_num(b, axh)
+        call builder_append(b, '" fill="none" stroke="#000000" stroke-width="0.8"/>')
+        call builder_append(b, new_line("a"))
+
+        ! x ticks
+        do i = 1, nxt
+            px = map_x(xticks(i), xmin, xmax, axl, axw, xlog)
+            call builder_append(b, '<line x1="')
+            call append_num(b, px)
+            call builder_append(b, '" y1="')
+            call append_num(b, axb)
+            call builder_append(b, '" x2="')
+            call append_num(b, px)
+            call builder_append(b, '" y2="')
+            call append_num(b, axb + 3.5_dp)
+            call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
+            call builder_append(b, new_line("a"))
+            call format_tick_to(xticks(i), xlog, lbl, ln)
+            call builder_append(b, '<text x="')
+            call append_num(b, px)
+            call builder_append(b, '" y="')
+            call append_num(b, axb + 16.0_dp)
+            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
+            call builder_append(b, 'font-size="10" fill="#000000">')
+            call builder_append(b, lbl(1:ln))
+            call builder_append(b, "</text>")
+            call builder_append(b, new_line("a"))
+        end do
+
+        ! y ticks
+        do i = 1, nyt
+            py = map_y(yticks(i), ymin, ymax, axb, axh, ylog)
+            call builder_append(b, '<line x1="')
+            call append_num(b, axl)
+            call builder_append(b, '" y1="')
+            call append_num(b, py)
+            call builder_append(b, '" x2="')
+            call append_num(b, axl - 3.5_dp)
+            call builder_append(b, '" y2="')
+            call append_num(b, py)
+            call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
+            call builder_append(b, new_line("a"))
+            call format_tick_to(yticks(i), ylog, lbl, ln)
+            call builder_append(b, '<text x="')
+            call append_num(b, axl - 7.0_dp)
+            call builder_append(b, '" y="')
+            call append_num(b, py + 3.5_dp)
+            call builder_append(b, '" text-anchor="end" font-family="DejaVu Sans, sans-serif" ')
+            call builder_append(b, 'font-size="10" fill="#000000">')
+            call builder_append(b, lbl(1:ln))
+            call builder_append(b, "</text>")
+            call builder_append(b, new_line("a"))
+        end do
+
+        ! xlabel (below this axes, centered on it)
+        if (len_trim(a%xlabel) > 0) then
+            call xml_escape_to(a%xlabel, esc, en)
+            call builder_append(b, '<text x="')
+            call append_num(b, 0.5_dp * (axl + axr))
+            call builder_append(b, '" y="')
+            call append_num(b, axb + 28.6_dp)
+            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
+            call builder_append(b, 'font-size="11" fill="#000000">')
+            call builder_append(b, esc(1:en))
+            call builder_append(b, "</text>")
+            call builder_append(b, new_line("a"))
+        end if
+
+        ! ylabel (left of this axes, centered on it)
+        if (len_trim(a%ylabel) > 0) then
+            call xml_escape_to(a%ylabel, esc, en)
+            call builder_append(b, '<text x="')
+            call append_num(b, axl - 34.0_dp)
+            call builder_append(b, '" y="')
+            call append_num(b, 0.5_dp * (axt + axb))
+            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
+            call builder_append(b, 'font-size="11" fill="#000000" transform="rotate(-90 ')
+            call append_num(b, axl - 34.0_dp)
+            call builder_append(b, " ")
+            call append_num(b, 0.5_dp * (axt + axb))
+            call builder_append(b, ')">')
+            call builder_append(b, esc(1:en))
+            call builder_append(b, "</text>")
+            call builder_append(b, new_line("a"))
+        end if
+
+        ! title
+        if (len_trim(a%title) > 0) then
+            call xml_escape_to(a%title, esc, en)
+            call builder_append(b, '<text x="')
+            call append_num(b, 0.5_dp * (axl + axr))
+            call builder_append(b, '" y="')
+            call append_num(b, axt - 6.0_dp)
+            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
+            call builder_append(b, 'font-size="12" fill="#000000">')
+            call builder_append(b, esc(1:en))
+            call builder_append(b, "</text>")
+            call builder_append(b, new_line("a"))
+        end if
+
+        ! legend
+        if (a%legend_on) then
+            n_leg = 0
+            do i = 1, a%n_series
+                if (len_trim(a%series(i)%label) > 0) n_leg = n_leg + 1
+            end do
+            if (n_leg > 0) then
+                row_h = 18.0_dp
+                leg_w = 100.0_dp
+                leg_h = 8.0_dp + real(n_leg, dp) * row_h
+                leg_x = axr - leg_w - 8.0_dp
+                leg_y = axt + 8.0_dp
+                call builder_append(b, '<rect x="')
+                call append_num(b, leg_x)
+                call builder_append(b, '" y="')
+                call append_num(b, leg_y)
+                call builder_append(b, '" width="')
+                call append_num(b, leg_w)
+                call builder_append(b, '" height="')
+                call append_num(b, leg_h)
+                call builder_append(b, '" fill="#ffffff" stroke="#cccccc" stroke-width="0.8" rx="2"/>')
+                call builder_append(b, new_line("a"))
+                k = 0
+                do i = 1, a%n_series
+                    if (len_trim(a%series(i)%label) == 0) cycle
+                    k = k + 1
+                    py = leg_y + 4.0_dp + (real(k, dp) - 0.5_dp) * row_h
+                    if (a%series(i)%linestyle /= LINE_NONE) then
+                        call builder_append(b, '<line x1="')
+                        call append_num(b, leg_x + 8.0_dp)
+                        call builder_append(b, '" y1="')
+                        call append_num(b, py)
+                        call builder_append(b, '" x2="')
+                        call append_num(b, leg_x + 28.0_dp)
+                        call builder_append(b, '" y2="')
+                        call append_num(b, py)
+                        call builder_append(b, '" stroke="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '" stroke-width="')
+                        call append_num(b, a%series(i)%linewidth)
+                        call builder_append(b, '"')
+                        call append_dash(b, a%series(i)%linestyle)
+                        call builder_append(b, "/>")
+                        call builder_append(b, new_line("a"))
+                    end if
+                    mid = leg_x + 18.0_dp
+                    if (a%series(i)%marker == MARKER_CIRCLE) then
+                        call builder_append(b, '<circle cx="')
+                        call append_num(b, mid)
+                        call builder_append(b, '" cy="')
+                        call append_num(b, py)
+                        call builder_append(b, '" r="3" fill="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '"/>')
+                        call builder_append(b, new_line("a"))
+                    else if (a%series(i)%marker == MARKER_POINT) then
+                        call builder_append(b, '<circle cx="')
+                        call append_num(b, mid)
+                        call builder_append(b, '" cy="')
+                        call append_num(b, py)
+                        call builder_append(b, '" r="1.5" fill="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '"/>')
+                        call builder_append(b, new_line("a"))
+                    else if (a%series(i)%marker == MARKER_X) then
+                        r = 3.0_dp
+                        call builder_append(b, '<path d="M ')
+                        call append_num(b, mid - r)
+                        call builder_append(b, " ")
+                        call append_num(b, py - r)
+                        call builder_append(b, " L ")
+                        call append_num(b, mid + r)
+                        call builder_append(b, " ")
+                        call append_num(b, py + r)
+                        call builder_append(b, " M ")
+                        call append_num(b, mid - r)
+                        call builder_append(b, " ")
+                        call append_num(b, py + r)
+                        call builder_append(b, " L ")
+                        call append_num(b, mid + r)
+                        call builder_append(b, " ")
+                        call append_num(b, py - r)
+                        call builder_append(b, '" stroke="')
+                        call builder_append(b, trim(a%series(i)%color))
+                        call builder_append(b, '" stroke-width="1.5" fill="none"/>')
+                        call builder_append(b, new_line("a"))
+                    end if
+                    call xml_escape_to(a%series(i)%label, esc, en)
+                    call builder_append(b, '<text x="')
+                    call append_num(b, leg_x + 34.0_dp)
+                    call builder_append(b, '" y="')
+                    call append_num(b, py + 3.5_dp)
+                    call builder_append(b, '" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#000000">')
+                    call builder_append(b, esc(1:en))
+                    call builder_append(b, "</text>")
+                    call builder_append(b, new_line("a"))
+                end do
+            end if
+        end if
+    end subroutine render_axes
+
+    function render_svg() result(svg)
+        character(len=:), allocatable :: svg
+        type(svg_builder) :: b
+        real(dp) :: W, H
+        character(len=512) :: esc
+        integer :: i, en
+
+        call ensure_fig()
+        call builder_init(b)
+
+        W = fig_w_in * 72.0_dp
+        H = fig_h_in * 72.0_dp
 
         call builder_append(b, '<?xml version="1.0" encoding="utf-8" standalone="no"?>')
         call builder_append(b, new_line("a"))
@@ -496,360 +1001,41 @@ contains
         call builder_append(b, '" fill="#ffffff"/>')
         call builder_append(b, new_line("a"))
 
-        ! clip
-        call builder_append(b, '<defs><clipPath id="axclip"><rect x="')
-        call append_num(b, ax_l)
-        call builder_append(b, '" y="')
-        call append_num(b, ax_t)
-        call builder_append(b, '" width="')
-        call append_num(b, ax_w)
-        call builder_append(b, '" height="')
-        call append_num(b, ax_h)
-        call builder_append(b, '"/></clipPath></defs>')
-        call builder_append(b, new_line("a"))
-
-        ! axes face
-        call builder_append(b, '<rect x="')
-        call append_num(b, ax_l)
-        call builder_append(b, '" y="')
-        call append_num(b, ax_t)
-        call builder_append(b, '" width="')
-        call append_num(b, ax_w)
-        call builder_append(b, '" height="')
-        call append_num(b, ax_h)
-        call builder_append(b, '" fill="#ffffff"/>')
-        call builder_append(b, new_line("a"))
-
-        ! grid
-        if (grid_on) then
-            do i = 1, nxt
-                px = map_x(xticks(i), xmin, xmax, ax_l, ax_w, xlog)
-                call builder_append(b, '<line x1="')
-                call append_num(b, px)
-                call builder_append(b, '" y1="')
-                call append_num(b, ax_t)
-                call builder_append(b, '" x2="')
-                call append_num(b, px)
-                call builder_append(b, '" y2="')
-                call append_num(b, ax_b)
-                call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
-                call builder_append(b, new_line("a"))
-            end do
-            do i = 1, nyt
-                py = map_y(yticks(i), ymin, ymax, ax_b, ax_h, ylog)
-                call builder_append(b, '<line x1="')
-                call append_num(b, ax_l)
-                call builder_append(b, '" y1="')
-                call append_num(b, py)
-                call builder_append(b, '" x2="')
-                call append_num(b, ax_r)
-                call builder_append(b, '" y2="')
-                call append_num(b, py)
-                call builder_append(b, '" stroke="#b0b0b0" stroke-width="0.8"/>')
-                call builder_append(b, new_line("a"))
-            end do
-        end if
-
-        ! data
-        call builder_append(b, '<g clip-path="url(#axclip)">')
-        call builder_append(b, new_line("a"))
-        do i = 1, n_series
-            n = series(i)%n
-            if (n <= 0) cycle
-
-            if (series(i)%linestyle /= LINE_NONE .and. n >= 2) then
-                call builder_append(b, '<polyline fill="none" stroke="')
-                call builder_append(b, trim(series(i)%color))
-                call builder_append(b, '" stroke-width="')
-                call append_num(b, series(i)%linewidth)
-                call builder_append(b, '" stroke-linejoin="round" stroke-linecap="butt"')
-                call append_dash(b, series(i)%linestyle)
-                call builder_append(b, ' points="')
-                nl = 0
-                do j = 1, n
-                    if (xscale == SCALE_LOG .and. series(i)%x(j) <= 0.0_dp) cycle
-                    if (yscale == SCALE_LOG .and. series(i)%y(j) <= 0.0_dp) cycle
-                    px = map_x(series(i)%x(j), xmin, xmax, ax_l, ax_w, xlog)
-                    py = map_y(series(i)%y(j), ymin, ymax, ax_b, ax_h, ylog)
-                    if (nl > 0) call builder_append(b, " ")
-                    call append_num(b, px)
-                    call builder_append(b, ",")
-                    call append_num(b, py)
-                    nl = nl + 1
-                end do
-                call builder_append(b, '"/>')
-                call builder_append(b, new_line("a"))
-            end if
-
-            if (series(i)%marker /= MARKER_NONE) then
-                ms = series(i)%markersize
-                do j = 1, n
-                    if (xscale == SCALE_LOG .and. series(i)%x(j) <= 0.0_dp) cycle
-                    if (yscale == SCALE_LOG .and. series(i)%y(j) <= 0.0_dp) cycle
-                    px = map_x(series(i)%x(j), xmin, xmax, ax_l, ax_w, xlog)
-                    py = map_y(series(i)%y(j), ymin, ymax, ax_b, ax_h, ylog)
-                    select case (series(i)%marker)
-                    case (MARKER_CIRCLE)
-                        r = 0.5_dp * ms * 0.75_dp
-                        call builder_append(b, '<circle cx="')
-                        call append_num(b, px)
-                        call builder_append(b, '" cy="')
-                        call append_num(b, py)
-                        call builder_append(b, '" r="')
-                        call append_num(b, r)
-                        call builder_append(b, '" fill="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '" stroke="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '" stroke-width="1"/>')
-                        call builder_append(b, new_line("a"))
-                    case (MARKER_POINT)
-                        r = 0.5_dp * ms * 0.35_dp
-                        call builder_append(b, '<circle cx="')
-                        call append_num(b, px)
-                        call builder_append(b, '" cy="')
-                        call append_num(b, py)
-                        call builder_append(b, '" r="')
-                        call append_num(b, r)
-                        call builder_append(b, '" fill="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '"/>')
-                        call builder_append(b, new_line("a"))
-                    case (MARKER_X)
-                        r = 0.5_dp * ms * 0.7_dp
-                        call builder_append(b, '<path d="M ')
-                        call append_num(b, px - r)
-                        call builder_append(b, " ")
-                        call append_num(b, py - r)
-                        call builder_append(b, " L ")
-                        call append_num(b, px + r)
-                        call builder_append(b, " ")
-                        call append_num(b, py + r)
-                        call builder_append(b, " M ")
-                        call append_num(b, px - r)
-                        call builder_append(b, " ")
-                        call append_num(b, py + r)
-                        call builder_append(b, " L ")
-                        call append_num(b, px + r)
-                        call builder_append(b, " ")
-                        call append_num(b, py - r)
-                        call builder_append(b, '" stroke="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '" stroke-width="1.5" fill="none"/>')
-                        call builder_append(b, new_line("a"))
-                    end select
-                end do
-            end if
-        end do
-        call builder_append(b, "</g>")
-        call builder_append(b, new_line("a"))
-
-        ! spines
-        call builder_append(b, '<rect x="')
-        call append_num(b, ax_l)
-        call builder_append(b, '" y="')
-        call append_num(b, ax_t)
-        call builder_append(b, '" width="')
-        call append_num(b, ax_w)
-        call builder_append(b, '" height="')
-        call append_num(b, ax_h)
-        call builder_append(b, '" fill="none" stroke="#000000" stroke-width="0.8"/>')
-        call builder_append(b, new_line("a"))
-
-        ! x ticks
-        do i = 1, nxt
-            px = map_x(xticks(i), xmin, xmax, ax_l, ax_w, xlog)
-            call builder_append(b, '<line x1="')
-            call append_num(b, px)
-            call builder_append(b, '" y1="')
-            call append_num(b, ax_b)
-            call builder_append(b, '" x2="')
-            call append_num(b, px)
-            call builder_append(b, '" y2="')
-            call append_num(b, ax_b + 3.5_dp)
-            call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
-            call builder_append(b, new_line("a"))
-            call format_tick_to(xticks(i), xlog, lbl, ln)
-            call builder_append(b, '<text x="')
-            call append_num(b, px)
+        ! clip paths (one per axes)
+        call builder_append(b, "<defs>")
+        do i = 1, n_ax
+            call builder_append(b, '<clipPath id="axclip')
+            call builder_append(b, int_to_str(i))
+            call builder_append(b, '"><rect x="')
+            call append_num(b, ax(i)%left * W)
             call builder_append(b, '" y="')
-            call append_num(b, ax_b + 16.0_dp)
-            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
-            call builder_append(b, 'font-size="10" fill="#000000">')
-            call builder_append(b, lbl(1:ln))
-            call builder_append(b, "</text>")
-            call builder_append(b, new_line("a"))
+            call append_num(b, (1.0_dp - ax(i)%top) * H)
+            call builder_append(b, '" width="')
+            call append_num(b, (ax(i)%right - ax(i)%left) * W)
+            call builder_append(b, '" height="')
+            call append_num(b, (ax(i)%top - ax(i)%bottom) * H)
+            call builder_append(b, '"/></clipPath>')
+        end do
+        call builder_append(b, "</defs>")
+        call builder_append(b, new_line("a"))
+
+        ! axes (subplots)
+        do i = 1, n_ax
+            call render_axes(b, ax(i), i, W, H)
         end do
 
-        ! y ticks
-        do i = 1, nyt
-            py = map_y(yticks(i), ymin, ymax, ax_b, ax_h, ylog)
-            call builder_append(b, '<line x1="')
-            call append_num(b, ax_l)
-            call builder_append(b, '" y1="')
-            call append_num(b, py)
-            call builder_append(b, '" x2="')
-            call append_num(b, ax_l - 3.5_dp)
-            call builder_append(b, '" y2="')
-            call append_num(b, py)
-            call builder_append(b, '" stroke="#000000" stroke-width="0.8"/>')
-            call builder_append(b, new_line("a"))
-            call format_tick_to(yticks(i), ylog, lbl, ln)
+        ! suptitle (figure-level, above all axes)
+        if (len_trim(fig_suptitle) > 0) then
+            call xml_escape_to(fig_suptitle, esc, en)
             call builder_append(b, '<text x="')
-            call append_num(b, ax_l - 7.0_dp)
+            call append_num(b, 0.5_dp * W)
             call builder_append(b, '" y="')
-            call append_num(b, py + 3.5_dp)
-            call builder_append(b, '" text-anchor="end" font-family="DejaVu Sans, sans-serif" ')
-            call builder_append(b, 'font-size="10" fill="#000000">')
-            call builder_append(b, lbl(1:ln))
-            call builder_append(b, "</text>")
-            call builder_append(b, new_line("a"))
-        end do
-
-        ! xlabel
-        if (len_trim(fig_xlabel) > 0) then
-            call xml_escape_to(fig_xlabel, esc, en)
-            call builder_append(b, '<text x="')
-            call append_num(b, 0.5_dp * (ax_l + ax_r))
-            call builder_append(b, '" y="')
-            call append_num(b, H - 8.0_dp)
-            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
-            call builder_append(b, 'font-size="11" fill="#000000">')
-            call builder_append(b, esc(1:en))
-            call builder_append(b, "</text>")
-            call builder_append(b, new_line("a"))
-        end if
-
-        ! ylabel
-        if (len_trim(fig_ylabel) > 0) then
-            call xml_escape_to(fig_ylabel, esc, en)
-            call builder_append(b, '<text x="')
-            call append_num(b, 16.0_dp)
-            call builder_append(b, '" y="')
-            call append_num(b, 0.5_dp * (ax_t + ax_b))
-            call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
-            call builder_append(b, 'font-size="11" fill="#000000" transform="rotate(-90 ')
-            call append_num(b, 16.0_dp)
-            call builder_append(b, " ")
-            call append_num(b, 0.5_dp * (ax_t + ax_b))
-            call builder_append(b, ')">')
-            call builder_append(b, esc(1:en))
-            call builder_append(b, "</text>")
-            call builder_append(b, new_line("a"))
-        end if
-
-        ! title
-        if (len_trim(fig_title) > 0) then
-            call xml_escape_to(fig_title, esc, en)
-            call builder_append(b, '<text x="')
-            call append_num(b, 0.5_dp * (ax_l + ax_r))
-            call builder_append(b, '" y="')
-            call append_num(b, ax_t - 10.0_dp)
+            call append_num(b, (1.0_dp - 0.98_dp) * H + 4.2_dp)
             call builder_append(b, '" text-anchor="middle" font-family="DejaVu Sans, sans-serif" ')
             call builder_append(b, 'font-size="12" fill="#000000">')
             call builder_append(b, esc(1:en))
             call builder_append(b, "</text>")
             call builder_append(b, new_line("a"))
-        end if
-
-        ! legend
-        if (legend_on) then
-            n_leg = 0
-            do i = 1, n_series
-                if (len_trim(series(i)%label) > 0) n_leg = n_leg + 1
-            end do
-            if (n_leg > 0) then
-                row_h = 18.0_dp
-                leg_w = 100.0_dp
-                leg_h = 8.0_dp + real(n_leg, dp) * row_h
-                leg_x = ax_r - leg_w - 8.0_dp
-                leg_y = ax_t + 8.0_dp
-                call builder_append(b, '<rect x="')
-                call append_num(b, leg_x)
-                call builder_append(b, '" y="')
-                call append_num(b, leg_y)
-                call builder_append(b, '" width="')
-                call append_num(b, leg_w)
-                call builder_append(b, '" height="')
-                call append_num(b, leg_h)
-                call builder_append(b, '" fill="#ffffff" stroke="#cccccc" stroke-width="0.8" rx="2"/>')
-                call builder_append(b, new_line("a"))
-                n = 0
-                do i = 1, n_series
-                    if (len_trim(series(i)%label) == 0) cycle
-                    n = n + 1
-                    py = leg_y + 4.0_dp + (real(n, dp) - 0.5_dp) * row_h
-                    if (series(i)%linestyle /= LINE_NONE) then
-                        call builder_append(b, '<line x1="')
-                        call append_num(b, leg_x + 8.0_dp)
-                        call builder_append(b, '" y1="')
-                        call append_num(b, py)
-                        call builder_append(b, '" x2="')
-                        call append_num(b, leg_x + 28.0_dp)
-                        call builder_append(b, '" y2="')
-                        call append_num(b, py)
-                        call builder_append(b, '" stroke="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '" stroke-width="')
-                        call append_num(b, series(i)%linewidth)
-                        call builder_append(b, '"')
-                        call append_dash(b, series(i)%linestyle)
-                        call builder_append(b, "/>")
-                        call builder_append(b, new_line("a"))
-                    end if
-                    mid = leg_x + 18.0_dp
-                    if (series(i)%marker == MARKER_CIRCLE) then
-                        call builder_append(b, '<circle cx="')
-                        call append_num(b, mid)
-                        call builder_append(b, '" cy="')
-                        call append_num(b, py)
-                        call builder_append(b, '" r="3" fill="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '"/>')
-                        call builder_append(b, new_line("a"))
-                    else if (series(i)%marker == MARKER_POINT) then
-                        call builder_append(b, '<circle cx="')
-                        call append_num(b, mid)
-                        call builder_append(b, '" cy="')
-                        call append_num(b, py)
-                        call builder_append(b, '" r="1.5" fill="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '"/>')
-                        call builder_append(b, new_line("a"))
-                    else if (series(i)%marker == MARKER_X) then
-                        r = 3.0_dp
-                        call builder_append(b, '<path d="M ')
-                        call append_num(b, mid - r)
-                        call builder_append(b, " ")
-                        call append_num(b, py - r)
-                        call builder_append(b, " L ")
-                        call append_num(b, mid + r)
-                        call builder_append(b, " ")
-                        call append_num(b, py + r)
-                        call builder_append(b, " M ")
-                        call append_num(b, mid - r)
-                        call builder_append(b, " ")
-                        call append_num(b, py + r)
-                        call builder_append(b, " L ")
-                        call append_num(b, mid + r)
-                        call builder_append(b, " ")
-                        call append_num(b, py - r)
-                        call builder_append(b, '" stroke="')
-                        call builder_append(b, trim(series(i)%color))
-                        call builder_append(b, '" stroke-width="1.5" fill="none"/>')
-                        call builder_append(b, new_line("a"))
-                    end if
-                    call xml_escape_to(series(i)%label, esc, en)
-                    call builder_append(b, '<text x="')
-                    call append_num(b, leg_x + 34.0_dp)
-                    call builder_append(b, '" y="')
-                    call append_num(b, py + 3.5_dp)
-                    call builder_append(b, '" font-family="DejaVu Sans, sans-serif" font-size="10" fill="#000000">')
-                    call builder_append(b, esc(1:en))
-                    call builder_append(b, "</text>")
-                    call builder_append(b, new_line("a"))
-                end do
-            end if
         end if
 
         call builder_append(b, "</svg>")

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -85,52 +85,9 @@ contains
         call clf()
     end subroutine figure
 
-    subroutine free_series(a, i)
-        type(axes_t), intent(inout) :: a
-        integer, intent(in) :: i
-        if (allocated(a%series(i)%x)) deallocate (a%series(i)%x)
-        if (allocated(a%series(i)%y)) deallocate (a%series(i)%y)
-        a%series(i)%n = 0
-        a%series(i)%label = ""
-        a%series(i)%color = "#1f77b4"
-        a%series(i)%marker = MARKER_NONE
-        a%series(i)%linestyle = LINE_SOLID
-        a%series(i)%linewidth = default_linewidth
-        a%series(i)%markersize = default_markersize
-    end subroutine free_series
-
-    subroutine clear_axes(a)
-        type(axes_t), intent(inout) :: a
-        integer :: i
-        do i = 1, MAX_SERIES
-            call free_series(a, i)
-        end do
-        a%n_series = 0
-        a%title = ""
-        a%xlabel = ""
-        a%ylabel = ""
-        a%grid_on = .false.
-        a%legend_on = .false.
-        a%xscale = SCALE_LINEAR
-        a%yscale = SCALE_LINEAR
-        a%xlim_set = .false.
-        a%ylim_set = .false.
-        a%xmin_user = 0.0_dp
-        a%xmax_user = 1.0_dp
-        a%ymin_user = 0.0_dp
-        a%ymax_user = 1.0_dp
-        a%color_cycle = 0
-    end subroutine clear_axes
-
     subroutine clf()
-        integer :: i
         cur_i = 0
-        if (n_ax > 0 .and. allocated(ax)) then
-            do i = 1, n_ax
-                call clear_axes(ax(i))
-            end do
-            deallocate (ax)
-        end if
+        if (allocated(ax)) deallocate (ax)
         n_ax = 0
         grid_m = 0
         grid_n = 0
@@ -147,12 +104,7 @@ contains
         real(dp) :: w, h
 
         cur_i = 0
-        if (n_ax > 0 .and. allocated(ax)) then
-            do i = 1, n_ax
-                call clear_axes(ax(i))
-            end do
-            deallocate (ax)
-        end if
+        if (allocated(ax)) deallocate (ax)
 
         n_ax = m * n
         allocate (ax(n_ax))
@@ -332,7 +284,6 @@ contains
 
         ax(ia)%n_series = ax(ia)%n_series + 1
         is = ax(ia)%n_series
-        call free_series(ax(ia), is)
 
         allocate (ax(ia)%series(is)%x(n), ax(ia)%series(is)%y(n))
         ax(ia)%series(is)%x(1:n) = x(1:n)

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -181,13 +181,9 @@ contains
     ! Select (or create) the i-th axes of an m x n grid.
     ! Forms: subplot(m, n, i), subplot(m, n) [i=1], subplot(231) [code].
     subroutine subplot(m, n, i)
-        integer, intent(in), optional :: m, n, i
+        integer, intent(in) :: m
+        integer, intent(in), optional :: n, i
         integer :: mm, nn, ii
-
-        if (.not. present(m)) then
-            print *, "fplot: subplot requires at least one argument"
-            return
-        end if
 
         if (present(n)) then
             ! subplot(m, n[, i]) form

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -17,7 +17,6 @@ module fplot
     integer, parameter :: SCALE_LOG = 1
     integer, parameter :: MAX_SERIES = 32
     integer, parameter :: MAX_POINTS = 100000
-    integer, parameter :: MAX_AXES = 16
 
     ! Default figure margins (matplotlib rcParams), in figure fractions.
     real(dp), parameter :: MARGIN_LEFT = 0.125_dp
@@ -128,56 +127,19 @@ contains
         grid_n = n
     end subroutine new_axes_grid
 
-    ! Select (or create) the i-th axes of an m x n grid.
-    ! Forms: subplot(m, n, i), subplot(m, n) [i=1], subplot(231) [code].
+    ! Select the i-th axes (row-major) of an m x n grid, creating the grid
+    ! if it differs from the current one.
     subroutine subplot(m, n, i)
-        integer, intent(in) :: m
-        integer, intent(in), optional :: n, i
-        integer :: mm, nn, ii
+        integer, intent(in) :: m, n, i
 
-        if (present(n)) then
-            ! subplot(m, n[, i]) form
-            mm = m
-            nn = n
-            if (present(i)) then
-                ii = i
-            else
-                ii = 1
-            end if
-        else
-            ! Single-integer form: subplot(1) or a 3-digit code like 231.
-            mm = m
-            if (mm == 1) then
-                nn = 1
-                ii = 1
-            else if (mm >= 100 .and. mm <= 999) then
-                ii = mod(mm, 10)
-                nn = (mm / 10) - 10 * (mm / 100)
-                mm = mm / 100
-            else
-                print *, "fplot: subplot single argument must be 1 or a 3-digit code (e.g. 231)"
-                return
-            end if
-        end if
-
-        if (mm < 1 .or. nn < 1 .or. ii < 1 .or. ii > mm * nn) then
-            print *, "fplot: invalid subplot indices (m=", mm, ", n=", nn, &
-                     ", i=", ii, ")"
-            return
-        end if
-        if (mm * nn > MAX_AXES) then
-            print *, "fplot: too many subplots (max ", MAX_AXES, ")"
-            return
+        if (m < 1 .or. n < 1 .or. i < 1 .or. i > m * n) then
+            print *, "fplot: invalid subplot indices: m=", m, " n=", n, " i=", i
+            error stop
         end if
 
         if (.not. fig_initialized) call clf()
-
-        if (n_ax == mm * nn .and. grid_m == mm .and. grid_n == nn) then
-            cur_i = ii
-        else
-            call new_axes_grid(mm, nn)
-            cur_i = ii
-        end if
+        if (grid_m /= m .or. grid_n /= n) call new_axes_grid(m, n)
+        cur_i = i
     end subroutine subplot
 
     subroutine suptitle(s)

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -29,6 +29,9 @@ module fplot
     ! Suptitle baseline (matplotlib figure.suptitle default y), in figure
     ! fractions measured from the bottom.
     real(dp), parameter :: SUPTITLE_Y = 0.98_dp
+    ! Mean advance width of DejaVu Sans at the 10 pt legend font size, used
+    ! to size the legend box to its labels.
+    real(dp), parameter :: LEGEND_CHAR_W = 5.6_dp
 
     type :: series_t
         integer :: n = 0
@@ -504,7 +507,7 @@ contains
         character(len=512) :: esc
         integer :: ln, en
         logical :: xlog, ylog
-        integer :: n_leg, k
+        integer :: n_leg, k, max_lbl
         real(dp) :: leg_x, leg_y, leg_w, leg_h, row_h
 
         axl = a%left * W
@@ -790,12 +793,19 @@ contains
         ! legend
         if (a%legend_on) then
             n_leg = 0
+            max_lbl = 0
             do i = 1, a%n_series
-                if (len_trim(a%series(i)%label) > 0) n_leg = n_leg + 1
+                if (len_trim(a%series(i)%label) > 0) then
+                    n_leg = n_leg + 1
+                    max_lbl = max(max_lbl, len_trim(a%series(i)%label))
+                end if
             end do
             if (n_leg > 0) then
                 row_h = 18.0_dp
-                leg_w = 100.0_dp
+                ! Sample line (leg_x+8 .. leg_x+28), gap to the text at
+                ! leg_x+34, the label itself, and a trailing pad.
+                leg_w = 34.0_dp + real(max_lbl, dp) * LEGEND_CHAR_W + 8.0_dp
+                leg_w = min(leg_w, axw - 16.0_dp)
                 leg_h = 8.0_dp + real(n_leg, dp) * row_h
                 leg_x = axr - leg_w - 8.0_dp
                 leg_y = axt + 8.0_dp

--- a/tests/compare_svgs.py
+++ b/tests/compare_svgs.py
@@ -18,6 +18,8 @@ CASES = [
     "semilogx",
     "semilogy",
     "loglog",
+    "subplots_2x1",
+    "subplots_2x2",
 ]
 
 
@@ -92,6 +94,15 @@ def main() -> int:
             f"circle={count_tags(out, 'circle')} line={count_tags(out, 'line')} "
             f"text={out.count('<text')}"
         )
+
+        # Axes count: matplotlib <g id="axes_N"> vs fplot clip paths.
+        n_ax_mpl = len(re.findall(r'<g id="axes_\d+"', ref))
+        n_ax_fplot = len(re.findall(r'<clipPath id="axclip', out))
+        if n_ax_mpl == n_ax_fplot:
+            print(f"  ok: axes count matches ({n_ax_mpl})")
+        else:
+            print(f"  HARD: axes count mpl={n_ax_mpl} fplot={n_ax_fplot}")
+            hard_fail += 1
         print(f"  sizes: mpl={len(ref)} bytes, fplot={len(out)} bytes")
 
         # Optional raster compare

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -20,6 +20,8 @@ OUT_NAMES = [
     "semilogx",
     "semilogy",
     "loglog",
+    "subplots_2x1",
+    "subplots_2x2",
 ]
 
 
@@ -123,6 +125,46 @@ def main() -> None:
     ax.set_xlim(0.1, 10.0)
     ax.set_ylim(0.01, 100.0)
     save(fig, "loglog")
+
+    # 7 subplots_2x1
+    fig, (ax_top, ax_bot) = plt.subplots(2, 1, figsize=(6.4, 4.8))
+    ax_top.plot(x, y, "b-", label="sin")
+    ax_top.set_title("top: sin")
+    ax_top.set_xlabel("x")
+    ax_top.set_ylabel("y")
+    ax_top.grid(True)
+    ax_top.legend()
+
+    ax_bot.plot(x, y2, "r--", label="cos")
+    ax_bot.set_title("bottom: cos")
+    ax_bot.set_xlabel("x")
+    ax_bot.set_ylabel("y")
+    ax_bot.grid(True)
+    ax_bot.legend()
+
+    fig.suptitle("fplot subplots")
+    save(fig, "subplots_2x1")
+
+    # 8 subplots_2x2
+    fig, axs = plt.subplots(2, 2, figsize=(6.4, 4.8))
+    axs[0, 0].plot(x, y, "b-", label="sin")
+    axs[0, 0].set_title("sin")
+    axs[0, 0].grid(True)
+
+    axs[0, 1].plot(x, y2, "r--", label="cos")
+    axs[0, 1].set_title("cos")
+    axs[0, 1].grid(True)
+
+    axs[1, 0].plot(x, y3, "g-", label="0.5 sin(2x)")
+    axs[1, 0].set_title("half sin 2x")
+    axs[1, 0].grid(True)
+
+    axs[1, 1].semilogx(xl, yl, "k-", label="x^2")
+    axs[1, 1].set_title("semilogx panel")
+    axs[1, 1].grid(True)
+
+    fig.suptitle("fplot 2x2 subplots")
+    save(fig, "subplots_2x2")
 
     print("All matplotlib references written.")
 

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -104,5 +104,54 @@ program test_plots
     call savefig("tests/out/loglog.svg")
     print *, "wrote tests/out/loglog.svg"
 
+    ! 7) subplots_2x1 (two rows, one column; exercises subplot(m,n,i),
+    !    the 3-digit code form, per-axes state, and suptitle)
+    call clf()
+    call subplot(2, 1, 1)
+    call plot(x, y, "b-", label="sin")
+    call title("top: sin")
+    call xlabel("x")
+    call ylabel("y")
+    call grid(.true.)
+    call legend()
+
+    call subplot(212)
+    call plot(x, y2, "r--", label="cos")
+    call title("bottom: cos")
+    call xlabel("x")
+    call ylabel("y")
+    call grid(.true.)
+    call legend()
+
+    call suptitle("fplot subplots")
+    call savefig("tests/out/subplots_2x1.svg")
+    print *, "wrote tests/out/subplots_2x1.svg"
+
+    ! 8) subplots_2x2 (four panels; also checks per-axes log scale)
+    call clf()
+    call subplot(2, 2, 1)
+    call plot(x, y, "b-", label="sin")
+    call title("sin")
+    call grid(.true.)
+
+    call subplot(2, 2, 2)
+    call plot(x, y2, "r--", label="cos")
+    call title("cos")
+    call grid(.true.)
+
+    call subplot(2, 2, 3)
+    call plot(x, y3, "g-", label="0.5 sin(2x)")
+    call title("half sin 2x")
+    call grid(.true.)
+
+    call subplot(2, 2, 4)
+    call semilogx(xl, yl, "k-", label="x^2")
+    call title("semilogx panel")
+    call grid(.true.)
+
+    call suptitle("fplot 2x2 subplots")
+    call savefig("tests/out/subplots_2x2.svg")
+    print *, "wrote tests/out/subplots_2x2.svg"
+
     print *, "All test plots written."
 end program test_plots

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -105,7 +105,7 @@ program test_plots
     print *, "wrote tests/out/loglog.svg"
 
     ! 7) subplots_2x1 (two rows, one column; exercises subplot(m,n,i),
-    !    the 3-digit code form, per-axes state, and suptitle)
+    !    per-axes state, and suptitle)
     call clf()
     call subplot(2, 1, 1)
     call plot(x, y, "b-", label="sin")
@@ -115,7 +115,7 @@ program test_plots
     call grid(.true.)
     call legend()
 
-    call subplot(212)
+    call subplot(2, 1, 2)
     call plot(x, y2, "r--", label="cos")
     call title("bottom: cos")
     call xlabel("x")


### PR DESCRIPTION
Refactor figure state into an axes_t type (series, labels, grid/legend, scales, limits, color cycle, geometry) held in an allocatable array with a current-axes pointer. plot/title/etc. now operate on the current axes; without subplot() a single full-figure axes is created as before.

- subplot(m, n, i), subplot(m, n) [i=1], and the 3-digit code form (e.g. subplot(212)); selecting an existing grid keeps its data, a different grid replaces it; per-axes color cycle and log scales
- suptitle(s) for a figure-level title
- Layout uses matplotlib's default subplot params (margins 0.125/0.9/ 0.11/0.88, wspace=hspace=0.2); axes boxes match matplotlib to <0.01 pt
- Per-axes xlabel/ylabel/title placement matching matplotlib offsets (xlabel axb+28.6, ylabel axl-34 centered, title axt-6)
- render_svg emits one clip path per axes and renders each axes group

Tests: new subplots_2x1 and subplots_2x2 cases in test_plots.f90 with matplotlib references; compare_svgs.py now also checks the axes count. Raster MAE vs matplotlib refs: 1.4-4.5/255 across all 8 cases, identical output from Flang and LFortran.

Also: pin lfortran via pixi (conda-forge 0.64) so builds don't depend on a dev build in PATH; add cairosvg/pillow to enable the raster compare.