### PR TITLE
Close the last gaps against the roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ call title("bottom")
 call suptitle("figure title")
 ```
 
-## Features (MVP)
+## Features
 
 - `plot`, `scatter`, `bar`, `hist`, `fill_between`, `errorbar`
 - `scatter` also takes per-point `sizes=` and color-mapped `cvals=`
@@ -166,6 +166,23 @@ call display_data("image/svg+xml", render_svg())
 
 `show()` always writes `fplot_show.svg` (works with Flang and LFortran offline).
 
-## Comparison note
+## Fidelity to matplotlib
 
-Output is **visually** similar to matplotlib, not bit-identical SVG. Matplotlib embeds DejaVu glyph outlines and rich metadata; fplot uses SVG `<text>` and simpler geometry.
+fplot is measured against matplotlib rather than described as similar to it:
+every feature has a case in `tests/test_plots.f90` and a matplotlib reference
+in `tests/gen_mpl_refs.py`, and the comparisons above put a number on the
+difference. As of this writing, over 75 cases:
+
+| format | cases | mean difference |
+| --- | --- | --- |
+| PNG | 75 | 1.55/255 |
+| PDF | 74 | 1.99/255 |
+| EPS | 75 | 3.61/255 |
+| GIF | 20 frames | 0.60/255 |
+
+What is left is mostly antialiasing along edges, and text: fplot draws with
+its own compiled-in DejaVu Sans metrics and glyph outlines, so a stem lands
+on the same pixel column as matplotlib's but not always with the same
+coverage. The SVG is not matplotlib's SVG byte for byte, and is not meant to
+be: matplotlib writes every glyph as a path and attaches its own metadata,
+while fplot writes `<text>` and leaves the glyphs to the viewer.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ call suptitle("figure title")
   `zlabel` and `zlim`, drawn with mplot3d's camera, panes and lighting
 - Polar axes: `polar(theta, r)`, or `set_polar()` on an axes, with the
   angular grid, the degree labels and the radial labels along 22.5°
-- Patches: `add_rectangle`, `add_circle`, `add_ellipse` and `add_polygon`,
+- Patches: `add_rectangle`, `add_circle`, `add_ellipse`, `add_polygon`,
+  `add_arrow` and `add_path` for an arbitrary path of lines and cubics,
   filled and outlined in data coordinates
 - `clabel` to write the level into each contour line, breaking the line
   at its straightest stretch to make room

--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ call suptitle("figure title")
   once and drawn by every backend
 - Categorical axes: `plot`, `bar` and `barh` take a list of names in place
   of the numbers, and place them at 0, 1, 2, ... with the names as ticks
-- 49 matplotlib colormaps, any of them reversed with a `_r` suffix, and
-  `imshow(norm="log")` for a logarithmic color scale
+- 49 matplotlib colormaps, plus the qualitative `tab10`, `tab20` and
+  `Set1`, any of them reversed with a `_r` suffix
+- `imshow(norm="log")` for a logarithmic color scale, and
+  `imshow(boundaries=)` for matplotlib's `BoundaryNorm`: one flat color
+  per band, and a colorbar of blocks to match
 - `errorbar` with `xerr=` and asymmetric `yerr_lo=`/`yerr_hi=` arms
 - `fill_between(where=)` to shade only where a condition holds
 - `hist(bins=, bin_edges=, density=, cumulative=, histtype="step"/"stepfilled",

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ call suptitle("figure title")
   `imshow(norm="log")` for a logarithmic color scale
 - `errorbar` with `xerr=` and asymmetric `yerr_lo=`/`yerr_hi=` arms
 - `fill_between(where=)` to shade only where a condition holds
-- `hist(bins=, bin_edges=, density=, cumulative=, histtype="step"/"stepfilled")`
+- `hist(bins=, bin_edges=, density=, cumulative=, histtype="step"/"stepfilled",
+  weights=, stacked=)`
 - `axhspan`/`axvspan` shaded bands and `hlines`/`vlines` line runs
 - `style_use("ggplot")` and friends (`seaborn`, `fivethirtyeight`,
   `dark_background`, `grayscale`, `default`), or `rc(figsize=, dpi=,

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ call suptitle("figure title")
   have the ticks land on round dates and read as dates
 - `subplot2grid`: panels that span several cells of a grid, so a wide
   plot can sit over two narrow ones
+- `gridspec(width_ratios=, height_ratios=)`: columns and rows of unequal
+  size, for a wide panel beside a narrow one
 - `pcolormesh` and `pcolor`: a grid of cells with edges of your own
   choosing, which is what an unevenly sampled field needs
 - matplotlib's tick locator and formatter: the same 1/2/2.5/5 steps, the

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ call suptitle("figure title")
 - `tick_params(axis=, direction=, length=, labelsize=, rotation=)` and `spines`
 - `legend(loc=, fontsize=, ncol=, frameon=, title=, bbox_to_anchor=)`,
   `xticks` / `yticks` with optional labels, `minorticks_on`
+- Formatters and locators: `tick_format(axis, "percent"/"comma"/"fixed")`,
+  `tick_locator(axis, base=, nbins=)` and `ticklabel_format(style=,
+  useoffset=, scilimits=)`. An axis whose labels would otherwise repeat
+  themselves factors the shared offset and power of ten out into a single
+  label at its end, as matplotlib's ScalarFormatter does
 - Font sizes: `fontsize=` on `title` / `xlabel` / `ylabel` / `suptitle`, and
   `set_fontsize(size=, title=, labels=, ticks=, legend=)` to set them globally
 - `savefig(dpi=, bbox_inches="tight", pad_inches=)` to crop to the drawing

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -34,6 +34,7 @@ module fplot
     public :: axis, set_aspect, tick_params, spines
     public :: text, annotate
     public :: xticks, yticks, minorticks_on
+    public :: ticklabel_format, tick_format, tick_locator
     public :: imshow, colorbar, contour, contourf, clabel
     public :: title, xlabel, ylabel, grid, legend
     public :: xlim, ylim, clf, savefig, show, figure
@@ -48,6 +49,14 @@ module fplot
     public :: axes, subplots, sca
     public :: style_use, rc
 
+    ! How the ticks of an axis are written. FMT_AUTO is matplotlib's
+    ! ScalarFormatter, which is what an axis does unless it is told
+    ! otherwise; the rest are its named formatters.
+    integer, parameter :: FMT_AUTO = 0
+    integer, parameter :: FMT_PERCENT = 1
+    integer, parameter :: FMT_COMMA = 2
+    integer, parameter :: FMT_FIXED = 3
+
     ! What one axis agreed to write on its ticks: how many decimals, and
     ! the offset and power of ten factored out of every label and written
     ! once at the end of the axis instead.
@@ -55,6 +64,8 @@ module fplot
         integer :: dec = 0
         real(dp) :: off = 0.0_dp
         integer :: oom = 0
+        integer :: style = FMT_AUTO
+        real(dp) :: whole = 100.0_dp
     end type tickfmt_t
 
     ! Initial slot count for the per-axes series and text arrays; both grow
@@ -275,6 +286,17 @@ module fplot
         ! An axis whose numbers are days since 1970-01-01, and so takes
         ! its ticks and labels from the calendar.
         logical :: x_date = .false., y_date = .false.
+        ! Formatter and locator chosen by the user. A style of FMT_AUTO, a
+        ! decimal count of -1, a base of zero and a bin count of zero all
+        ! mean "whatever matplotlib would have done".
+        integer :: xfmt_style = FMT_AUTO, yfmt_style = FMT_AUTO
+        integer :: xfmt_dec = -1, yfmt_dec = -1
+        real(dp) :: xfmt_whole = 100.0_dp, yfmt_whole = 100.0_dp
+        logical :: x_use_offset = .true., y_use_offset = .true.
+        integer :: x_scilo = -5, x_scihi = 6
+        integer :: y_scilo = -5, y_scihi = 6
+        real(dp) :: xtick_base = 0.0_dp, ytick_base = 0.0_dp
+        integer :: xtick_nbins = 0, ytick_nbins = 0
         logical :: has_mesh = .false.
         real(dp), allocatable :: mesh_x(:), mesh_y(:)
         ! Data units per point in y over the same in x. Zero means auto.
@@ -1187,11 +1209,12 @@ contains
         v = 0.0_dp
         call compute_limits(a, xmin, xmax, ymin, ymax)
         call axis_ticks(a%n_yticks, a%ytick_pos, min(ymin, ymax), max(ymin, ymax), &
-                        a%ysc, 9, a%y_date, t, nt, du)
+                        a%ysc, nbins_for(a%ytick_nbins, 0.0_dp, a%ytick_size, .false.), &
+                        a%y_date, t, nt, du, a%ytick_base)
         do i = 1, nt
             call tick_label(a%ytick_labeled, a%ytick_lab, i, t(i), a%ysc, &
-                            axis_fmt(t, nt, a%ysc, min(ymin, ymax), max(ymin, ymax)), &
-                            du, lbl, ln)
+                            axis_fmt(t, nt, a, .false., min(ymin, ymax), &
+                                     max(ymin, ymax)), du, lbl, ln)
             if (math_is(lbl(1:ln))) then
                 v = max(v, math_width(lbl(1:ln), a%ytick_size))
             else
@@ -2053,6 +2076,131 @@ contains
             ax(cur_i)%legend_has_bbox = .true.
         end if
     end subroutine legend
+
+
+    ! ------------------------------------------------------------------
+    ! Formatters and locators. matplotlib reaches these through the axis
+    ! object (set_major_formatter, set_major_locator) and a pyplot
+    ! shortcut; there is one shortcut per job here instead, because a
+    ! formatter object of our own would be a class with one method and
+    ! nothing to say.
+    ! ------------------------------------------------------------------
+
+    ! matplotlib's ticklabel_format: whether an axis may factor an offset
+    ! or a power of ten out of its labels, and from where.
+    subroutine ticklabel_format(axis, style, useoffset, scilimits)
+        character(len=*), intent(in), optional :: axis, style
+        logical, intent(in), optional :: useoffset
+        integer, intent(in), optional :: scilimits(2)
+        logical :: dox, doy
+        integer :: lo, hi
+
+        call ensure_fig()
+        call which_axis(axis, dox, doy)
+        if (present(useoffset)) then
+            if (dox) ax(cur_i)%x_use_offset = useoffset
+            if (doy) ax(cur_i)%y_use_offset = useoffset
+        end if
+        lo = -5
+        hi = 6
+        if (present(style)) then
+            select case (lower(style))
+            case ("plain")
+                ! Never factor a power of ten out: no limit is ever met.
+                lo = -huge(1)/2
+                hi = huge(1)/2
+            case ("sci", "scientific")
+                ! Always factor one out, which is what (0, 0) means.
+                lo = 0
+                hi = 0
+            end select
+        end if
+        if (present(scilimits)) then
+            lo = scilimits(1)
+            hi = scilimits(2)
+        end if
+        if (present(style) .or. present(scilimits)) then
+            if (dox) then
+                ax(cur_i)%x_scilo = lo
+                ax(cur_i)%x_scihi = hi
+            end if
+            if (doy) then
+                ax(cur_i)%y_scilo = lo
+                ax(cur_i)%y_scihi = hi
+            end if
+        end if
+    end subroutine ticklabel_format
+
+    ! One of matplotlib's named formatters: "percent" is PercentFormatter,
+    ! "comma" is a StrMethodFormatter with a thousands separator, "fixed"
+    ! is a FormatStrFormatter with a set number of decimals, and "auto" is
+    ! the ScalarFormatter every axis starts with.
+    subroutine tick_format(axis, style, decimals, whole)
+        character(len=*), intent(in) :: style
+        character(len=*), intent(in), optional :: axis
+        integer, intent(in), optional :: decimals
+        real(dp), intent(in), optional :: whole
+        logical :: dox, doy
+        integer :: st, dec
+
+        call ensure_fig()
+        call which_axis(axis, dox, doy)
+        select case (lower(style))
+        case ("percent"); st = FMT_PERCENT
+        case ("comma", "thousands"); st = FMT_COMMA
+        case ("fixed"); st = FMT_FIXED
+        case default; st = FMT_AUTO
+        end select
+        dec = -1
+        if (present(decimals)) dec = decimals
+        ! A percentage with no decimals asked for is written whole, which
+        ! is what PercentFormatter defaults to.
+        if (st == FMT_PERCENT .and. dec < 0) dec = 0
+        if (dox) then
+            ax(cur_i)%xfmt_style = st
+            ax(cur_i)%xfmt_dec = dec
+            if (present(whole)) ax(cur_i)%xfmt_whole = whole
+        end if
+        if (doy) then
+            ax(cur_i)%yfmt_style = st
+            ax(cur_i)%yfmt_dec = dec
+            if (present(whole)) ax(cur_i)%yfmt_whole = whole
+        end if
+    end subroutine tick_format
+
+    ! base is MultipleLocator, nbins is MaxNLocator. Neither moves the
+    ! limits; they only decide where the ticks land inside them.
+    subroutine tick_locator(axis, base, nbins)
+        character(len=*), intent(in), optional :: axis
+        real(dp), intent(in), optional :: base
+        integer, intent(in), optional :: nbins
+        logical :: dox, doy
+
+        call ensure_fig()
+        call which_axis(axis, dox, doy)
+        if (present(base)) then
+            if (dox) ax(cur_i)%xtick_base = base
+            if (doy) ax(cur_i)%ytick_base = base
+        end if
+        if (present(nbins)) then
+            if (dox) ax(cur_i)%xtick_nbins = nbins
+            if (doy) ax(cur_i)%ytick_nbins = nbins
+        end if
+    end subroutine tick_locator
+
+    ! "x", "y" or "both", the way every matplotlib call that takes an axis
+    ! name spells it. Absent means both.
+    subroutine which_axis(axis, dox, doy)
+        character(len=*), intent(in), optional :: axis
+        logical, intent(out) :: dox, doy
+        dox = .true.
+        doy = .true.
+        if (.not. present(axis)) return
+        select case (lower(axis))
+        case ("x"); doy = .false.
+        case ("y"); dox = .false.
+        end select
+    end subroutine which_axis
 
     subroutine xticks(vals, labels)
         real(dp), intent(in) :: vals(:)
@@ -5696,8 +5844,28 @@ contains
         end if
     end function tick_space
 
+    ! How many intervals to ask the locator for: what the user asked for
+    ! with MaxNLocator, else as many as the axis is long enough to label.
+    ! A length of zero is the layout pass, which has no geometry yet and
+    ! uses matplotlib's own default of nine.
+    pure function nbins_for(nbins, length, size, horizontal) result(n)
+        integer, intent(in) :: nbins
+        real(dp), intent(in) :: length, size
+        logical, intent(in) :: horizontal
+        integer :: n
+        if (nbins > 0) then
+            n = nbins
+        else if (length <= 0.0_dp) then
+            n = 9
+        else
+            n = tick_space(length, size, horizontal)
+        end if
+    end function nbins_for
+
+    ! base, when it is positive, is MultipleLocator: ticks every base
+    ! units rather than wherever the automatic locator would put them.
     subroutine axis_ticks(n_user, user_pos, vmin, vmax, sc, nbins, is_date, &
-                          t, nt, date_unit)
+                          t, nt, date_unit, base)
         integer, intent(in) :: n_user
         real(dp), intent(in) :: user_pos(MAX_TICKS), vmin, vmax
         type(scale_t), intent(in) :: sc
@@ -5706,8 +5874,15 @@ contains
         real(dp), intent(out) :: t(MAX_TICKS)
         integer, intent(out) :: nt
         integer, intent(out) :: date_unit
+        real(dp), intent(in), optional :: base
 
         date_unit = 0
+        if (present(base)) then
+            if (base > 0.0_dp .and. n_user == 0) then
+                call multiple_ticks(vmin, vmax, base, t, nt)
+                return
+            end if
+        end if
         if (n_user < 0) then
             nt = 0
         else if (n_user > 0) then
@@ -6687,7 +6862,14 @@ contains
         else if (sc%kind == SCALE_LOG) then
             call format_tick_to(v, .true., out, n)
         else
-            call format_tick_fixed((v - f%off)/10.0_dp**f%oom, f%dec, out, n)
+            select case (f%style)
+            case (FMT_PERCENT)
+                call format_percent(v, f%whole, f%dec, out, n)
+            case (FMT_COMMA)
+                call format_grouped(v, f%dec, out, n)
+            case default
+                call format_tick_fixed((v - f%off)/10.0_dp**f%oom, f%dec, out, n)
+            end select
         end if
     end subroutine tick_label
 
@@ -6708,17 +6890,40 @@ contains
     ! The same for an axis that may factor an offset or a power of ten out
     ! of its labels. Only a linear axis does; a log or date axis writes its
     ! own labels and has nothing to factor.
-    function axis_fmt(t, nt, sc, vmin, vmax) result(f)
+    function axis_fmt(t, nt, a, is_x, vmin, vmax) result(f)
         real(dp), intent(in) :: t(MAX_TICKS), vmin, vmax
         integer, intent(in) :: nt
-        type(scale_t), intent(in) :: sc
+        type(axes_t), intent(in) :: a
+        logical, intent(in) :: is_x
         type(tickfmt_t) :: f
+        type(scale_t) :: sc
+
+        sc = a%ysc
+        if (is_x) sc = a%xsc
         if (sc%kind /= SCALE_LINEAR) then
             f%dec = -1
             return
         end if
-        call tick_offset(t, nt, vmin, vmax, f%off, f%oom)
+        if (is_x) then
+            f%style = a%xfmt_style
+            f%whole = a%xfmt_whole
+            call tick_offset(t, nt, vmin, vmax, f%off, f%oom, &
+                             a%x_use_offset, a%x_scilo, a%x_scihi)
+        else
+            f%style = a%yfmt_style
+            f%whole = a%yfmt_whole
+            call tick_offset(t, nt, vmin, vmax, f%off, f%oom, &
+                             a%y_use_offset, a%y_scilo, a%y_scihi)
+        end if
+        ! A named formatter writes the value itself, so nothing may be
+        ! taken out of it first.
+        if (f%style /= FMT_AUTO) then
+            f%off = 0.0_dp
+            f%oom = 0
+        end if
         f%dec = tick_decimals_at(t, nt, f%off, f%oom)
+        if (is_x .and. a%xfmt_dec >= 0) f%dec = a%xfmt_dec
+        if (.not. is_x .and. a%yfmt_dec >= 0) f%dec = a%yfmt_dec
     end function axis_fmt
 
     ! A polar axes. The box holds the largest circle that fits: the angle
@@ -7346,13 +7551,13 @@ contains
         ysc = a%ysc
 
         call axis_ticks(a%n_xticks, a%xtick_pos, xmin, xmax, xsc, &
-                        tick_space(ax_w, a%xtick_size, .true.), a%x_date, &
-                        xticks, nxt, x_unit)
+                        nbins_for(a%xtick_nbins, ax_w, a%xtick_size, .true.), a%x_date, &
+                        xticks, nxt, x_unit, a%xtick_base)
         call axis_ticks(a%n_yticks, a%ytick_pos, min(ymin, ymax), max(ymin, ymax), &
-                        ysc, tick_space(ax_h, a%ytick_size, .false.), a%y_date, &
-                        yticks, nyt, y_unit)
-        xfmt = axis_fmt(xticks, nxt, xsc, xmin, xmax)
-        yfmt = axis_fmt(yticks, nyt, ysc, min(ymin, ymax), max(ymin, ymax))
+                        ysc, nbins_for(a%ytick_nbins, ax_h, a%ytick_size, .false.), &
+                        a%y_date, yticks, nyt, y_unit, a%ytick_base)
+        xfmt = axis_fmt(xticks, nxt, a, .true., xmin, xmax)
+        yfmt = axis_fmt(yticks, nyt, a, .false., min(ymin, ymax), max(ymin, ymax))
         if (a%minor_ticks) then
             call minor_positions(xticks, nxt, xmin, xmax, xsc, xminor, nxm)
             call minor_positions(yticks, nyt, ymin, ymax, ysc, yminor, nym)

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -278,6 +278,9 @@ module fplot
         ! How a value is placed on the colormap: linearly, or by its
         ! logarithm, matplotlib's LogNorm.
         logical :: img_log_norm = .false.
+        ! BoundaryNorm: the edges of the bands the data is sorted into. The
+        ! image then takes one flat color per band rather than a ramp.
+        real(dp), allocatable :: img_bounds(:)
         real(dp) :: img_ext(4) = [0.0_dp, 1.0_dp, 0.0_dp, 1.0_dp]
         logical :: img_origin_upper = .true.
         ! pcolormesh keeps the same samples in img, but with its own cell
@@ -1773,13 +1776,16 @@ contains
         call stem(x, y, color, label, alpha)
     end subroutine ax_stem
 
-    subroutine ax_imshow(self, z, cmap, vmin, vmax, extent, origin, aspect, norm)
+    subroutine ax_imshow(self, z, cmap, vmin, vmax, extent, origin, aspect, &
+                         norm, interpolation, boundaries)
         class(axes), intent(in) :: self
         real(dp), intent(in) :: z(:, :)
         character(len=*), intent(in), optional :: cmap, origin, aspect, norm
-        real(dp), intent(in), optional :: vmin, vmax, extent(4)
+        character(len=*), intent(in), optional :: interpolation
+        real(dp), intent(in), optional :: vmin, vmax, extent(4), boundaries(:)
         call ax_sca(self)
-        call imshow(z, cmap, vmin, vmax, extent, origin, aspect, norm)
+        call imshow(z, cmap, vmin, vmax, extent, origin, aspect, norm, &
+                    interpolation, boundaries)
     end subroutine ax_imshow
 
     subroutine ax_xaxis_date(self)
@@ -2634,10 +2640,11 @@ contains
     ! Draw z as an image. z is indexed (row, column) and, with the default
     ! origin="upper", row 1 is drawn at the top, which is why that case gives
     ! a descending y axis exactly as matplotlib does.
-    subroutine imshow(z, cmap, vmin, vmax, extent, origin, aspect, norm, interpolation)
+    subroutine imshow(z, cmap, vmin, vmax, extent, origin, aspect, norm, &
+                      interpolation, boundaries)
         real(dp), intent(in) :: z(:, :)
         character(len=*), intent(in), optional :: cmap, origin, aspect, norm, interpolation
-        real(dp), intent(in), optional :: vmin, vmax, extent(4)
+        real(dp), intent(in), optional :: vmin, vmax, extent(4), boundaries(:)
         integer :: nr, nc
         real(dp) :: lo, hi
 
@@ -2662,6 +2669,14 @@ contains
         ax(cur_i)%img_log_norm = .false.
         if (present(norm)) ax(cur_i)%img_log_norm = trim(norm) == "log"
 
+        if (allocated(ax(cur_i)%img_bounds)) deallocate (ax(cur_i)%img_bounds)
+        if (present(boundaries)) then
+            if (size(boundaries) >= 2) then
+                allocate (ax(cur_i)%img_bounds(size(boundaries)))
+                ax(cur_i)%img_bounds = boundaries
+            end if
+        end if
+
         if (ax(cur_i)%img_log_norm) then
             ! A log scale cannot start at zero, so the smallest positive
             ! sample sets the bottom of the range.
@@ -2674,6 +2689,11 @@ contains
         end if
         if (present(vmin)) lo = vmin
         if (present(vmax)) hi = vmax
+        ! The bands say what the range is; anything outside them is clamped.
+        if (allocated(ax(cur_i)%img_bounds)) then
+            lo = ax(cur_i)%img_bounds(1)
+            hi = ax(cur_i)%img_bounds(size(ax(cur_i)%img_bounds))
+        end if
         if (hi <= lo) hi = lo + 1.0_dp
         ax(cur_i)%img_vmin = lo
         ax(cur_i)%img_vmax = hi
@@ -6739,19 +6759,36 @@ contains
         ! Slices are grown slightly so they abut without seams, so keep them
         ! inside the bar.
         call set_clip(bx, bt, bw, bh)
-        do i = 1, CBAR_SLICES
-            y1 = bb - real(i - 1, dp) * bh / real(CBAR_SLICES, dp)
-            y0 = bb - real(i, dp) * bh / real(CBAR_SLICES, dp)
-            t = (real(i, dp) - 0.5_dp) / real(CBAR_SLICES, dp)
-            call append_cell(b, bx, y0, bw, y1 - y0, cmap_color(a%img_cmap, t))
-        end do
+        if (allocated(a%img_bounds)) then
+            ! One block per band, as tall as the band is wide in the data.
+            lo = a%img_bounds(1)
+            hi = a%img_bounds(size(a%img_bounds))
+            do i = 1, size(a%img_bounds) - 1
+                y1 = bb - (a%img_bounds(i) - lo) / (hi - lo) * bh
+                y0 = bb - (a%img_bounds(i + 1) - lo) / (hi - lo) * bh
+                v = 0.5_dp * (a%img_bounds(i) + a%img_bounds(i + 1))
+                call append_cell(b, bx, y0, bw, y1 - y0, &
+                                 cmap_color(a%img_cmap, cmap_t(a, v)))
+            end do
+        else
+            do i = 1, CBAR_SLICES
+                y1 = bb - real(i - 1, dp) * bh / real(CBAR_SLICES, dp)
+                y0 = bb - real(i, dp) * bh / real(CBAR_SLICES, dp)
+                t = (real(i, dp) - 0.5_dp) / real(CBAR_SLICES, dp)
+                call append_cell(b, bx, y0, bw, y1 - y0, cmap_color(a%img_cmap, t))
+            end do
+        end if
         call clear_clip()
 
         call b%draw_rect(bx, bt, bw, bh, pen(rc_spine_color, rc_spine_lw))
 
         lo = a%img_vmin
         hi = a%img_vmax
-        if (a%img_log_norm) then
+        if (allocated(a%img_bounds)) then
+            ! A tick at every band edge, which is what the bands mean.
+            nt = min(MAX_TICKS, size(a%img_bounds))
+            cb_ticks(1:nt) = a%img_bounds(1:nt)
+        else if (a%img_log_norm) then
             call log_ticks(lo, hi, cb_ticks, nt)
         else
             call linear_ticks(lo, hi, tick_space(bh, a%ytick_size, .false.), &
@@ -6759,10 +6796,12 @@ contains
         end if
         dec = -1
         if (.not. a%img_log_norm) dec = tick_decimals(cb_ticks, nt)
+
         do i = 1, nt
             v = cb_ticks(i)
             if (v < lo .or. v > hi) cycle
-            py = bb - cmap_t(a, v) * bh
+            py = bb - (v - lo) / (hi - lo) * bh
+            if (a%img_log_norm) py = bb - cmap_t(a, v) * bh
             call append_tick(b, bx + bw, py, bx + bw + 3.5_dp, py)
             if (a%img_log_norm) then
                 call format_tick_to(v, .true., lbl, ln)
@@ -6793,8 +6832,27 @@ contains
         type(axes_t), intent(in) :: a
         real(dp), intent(in) :: v
         real(dp) :: t, lo, hi
+        integer :: i, nb
         lo = a%img_vmin
         hi = a%img_vmax
+        if (allocated(a%img_bounds)) then
+            ! BoundaryNorm: find the band, then take the color matplotlib
+            ! gives that band, which is band*(N-1)/(nband-1) of the map.
+            nb = size(a%img_bounds) - 1
+            i = 0
+            do while (i < nb)
+                if (v < a%img_bounds(i + 2)) exit
+                i = i + 1
+            end do
+            if (v < a%img_bounds(1)) i = 0
+            i = max(0, min(nb - 1, i))
+            if (nb <= 1) then
+                t = 0.0_dp
+            else
+                t = real(int(real(i, dp) * 255.0_dp / real(nb - 1, dp)), dp) / 255.0_dp
+            end if
+            return
+        end if
         if (a%img_log_norm) then
             ! Anything at or below zero has no logarithm, so it takes the
             ! bottom of the map, as matplotlib's LogNorm does.

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -41,7 +41,7 @@ module fplot
     public :: render_svg, render_pdf, render_png, render_eps
     public :: add_frame, save_animation
     public :: axes3d, plot3d, scatter3d, plot_surface, view_init, zlabel, zlim
-    public :: subplot, subplot2grid, suptitle, subplots_adjust, tight_layout
+    public :: subplot, subplot2grid, gridspec, suptitle, subplots_adjust, tight_layout
     public :: xaxis_date, yaxis_date, date_num
     public :: twinx, twiny
     public :: set_fontsize
@@ -52,6 +52,9 @@ module fplot
     ! How the ticks of an axis are written. FMT_AUTO is matplotlib's
     ! ScalarFormatter, which is what an axis does unless it is told
     ! otherwise; the rest are its named formatters.
+    ! Most rows or columns a figure's grid can be given a ratio for.
+    integer, parameter :: MAX_RATIO = 32
+
     integer, parameter :: FMT_AUTO = 0
     integer, parameter :: FMT_PERCENT = 1
     integer, parameter :: FMT_COMMA = 2
@@ -527,6 +530,10 @@ module fplot
     integer, save :: n_ax = 0
     integer, save :: cur_i = 0
     integer, save :: grid_m = 0, grid_n = 0
+    ! Relative column widths and row heights, GridSpec's width_ratios and
+    ! height_ratios. All ones, the default, is an even grid.
+    real(dp), save :: fig_wratio(MAX_RATIO) = 1.0_dp
+    real(dp), save :: fig_hratio(MAX_RATIO) = 1.0_dp
     ! A grid whose cells are filled in one at a time by subplot2grid,
     ! rather than all at once by subplot.
     logical, save :: grid_sparse = .false.
@@ -545,6 +552,7 @@ module fplot
         type(axes_t), allocatable :: ax(:)
         integer :: n_ax, cur_i, grid_m, grid_n
         logical :: sparse
+        real(dp) :: wratio(MAX_RATIO), hratio(MAX_RATIO)
     end type figure_t
     type(figure_t), allocatable, save :: figs(:)
     integer, save :: cur_fig = 0
@@ -594,6 +602,8 @@ contains
         figs(k)%grid_m = grid_m
         figs(k)%grid_n = grid_n
         figs(k)%sparse = grid_sparse
+        figs(k)%wratio = fig_wratio
+        figs(k)%hratio = fig_hratio
         if (allocated(figs(k)%ax)) deallocate (figs(k)%ax)
         ! Allocated explicitly rather than relying on reallocation on
         ! assignment, which is not on by default in every compiler.
@@ -614,6 +624,8 @@ contains
         fig_top = figs(k)%top
         fig_wspace = figs(k)%wspace
         fig_hspace = figs(k)%hspace
+        fig_wratio = figs(k)%wratio
+        fig_hratio = figs(k)%hratio
         fig_suptitle = figs(k)%suptitle
         def_title = figs(k)%d_title
         def_label = figs(k)%d_label
@@ -761,6 +773,8 @@ contains
         fig_top = MARGIN_TOP
         fig_wspace = WSPACE
         fig_hspace = HSPACE
+        fig_wratio = 1.0_dp
+        fig_hratio = 1.0_dp
         def_title = TITLE_FONT
         def_label = LABEL_FONT
         def_tick = TICK_FONT
@@ -946,19 +960,45 @@ contains
 
     ! Place the existing axes in the current margins. Called again whenever
     ! those margins move, so the axes objects themselves survive.
+    ! Where each column starts and how wide it is, in figure fractions.
+    ! The gap between cells is the same everywhere, as it is in matplotlib:
+    ! wspace and hspace are fractions of the average cell, not of each one,
+    ! so uneven ratios change the cells and leave the gaps alone.
+    subroutine grid_edges(nc, lo, hi, space, ratio, pos, len)
+        integer, intent(in) :: nc
+        real(dp), intent(in) :: lo, hi, space, ratio(MAX_RATIO)
+        real(dp), intent(out) :: pos(MAX_RATIO), len(MAX_RATIO)
+        real(dp) :: cell, sep, total, sumr, p
+        integer :: k
+
+        cell = (hi - lo)/(real(nc, dp) + space*real(nc - 1, dp))
+        sep = space*cell
+        total = cell*real(nc, dp)
+        sumr = 0.0_dp
+        do k = 1, nc
+            sumr = sumr + max(ratio(k), 0.0_dp)
+        end do
+        if (sumr <= 0.0_dp) sumr = real(nc, dp)
+        p = lo
+        do k = 1, nc
+            len(k) = total*max(ratio(k), 0.0_dp)/sumr
+            pos(k) = p
+            p = p + len(k) + sep
+        end do
+    end subroutine grid_edges
+
     subroutine layout_grid()
         integer :: i, r, c
-        real(dp) :: w, h, dx, dy
+        real(dp) :: xpos(MAX_RATIO), xlen(MAX_RATIO)
+        real(dp) :: ypos(MAX_RATIO), ylen(MAX_RATIO)
 
         if (grid_m < 1 .or. grid_n < 1) return
+        if (grid_m > MAX_RATIO .or. grid_n > MAX_RATIO) return
 
-        ! Cell size and cell pitch (cell plus gap), in figure fractions.
-        w = (fig_right - fig_left) / &
-            (real(grid_n, dp) + fig_wspace * real(grid_n - 1, dp))
-        h = (fig_top - fig_bottom) / &
-            (real(grid_m, dp) + fig_hspace * real(grid_m - 1, dp))
-        dx = w * (1.0_dp + fig_wspace)
-        dy = h * (1.0_dp + fig_hspace)
+        call grid_edges(grid_n, fig_left, fig_right, fig_wspace, fig_wratio, xpos, xlen)
+        ! Rows are laid out from the top, since that is how they are counted.
+        call grid_edges(grid_m, 1.0_dp - fig_top, 1.0_dp - fig_bottom, fig_hspace, &
+                        fig_hratio, ypos, ylen)
 
         do i = 1, n_ax
             if (ax(i)%fixed_pos .or. ax(i)%inset_of > 0) cycle
@@ -967,11 +1007,10 @@ contains
             if (r >= 1) cycle
             r = ax(i)%g_row          ! row from the top
             c = ax(i)%g_col          ! column from the left
-            ax(i)%left = fig_left + real(c, dp) * dx
-            ax(i)%right = ax(i)%left + w + real(ax(i)%g_colspan - 1, dp) * dx
-            ax(i)%bottom = fig_bottom + &
-                           real(grid_m - r - ax(i)%g_rowspan, dp) * dy
-            ax(i)%top = ax(i)%bottom + h + real(ax(i)%g_rowspan - 1, dp) * dy
+            ax(i)%left = xpos(c + 1)
+            ax(i)%right = xpos(c + ax(i)%g_colspan) + xlen(c + ax(i)%g_colspan)
+            ax(i)%top = 1.0_dp - ypos(r + 1)
+            ax(i)%bottom = 1.0_dp - (ypos(r + ax(i)%g_rowspan) + ylen(r + ax(i)%g_rowspan))
         end do
 
         do i = 1, n_ax
@@ -1373,6 +1412,28 @@ contains
         call layout_grid()
         h%idx = cur_i
     end function add_secondary
+
+    ! GridSpec's width_ratios and height_ratios: the columns and rows of the
+    ! grid need not be equal. Call it before the subplots are made; the
+    ! ratios stay with the figure and the panels are laid out to them.
+    subroutine gridspec(width_ratios, height_ratios)
+        real(dp), intent(in), optional :: width_ratios(:), height_ratios(:)
+        integer :: k
+
+        call ensure_fig()
+        if (present(width_ratios)) then
+            fig_wratio = 1.0_dp
+            do k = 1, min(size(width_ratios), MAX_RATIO)
+                fig_wratio(k) = width_ratios(k)
+            end do
+        end if
+        if (present(height_ratios)) then
+            fig_hratio = 1.0_dp
+            do k = 1, min(size(height_ratios), MAX_RATIO)
+                fig_hratio(k) = height_ratios(k)
+            end do
+        end if
+    end subroutine gridspec
 
     function subplot2grid(shape, loc, rowspan, colspan) result(h)
         integer, intent(in) :: shape(2), loc(2)

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -354,6 +354,8 @@ module fplot
         real(dp), allocatable :: tbl_w(:)
         real(dp) :: tbl_size = 10.0_dp
         character(len=16) :: tbl_loc = "bottom"
+        ! The running top of a stack of histograms, for hist(stacked=.true.).
+        real(dp), allocatable :: hstack(:)
         logical :: xroom_set = .false.
         real(dp) :: xroom(2) = 0.0_dp
         ! Whether that room is a sticky edge, taking no margin beyond it.
@@ -4198,17 +4200,17 @@ contains
 
     ! Histogram of x using `bins` equal-width bins over the data range.
     subroutine hist(x, bins, color, label, alpha, bin_edges, density, &
-                    cumulative, histtype)
+                    cumulative, histtype, weights, stacked)
         real(dp), intent(in) :: x(:)
         integer, intent(in), optional :: bins
         character(len=*), intent(in), optional :: color, label, histtype
-        real(dp), intent(in), optional :: alpha, bin_edges(:)
-        logical, intent(in), optional :: density, cumulative
+        real(dp), intent(in), optional :: alpha, bin_edges(:), weights(:)
+        logical, intent(in), optional :: density, cumulative, stacked
         integer :: nb, i, k, n, is
         real(dp) :: lo, hi, w, tot
         real(dp), allocatable :: edges(:), centers(:), counts(:), widths(:)
-        real(dp), allocatable :: sx(:), sy(:)
-        logical :: norm, cum
+        real(dp), allocatable :: sx(:), sy(:), base(:), sb(:)
+        logical :: norm, cum, stk
         character(len=16) :: ht
 
         n = size(x)
@@ -4217,6 +4219,8 @@ contains
         cum = .false.
         if (present(density)) norm = density
         if (present(cumulative)) cum = cumulative
+        stk = .false.
+        if (present(stacked)) stk = stacked
         ht = "bar"
         if (present(histtype)) ht = histtype
 
@@ -4251,7 +4255,11 @@ contains
         do i = 1, n
             if (x(i) < edges(1) .or. x(i) > edges(nb + 1)) cycle
             k = bin_of(x(i), edges, nb)
-            counts(k) = counts(k) + 1.0_dp
+            if (present(weights)) then
+                counts(k) = counts(k) + weights(min(i, size(weights)))
+            else
+                counts(k) = counts(k) + 1.0_dp
+            end if
         end do
 
         ! density normalises by the total area, so the bars integrate to one
@@ -4267,24 +4275,41 @@ contains
         end if
 
         call ensure_fig()
+        ! A stacked histogram starts where the last one in these axes ended.
+        allocate (base(nb))
+        base = 0.0_dp
+        if (stk) then
+            if (allocated(ax(cur_i)%hstack)) then
+                if (size(ax(cur_i)%hstack) == nb) base = ax(cur_i)%hstack
+                deallocate (ax(cur_i)%hstack)
+            end if
+            allocate (ax(cur_i)%hstack(nb))
+            ax(cur_i)%hstack = base + counts
+        else if (allocated(ax(cur_i)%hstack)) then
+            deallocate (ax(cur_i)%hstack)
+        end if
+
         select case (trim(ht))
         case ("step", "stepfilled")
             ! The outline of the same bars: up at every left edge, across
             ! the top, and back down to the baseline at both ends.
-            allocate (sx(2*nb + 2), sy(2*nb + 2))
+            allocate (sx(2*nb + 2), sy(2*nb + 2), sb(2*nb + 2))
             sx(1) = edges(1)
-            sy(1) = 0.0_dp
+            sy(1) = base(1)
+            sb(1) = base(1)
             do i = 1, nb
                 sx(2*i) = edges(i)
-                sy(2*i) = counts(i)
+                sy(2*i) = base(i) + counts(i)
+                sb(2*i) = base(i)
                 sx(2*i + 1) = edges(i + 1)
-                sy(2*i + 1) = counts(i)
+                sy(2*i + 1) = base(i) + counts(i)
+                sb(2*i + 1) = base(i)
             end do
             sx(2*nb + 2) = edges(nb + 1)
-            sy(2*nb + 2) = 0.0_dp
+            sy(2*nb + 2) = base(nb)
+            sb(2*nb + 2) = base(nb)
             if (trim(ht) == "stepfilled") then
-                call fill_between(sx, sy, spread(0.0_dp, 1, 2*nb + 2), color, &
-                                  label, alpha)
+                call fill_between(sx, sy, sb, color, label, alpha)
             else
                 is = new_shape_series(SERIES_LINE, sx, sy, color, label, alpha)
             end if
@@ -4297,6 +4322,10 @@ contains
                 ax(cur_i)%series(is)%width = widths(1)
                 allocate (ax(cur_i)%series(is)%bwidth(nb))
                 ax(cur_i)%series(is)%bwidth = widths
+                if (stk) then
+                    allocate (ax(cur_i)%series(is)%y2(nb))
+                    ax(cur_i)%series(is)%y2 = base
+                end if
             end if
         end select
     end subroutine hist

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -48,6 +48,15 @@ module fplot
     public :: axes, subplots, sca
     public :: style_use, rc
 
+    ! What one axis agreed to write on its ticks: how many decimals, and
+    ! the offset and power of ten factored out of every label and written
+    ! once at the end of the axis instead.
+    type :: tickfmt_t
+        integer :: dec = 0
+        real(dp) :: off = 0.0_dp
+        integer :: oom = 0
+    end type tickfmt_t
+
     ! Initial slot count for the per-axes series and text arrays; both grow
     ! on demand, so this is only the allocation granularity.
     integer, parameter :: INIT_SLOTS = 8
@@ -1181,7 +1190,8 @@ contains
                         a%ysc, 9, a%y_date, t, nt, du)
         do i = 1, nt
             call tick_label(a%ytick_labeled, a%ytick_lab, i, t(i), a%ysc, &
-                            axis_decimals(t, nt, a%ysc), du, lbl, ln)
+                            axis_fmt(t, nt, a%ysc, min(ymin, ymax), max(ymin, ymax)), &
+                            du, lbl, ln)
             if (math_is(lbl(1:ln))) then
                 v = max(v, math_width(lbl(1:ln), a%ytick_size))
             else
@@ -6657,15 +6667,16 @@ contains
         call append_text(b, x, y, s, anchor, fontsize, rc_text_color, rot)
     end subroutine append_tick_text
 
-    ! dec is the decimal count the whole axis agreed on, or -1 when the
-    ! scale writes its own labels.
-    subroutine tick_label(labeled, lab, i, v, sc, dec, date_unit, out, n)
+    ! f carries what the whole axis agreed on: the decimal count, or -1
+    ! when the scale writes its own labels, and anything factored out.
+    subroutine tick_label(labeled, lab, i, v, sc, f, date_unit, out, n)
         logical, intent(in) :: labeled
         character(len=24), intent(in) :: lab(MAX_TICKS)
         integer, intent(in) :: i
         real(dp), intent(in) :: v
         type(scale_t), intent(in) :: sc
-        integer, intent(in) :: dec, date_unit
+        type(tickfmt_t), intent(in) :: f
+        integer, intent(in) :: date_unit
         character(len=*), intent(out) :: out
         integer, intent(out) :: n
         if (labeled) then
@@ -6676,7 +6687,7 @@ contains
         else if (sc%kind == SCALE_LOG) then
             call format_tick_to(v, .true., out, n)
         else
-            call format_tick_fixed(v, dec, out, n)
+            call format_tick_fixed((v - f%off)/10.0_dp**f%oom, f%dec, out, n)
         end if
     end subroutine tick_label
 
@@ -6693,6 +6704,22 @@ contains
             d = tick_decimals(t, nt)
         end if
     end function axis_decimals
+
+    ! The same for an axis that may factor an offset or a power of ten out
+    ! of its labels. Only a linear axis does; a log or date axis writes its
+    ! own labels and has nothing to factor.
+    function axis_fmt(t, nt, sc, vmin, vmax) result(f)
+        real(dp), intent(in) :: t(MAX_TICKS), vmin, vmax
+        integer, intent(in) :: nt
+        type(scale_t), intent(in) :: sc
+        type(tickfmt_t) :: f
+        if (sc%kind /= SCALE_LINEAR) then
+            f%dec = -1
+            return
+        end if
+        call tick_offset(t, nt, vmin, vmax, f%off, f%oom)
+        f%dec = tick_decimals_at(t, nt, f%off, f%oom)
+    end function axis_fmt
 
     ! A polar axes. The box holds the largest circle that fits: the angle
     ! runs anticlockwise from the right and the radius from the middle out,
@@ -7260,6 +7287,7 @@ contains
         real(dp) :: x_edge, x_out, y_edge, y_out
         character(len=64) :: lbl
         character(len=64) :: tx, ty
+        type(tickfmt_t) :: xfmt, yfmt
         integer :: tn, tyn
         character(len=512) :: esc
         integer :: ln, en
@@ -7323,6 +7351,8 @@ contains
         call axis_ticks(a%n_yticks, a%ytick_pos, min(ymin, ymax), max(ymin, ymax), &
                         ysc, tick_space(ax_h, a%ytick_size, .false.), a%y_date, &
                         yticks, nyt, y_unit)
+        xfmt = axis_fmt(xticks, nxt, xsc, xmin, xmax)
+        yfmt = axis_fmt(yticks, nyt, ysc, min(ymin, ymax), max(ymin, ymax))
         if (a%minor_ticks) then
             call minor_positions(xticks, nxt, xmin, xmax, xsc, xminor, nxm)
             call minor_positions(yticks, nyt, ymin, ymax, ysc, yminor, nym)
@@ -7563,7 +7593,7 @@ contains
             call append_tick_at(b, px, x_edge, 0.0_dp, x_out, a%xtick_dir, a%xtick_len)
             if (.not. a%xticklabels_off) then
                 call tick_label(a%xtick_labeled, a%xtick_lab, i, xticks(i), xsc, &
-                                axis_decimals(xticks, nxt, xsc), x_unit, lbl, ln)
+                                xfmt, x_unit, lbl, ln)
                 call append_tick_text(b, px, x_edge + x_out * xtick_gap(a) - &
                                       merge(6.0_dp, 0.0_dp, a%x_top), lbl(1:ln), "center", &
                                       a%xtick_size, a%xtick_rot)
@@ -7589,7 +7619,7 @@ contains
             call append_tick_at(b, y_edge, py, y_out, 0.0_dp, a%ytick_dir, a%ytick_len)
             if (.not. a%yticklabels_off) then
                 call tick_label(a%ytick_labeled, a%ytick_lab, i, yticks(i), ysc, &
-                                axis_decimals(yticks, nyt, ysc), y_unit, lbl, ln)
+                                yfmt, y_unit, lbl, ln)
                 call append_tick_text(b, y_edge + y_out * 7.0_dp, py + 3.5_dp, lbl(1:ln), &
                                       merge("left ", "right", a%y_right), &
                                       a%ytick_size, a%ytick_rot)
@@ -7600,6 +7630,24 @@ contains
             call append_tick_at(b, y_edge, py, y_out, 0.0_dp, a%ytick_dir, &
                                 MINOR_FRAC * a%ytick_len)
         end do
+
+        ! What the labels left out, written once at the end of the axis:
+        ! matplotlib puts it past the far end of the x axis and above the
+        ! top of the y axis, three points clear of the tick labels.
+        if (nxt > 0 .and. .not. a%xticklabels_off) then
+            call format_offset_text(xfmt%off, xfmt%oom, lbl, ln)
+            if (ln > 0) &
+                call append_text(b, ax_r, ax_b + xtick_gap(a) + 0.24_dp*a%xtick_size &
+                                 + 3.0_dp + 0.76_dp*a%xtick_size, lbl(1:ln), "right", &
+                                 a%xtick_size, rc_text_color)
+        end if
+        if (nyt > 0 .and. .not. a%yticklabels_off) then
+            call format_offset_text(yfmt%off, yfmt%oom, lbl, ln)
+            if (ln > 0) &
+                call append_text(b, y_edge, ax_t - 3.0_dp, lbl(1:ln), &
+                                 merge("right", "left ", a%y_right), &
+                                 a%ytick_size, rc_text_color)
+        end if
 
         if (len_trim(a%xlabel) > 0) then
             call append_text(b, 0.5_dp * (ax_l + ax_r), &

--- a/src/fplot.f90
+++ b/src/fplot.f90
@@ -27,6 +27,7 @@ module fplot
     public :: matshow, eventplot, broken_barh, streamplot, table
     public :: add_axes, secondary_xaxis, secondary_yaxis
     public :: add_rectangle, add_circle, add_ellipse, add_polygon
+    public :: add_arrow, add_path
     public :: polar, set_polar
     public :: quiver
     public :: axhspan, axvspan, hlines, vlines, bar_label
@@ -186,6 +187,9 @@ module fplot
         ! only when edgecolor names one, as in matplotlib, where a patch is
         ! filled and edgeless unless asked otherwise.
         logical :: patch_fill = .true.
+        ! A patch drawn from an arbitrary path carries its own verbs; a
+        ! plain polygon leaves this alone and every point is a line to.
+        integer, allocatable :: pverb(:)
         ! Most patches never ask for room of their own; the ones a plotting
         ! call makes for itself, such as broken_barh, do.
         logical :: patch_scales = .false.
@@ -3837,6 +3841,82 @@ contains
         if (present(fill)) ax(cur_i)%series(is)%patch_fill = fill
     end subroutine add_polygon
 
+    ! matplotlib's Arrow patch: the same unit outline it uses, scaled to the
+    ! length of (dx, dy) and to `width` across, then turned to point along
+    ! the vector. It is built in data coordinates, as matplotlib builds it,
+    ! so an axes that is not square shears the arrow in the same way.
+    subroutine add_arrow(x, y, dx, dy, width, facecolor, edgecolor, lw, alpha, fill)
+        real(dp), intent(in) :: x, y, dx, dy
+        real(dp), intent(in), optional :: width, lw, alpha
+        character(len=*), intent(in), optional :: facecolor, edgecolor
+        logical, intent(in), optional :: fill
+        real(dp), parameter :: UX(7) = [0.0_dp, 0.0_dp, 0.8_dp, 0.8_dp, &
+                                        1.0_dp, 0.8_dp, 0.8_dp]
+        real(dp), parameter :: UY(7) = [0.1_dp, -0.1_dp, -0.1_dp, -0.3_dp, &
+                                        0.0_dp, 0.3_dp, 0.1_dp]
+        real(dp) :: w, ln, ct, st, ax_(7), ay(7), u, v
+        integer :: j
+
+        w = 1.0_dp
+        if (present(width)) w = width
+        ln = hypot(dx, dy)
+        if (ln <= 0.0_dp) return
+        ct = dx/ln
+        st = dy/ln
+        do j = 1, 7
+            u = UX(j)*ln
+            v = UY(j)*w
+            ax_(j) = x + ct*u - st*v
+            ay(j) = y + st*u + ct*v
+        end do
+        call add_polygon(ax_, ay, facecolor, edgecolor, lw, alpha, fill)
+    end subroutine add_arrow
+
+    ! An arbitrary path, as matplotlib's PathPatch draws one. `codes` has a
+    ! letter per verb: M moves, L draws a line, C draws a cubic from the
+    ! next three points and Z closes back to the last move.
+    subroutine add_path(x, y, codes, facecolor, edgecolor, lw, alpha, fill)
+        real(dp), intent(in) :: x(:), y(:)
+        character(len=*), intent(in) :: codes
+        real(dp), intent(in), optional :: lw, alpha
+        character(len=*), intent(in), optional :: facecolor, edgecolor
+        logical, intent(in), optional :: fill
+        integer :: is, j, np, nv
+        integer :: v(len_trim(codes))
+
+        nv = len_trim(codes)
+        np = 0
+        do j = 1, nv
+            select case (codes(j:j))
+            case ("M", "m")
+                v(j) = VERB_MOVE
+                np = np + 1
+            case ("L", "l")
+                v(j) = VERB_LINE
+                np = np + 1
+            case ("C", "c")
+                v(j) = VERB_CUBIC
+                np = np + 3
+            case ("Z", "z")
+                v(j) = VERB_CLOSE
+            case default
+                print *, "fplot: add_path: unknown code ", codes(j:j)
+                error stop
+            end select
+        end do
+        if (np < 2 .or. np > min(size(x), size(y))) then
+            print *, "fplot: add_path: codes need", np, "points, given", &
+                min(size(x), size(y))
+            error stop
+        end if
+
+        call add_polygon(x(1:np), y(1:np), facecolor, edgecolor, lw, alpha, fill)
+        is = ax(cur_i)%n_series
+        if (is < 1) return
+        allocate (ax(cur_i)%series(is)%pverb(nv))
+        ax(cur_i)%series(is)%pverb = v
+    end subroutine add_path
+
     ! A field of arrows, one per point, pointing along (u, v). Left to
     ! itself matplotlib sizes the arrows from the field: the shaft is a
     ! fixed fraction of the axes width and the scale is set so a vector of
@@ -5651,7 +5731,24 @@ contains
         real(dp), intent(in) :: xmin, xmax, ymin, ymax, ax_l, ax_w, ax_b, ax_h
         type(scale_t), intent(in) :: xsc, ysc
         real(dp) :: px(s%n + 1), py(s%n + 1)
+        type(paint_t) :: p
         integer :: j
+
+        if (allocated(s%pverb)) then
+            do j = 1, s%n
+                px(j) = map_x(s%x(j), xmin, xmax, ax_l, ax_w, xsc)
+                py(j) = map_y(s%y(j), ymin, ymax, ax_b, ax_h, ysc)
+            end do
+            if (s%patch_fill) then
+                p = brush(trim(s%color), s%alpha)
+                call b%draw_path(px(1:s%n), py(1:s%n), s%pverb, size(s%pverb), p)
+            end if
+            if (len_trim(s%edgecolor) > 0) then
+                p = pen(trim(s%edgecolor), s%edgewidth, s%alpha)
+                call b%draw_path(px(1:s%n), py(1:s%n), s%pverb, size(s%pverb), p)
+            end if
+            return
+        end if
 
         if (s%n < 3) return
         do j = 1, s%n

--- a/src/fplot_cmap.f90
+++ b/src/fplot_cmap.f90
@@ -9,7 +9,7 @@ module fplot_cmap
     private
 
     public :: CMAP_VIRIDIS, CMAP_PLASMA, CMAP_INFERNO, CMAP_MAGMA
-    public :: CMAP_GRAY, CMAP_COOLWARM, CMAP_REVERSED
+    public :: CMAP_GRAY, CMAP_COOLWARM, CMAP_REVERSED, CMAP_QUAL
     public :: cmap_from_str, cmap_color, cmap_rgb, cmap_name
 
     integer, parameter, public :: CMAP_N_ANCHOR = 65
@@ -18,6 +18,9 @@ module fplot_cmap
     ! A reversed map ("viridis_r") is the same table read backwards, so it
     ! is the same id with this flag added rather than a table of its own.
     integer, parameter :: CMAP_REVERSED = 1000
+
+    ! Ids at or above this are qualitative maps, held in QDATA below.
+    integer, parameter :: CMAP_QUAL = 500
 
     integer, parameter :: CMAP_VIRIDIS = 0
     integer, parameter :: CMAP_PLASMA = 1
@@ -876,10 +879,36 @@ module fplot_cmap
          239,  173,    0,  241,  182,    0,  243,  192,    0,  245,  202,    0, &
          247,  213,    0,  249,  223,    0,  251,  235,    0,  253,  246,    0, &
          255,  255,    0]
+    ! ------------------------------------------------------------------
+    ! Qualitative maps. These are lists of colors, not a ramp: matplotlib
+    ! picks the entry at int(t*N) and never blends two of them, so they
+    ! live in a table of their own rather than among the 65-anchor ramps.
+    ! ------------------------------------------------------------------
+    integer, parameter :: CMAP_QUAL_COUNT = 3
+    character(len=13), parameter :: QNAMES(CMAP_QUAL_COUNT) = [ &
+        "tab10        ", &
+        "tab20        ", &
+        "Set1         "]
+    integer, parameter :: QSIZE(CMAP_QUAL_COUNT) = [10, 20, 9]
+    ! Where each map starts in QDATA, in colors.
+    integer, parameter :: QOFF(CMAP_QUAL_COUNT) = [0, 10, 30]
+    integer, parameter :: QDATA(3 * 39) = [ &
+          31,  119,  180,  255,  127,   14,   44,  160,   44,  214,   39,   40, &
+         148,  103,  189,  140,   86,   75,  227,  119,  194,  127,  127,  127, &
+         188,  189,   34,   23,  190,  207,   31,  119,  180,  174,  199,  232, &
+         255,  127,   14,  255,  187,  120,   44,  160,   44,  152,  223,  138, &
+         214,   39,   40,  255,  152,  150,  148,  103,  189,  197,  176,  213, &
+         140,   86,   75,  196,  156,  148,  227,  119,  194,  247,  182,  210, &
+         127,  127,  127,  199,  199,  199,  188,  189,   34,  219,  219,  141, &
+          23,  190,  207,  158,  218,  229,  228,   26,   28,   55,  126,  184, &
+          77,  175,   74,  152,   78,  163,  255,  127,    0,  255,  255,   51, &
+         166,   86,   40,  247,  129,  191,  153,  153,  153]
+
 contains
 
     ! matplotlib's name, with a "_r" suffix meaning the map read backwards.
     ! An unknown name falls back to viridis, matplotlib's default.
+
     pure function cmap_from_str(name) result(id)
         character(len=*), intent(in) :: name
         integer :: id, i, n
@@ -897,6 +926,15 @@ contains
         end if
 
         id = CMAP_VIRIDIS
+        do i = 1, CMAP_QUAL_COUNT
+            if (len_trim(QNAMES(i)) == n) then
+                if (c(1:n) == QNAMES(i)(1:n)) then
+                    id = CMAP_QUAL + i - 1
+                    if (rev) id = id + CMAP_REVERSED
+                    return
+                end if
+            end if
+        end do
         do i = 1, CMAP_COUNT
             if (len_trim(NAMES(i)) == n) then
                 if (c(1:n) == NAMES(i)(1:n)) then
@@ -913,7 +951,11 @@ contains
     pure function cmap_name(id) result(s)
         integer, intent(in) :: id
         character(len=32) :: s
-        s = NAMES(modulo(id, CMAP_REVERSED) + 1)
+        if (modulo(id, CMAP_REVERSED) >= CMAP_QUAL) then
+            s = QNAMES(modulo(id, CMAP_REVERSED) - CMAP_QUAL + 1)
+        else
+            s = NAMES(modulo(id, CMAP_REVERSED) + 1)
+        end if
         if (id >= CMAP_REVERSED) s = trim(s) // "_r"
     end function cmap_name
 
@@ -923,7 +965,7 @@ contains
         real(dp), intent(in) :: t
         integer, intent(out) :: r, g, b
         real(dp) :: u, f
-        integer :: i0, i1, m, base
+        integer :: i0, i1, m, base, nq, k
 
         m = id
         u = t
@@ -932,6 +974,23 @@ contains
         if (m >= CMAP_REVERSED) then
             m = m - CMAP_REVERSED
             u = 1.0_dp - u
+        end if
+        if (m >= CMAP_QUAL) then
+            ! A list of colors: matplotlib takes the int(t*N)th entry whole.
+            k = m - CMAP_QUAL
+            if (k < 0 .or. k >= CMAP_QUAL_COUNT) k = 0
+            nq = QSIZE(k + 1)
+            ! Reversing a list reverses the entries, which is not the same
+            ! as indexing with 1-t at the boundary between two of them.
+            if (id >= CMAP_REVERSED) u = 1.0_dp - u
+            i0 = int(max(0.0_dp, min(1.0_dp, u)) * real(nq, dp))
+            i0 = max(0, min(nq - 1, i0))
+            if (id >= CMAP_REVERSED) i0 = nq - 1 - i0
+            base = 3 * (QOFF(k + 1) + i0)
+            r = QDATA(base + 1)
+            g = QDATA(base + 2)
+            b = QDATA(base + 3)
+            return
         end if
         if (m < 0 .or. m >= CMAP_COUNT) m = CMAP_VIRIDIS
         base = 3 * CMAP_N_ANCHOR * m

--- a/src/fplot_ticks.f90
+++ b/src/fplot_ticks.f90
@@ -13,6 +13,7 @@ module fplot_ticks
     public :: format_tick_to
     public :: tick_decimals
     public :: format_tick_fixed
+    public :: tick_offset, tick_decimals_at, format_offset_text
 
 contains
 
@@ -424,5 +425,152 @@ contains
             n = n - 1
         end if
     end subroutine format_tick_fixed
+
+
+    ! ------------------------------------------------------------------
+    ! An axis whose numbers are large, small, or nearly equal is unreadable
+    ! if every tick spells itself out. matplotlib factors out two things and
+    ! writes them once at the end of the axis: an offset, when every tick
+    ! shares its leading digits, and a power of ten, when the numbers are
+    ! far enough from one. What is left on each tick is the difference.
+    ! ------------------------------------------------------------------
+
+    ! floor(v / 10**k), which is what Python's // does for the positive
+    ! values this is asked about.
+    pure function decade_floor(v, k) result(r)
+        real(dp), intent(in) :: v
+        integer, intent(in) :: k
+        real(dp) :: r
+        r = floor(v/10.0_dp**k)
+    end function decade_floor
+
+    pure subroutine tick_offset(locs, n, vmin, vmax, off, oom)
+        real(dp), intent(in) :: locs(:), vmin, vmax
+        integer, intent(in) :: n
+        real(dp), intent(out) :: off
+        integer, intent(out) :: oom
+        ! rcParams axes.formatter.offset_threshold and .limits.
+        integer, parameter :: THRESHOLD = 4, PLO = -5, PHI = 6
+        real(dp) :: lmin, lmax, amin, amax, sgn, span
+        integer :: k, kmax
+
+        off = 0.0_dp
+        oom = 0
+        if (n < 1) return
+        lmin = minval(locs(1:n))
+        lmax = maxval(locs(1:n))
+
+        ! An offset is only worth it when the ticks all have the same sign,
+        ! and only when it saves at least four digits.
+        if (lmin /= lmax .and. .not. (lmin <= 0.0_dp .and. lmax >= 0.0_dp)) then
+            amin = min(abs(lmin), abs(lmax))
+            amax = max(abs(lmin), abs(lmax))
+            sgn = sign(1.0_dp, lmin)
+            kmax = ceiling(log10(amax))
+            ! The smallest power of ten at which the two ends still agree.
+            k = kmax
+            do while (k > kmax - 32)
+                if (decade_floor(amin, k) /= decade_floor(amax, k)) exit
+                k = k - 1
+            end do
+            k = k + 1
+            if ((amax - amin)/10.0_dp**k <= 1.0e-2_dp) then
+                ! The ticks straddle a multiple of a large power of ten, so
+                ! the digits they agree on are not the ones just counted.
+                k = kmax
+                do while (k > kmax - 32)
+                    if (decade_floor(amax, k) - decade_floor(amin, k) > 1.0_dp) exit
+                    k = k - 1
+                end do
+                k = k + 1
+            end if
+            if (decade_floor(amax, k) >= 10.0_dp**(THRESHOLD - 1)) &
+                off = sgn*decade_floor(amax, k)*10.0_dp**k
+        end if
+
+        ! The power of ten is measured on what is left once the offset is
+        ! taken away, which is the span of the axis rather than its values.
+        if (off /= 0.0_dp) then
+            span = abs(vmax - vmin)
+            if (span > 0.0_dp) oom = floor(log10(span))
+        else
+            amax = maxval(abs(locs(1:n)))
+            if (amax > 0.0_dp) oom = floor(log10(amax))
+        end if
+        if (oom > PLO .and. oom < PHI) oom = 0
+    end subroutine tick_offset
+
+    ! The decimals the labels need once the offset and the power of ten
+    ! have been taken out of them.
+    pure function tick_decimals_at(locs, n, off, oom) result(d)
+        real(dp), intent(in) :: locs(:), off
+        integer, intent(in) :: n, oom
+        integer :: d
+        real(dp) :: s(MAX_TICKS)
+        integer :: m
+
+        m = min(n, MAX_TICKS)
+        if (m < 1) then
+            d = 0
+            return
+        end if
+        s(1:m) = (locs(1:m) - off)/10.0_dp**oom
+        d = tick_decimals(s, m)
+    end function tick_decimals_at
+
+    ! One value as a significand and an exponent, the shortest way round:
+    ! 100000 is "1e5" and 250000 is "2.5e5".
+    pure subroutine format_significand(v, s, n)
+        real(dp), intent(in) :: v
+        character(len=*), intent(out) :: s
+        integer, intent(out) :: n
+        character(len=32) :: tmp, ex
+        real(dp) :: m
+        integer :: e
+
+        e = floor(log10(abs(v)))
+        m = anint(v/10.0_dp**e*1.0e6_dp)/1.0e6_dp
+        if (m == anint(m)) then
+            write (tmp, "(I0)") nint(m)
+        else
+            write (tmp, "(F0.6)") m
+            n = len_trim(tmp)
+            do while (n > 1 .and. tmp(n:n) == "0")
+                n = n - 1
+            end do
+            if (tmp(n:n) == ".") n = n - 1
+            tmp = tmp(1:n)
+        end if
+        if (e == 0) then
+            s = trim(tmp)
+        else
+            write (ex, "(I0)") e
+            s = trim(tmp)//"e"//trim(ex)
+        end if
+        n = len_trim(s)
+    end subroutine format_significand
+
+    ! What is written at the end of the axis: the power of ten, then the
+    ! offset with its sign, either of which may be absent.
+    pure subroutine format_offset_text(off, oom, s, n)
+        real(dp), intent(in) :: off
+        integer, intent(in) :: oom
+        character(len=*), intent(out) :: s
+        integer, intent(out) :: n
+        character(len=32) :: tmp, sig
+        integer :: m
+
+        s = ""
+        n = 0
+        if (oom /= 0) then
+            write (tmp, "(A,I0)") "1e", oom
+            s = trim(tmp)
+        end if
+        if (off /= 0.0_dp) then
+            call format_significand(abs(off), sig, m)
+            s = trim(s)//merge("+", "-", off > 0.0_dp)//sig(1:m)
+        end if
+        n = len_trim(s)
+    end subroutine format_offset_text
 
 end module fplot_ticks

--- a/src/fplot_ticks.f90
+++ b/src/fplot_ticks.f90
@@ -14,6 +14,7 @@ module fplot_ticks
     public :: tick_decimals
     public :: format_tick_fixed
     public :: tick_offset, tick_decimals_at, format_offset_text
+    public :: multiple_ticks, format_percent, format_grouped
 
 contains
 
@@ -444,25 +445,37 @@ contains
         r = floor(v/10.0_dp**k)
     end function decade_floor
 
-    pure subroutine tick_offset(locs, n, vmin, vmax, off, oom)
+    ! use_off and the power limits are what ticklabel_format sets; their
+    ! defaults are the rcParams ones, axes.formatter.useoffset and .limits.
+    pure subroutine tick_offset(locs, n, vmin, vmax, off, oom, use_off, plo, phi)
         real(dp), intent(in) :: locs(:), vmin, vmax
         integer, intent(in) :: n
         real(dp), intent(out) :: off
         integer, intent(out) :: oom
-        ! rcParams axes.formatter.offset_threshold and .limits.
-        integer, parameter :: THRESHOLD = 4, PLO = -5, PHI = 6
+        logical, intent(in), optional :: use_off
+        integer, intent(in), optional :: plo, phi
+        ! rcParams axes.formatter.offset_threshold.
+        integer, parameter :: THRESHOLD = 4
         real(dp) :: lmin, lmax, amin, amax, sgn, span
-        integer :: k, kmax
+        integer :: k, kmax, lo_lim, hi_lim
+        logical :: want_off
 
         off = 0.0_dp
         oom = 0
+        want_off = .true.
+        if (present(use_off)) want_off = use_off
+        lo_lim = -5
+        hi_lim = 6
+        if (present(plo)) lo_lim = plo
+        if (present(phi)) hi_lim = phi
         if (n < 1) return
         lmin = minval(locs(1:n))
         lmax = maxval(locs(1:n))
 
         ! An offset is only worth it when the ticks all have the same sign,
         ! and only when it saves at least four digits.
-        if (lmin /= lmax .and. .not. (lmin <= 0.0_dp .and. lmax >= 0.0_dp)) then
+        if (want_off .and. lmin /= lmax .and. &
+            .not. (lmin <= 0.0_dp .and. lmax >= 0.0_dp)) then
             amin = min(abs(lmin), abs(lmax))
             amax = max(abs(lmin), abs(lmax))
             sgn = sign(1.0_dp, lmin)
@@ -497,7 +510,7 @@ contains
             amax = maxval(abs(locs(1:n)))
             if (amax > 0.0_dp) oom = floor(log10(amax))
         end if
-        if (oom > PLO .and. oom < PHI) oom = 0
+        if (oom > lo_lim .and. oom < hi_lim) oom = 0
     end subroutine tick_offset
 
     ! The decimals the labels need once the offset and the power of ten
@@ -572,5 +585,81 @@ contains
         end if
         n = len_trim(s)
     end subroutine format_offset_text
+
+
+    ! Ticks every base units, which is matplotlib's MultipleLocator.
+    pure subroutine multiple_ticks(vmin, vmax, base, t, n)
+        real(dp), intent(in) :: vmin, vmax, base
+        real(dp), intent(out) :: t(MAX_TICKS)
+        integer, intent(out) :: n
+        integer :: k, k0, k1
+
+        n = 0
+        if (base <= 0.0_dp) return
+        k0 = ceiling(min(vmin, vmax)/base - 1.0e-9_dp)
+        k1 = floor(max(vmin, vmax)/base + 1.0e-9_dp)
+        do k = k0, k1
+            if (n >= MAX_TICKS) exit
+            n = n + 1
+            t(n) = real(k, dp)*base
+        end do
+    end subroutine multiple_ticks
+
+    ! A percentage, as matplotlib's PercentFormatter writes it: the value
+    ! is a fraction of whole, and whole is 100 when the data already is a
+    ! percentage.
+    pure subroutine format_percent(v, whole, dec, s, n)
+        real(dp), intent(in) :: v, whole
+        integer, intent(in) :: dec
+        character(len=*), intent(out) :: s
+        integer, intent(out) :: n
+        character(len=32) :: tmp
+        character(len=16) :: fmt
+
+        if (dec <= 0) then
+            write (tmp, "(I0)") nint(v/whole*100.0_dp)
+        else
+            write (fmt, "(A,I0,A)") "(F24.", dec, ")"
+            write (tmp, fmt) v/whole*100.0_dp
+        end if
+        s = trim(adjustl(tmp))//"%"
+        n = len_trim(s)
+    end subroutine format_percent
+
+    ! The integer part in groups of three, which is what a reader wants of
+    ! an axis counting people or dollars.
+    pure subroutine format_grouped(v, dec, s, n)
+        real(dp), intent(in) :: v
+        integer, intent(in) :: dec
+        character(len=*), intent(out) :: s
+        integer, intent(out) :: n
+        character(len=48) :: tmp, out
+        character(len=16) :: fmt
+        integer :: i, k, dot, first, d
+
+        d = max(0, dec)
+        if (d == 0) then
+            write (tmp, "(I0)") nint(abs(v))
+        else
+            write (fmt, "(A,I0,A)") "(F32.", d, ")"
+            write (tmp, fmt) abs(v)
+        end if
+        tmp = adjustl(tmp)
+        dot = index(tmp, ".")
+        if (dot == 0) dot = len_trim(tmp) + 1
+
+        out = ""
+        k = 0
+        first = dot - 1
+        do i = first, 1, -1
+            out = tmp(i:i)//trim(out)
+            k = k + 1
+            if (mod(k, 3) == 0 .and. i > 1) out = ","//trim(out)
+        end do
+        if (dot <= len_trim(tmp)) out = trim(out)//tmp(dot:len_trim(tmp))
+        if (v < 0.0_dp) out = "-"//trim(out)
+        s = trim(out)
+        n = len_trim(s)
+    end subroutine format_grouped
 
 end module fplot_ticks

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -10,7 +10,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from matplotlib.colors import LogNorm
+from matplotlib.colors import LogNorm, BoundaryNorm
 import matplotlib.dates as mdates
 from matplotlib.patches import Rectangle, Circle, Ellipse, Polygon
 import datetime
@@ -75,6 +75,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "cmap_discrete",
     "hist_stacked",
     "grid_ratios",
     "formatters",
@@ -850,6 +851,18 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 81 bands of a discrete norm, and the qualitative maps
+    fig = plt.figure(figsize=(6.4, 4.8))
+    a1 = fig.add_subplot(1, 2, 1)
+    bn = BoundaryNorm([-2.0, -1.0, 0.0, 1.0, 2.0], 256)
+    im = a1.imshow(zimg, cmap="viridis", norm=bn)
+    fig.colorbar(im, ax=a1)
+    a1.set_title("bands")
+    a2 = fig.add_subplot(1, 2, 2)
+    a2.imshow(zimg, cmap="tab20")
+    a2.set_title("tab20")
+    save(fig, "cmap_discrete")
 
     # 80 a stacked histogram, and one whose samples carry weights
     fig = plt.figure(figsize=(6.4, 4.8))

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -9,6 +9,7 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
 from matplotlib.colors import LogNorm
 import matplotlib.dates as mdates
 from matplotlib.patches import Rectangle, Circle, Ellipse, Polygon
@@ -74,6 +75,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "formatters",
     "offset_text",
     "surface3d",
     "line3d",
@@ -844,6 +846,15 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 78 named formatters and a locator
+    fig, ax = setup_fig()
+    ax.plot(1000 * np.arange(len(x)), 50 + 40 * y)
+    ax.yaxis.set_major_formatter(mticker.PercentFormatter())
+    ax.xaxis.set_major_formatter(mticker.StrMethodFormatter("{x:,.0f}"))
+    ax.yaxis.set_major_locator(mticker.MultipleLocator(25))
+    ax.set_title("formatters")
+    save(fig, "formatters")
 
     # 77 a large y axis and an offset x axis
     fig, ax = setup_fig()

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -74,6 +74,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "offset_text",
     "surface3d",
     "line3d",
     "scatter_cmap",
@@ -843,6 +844,12 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 77 a large y axis and an offset x axis
+    fig, ax = setup_fig()
+    ax.plot(1e5 + np.linspace(0, 3, len(x)), 2e6 * y)
+    ax.set_title("offset text")
+    save(fig, "offset_text")
 
     # 75 a 3D surface
     fig = plt.figure(figsize=(6.4, 4.8))

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -75,6 +75,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "grid_ratios",
     "formatters",
     "offset_text",
     "surface3d",
@@ -846,6 +847,15 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 79 a grid whose columns and rows are not equal
+    fig = plt.figure(figsize=(6.4, 4.8))
+    gs = fig.add_gridspec(2, 2, width_ratios=[2, 1], height_ratios=[1, 2])
+    a1 = fig.add_subplot(gs[0, 0]); a1.plot(x, y, "b-"); a1.set_title("wide")
+    a2 = fig.add_subplot(gs[0, 1]); a2.plot(x, y2, "r-"); a2.set_title("narrow")
+    a3 = fig.add_subplot(gs[1, 0]); a3.plot(x, y2, "g-")
+    a4 = fig.add_subplot(gs[1, 1]); a4.plot(x, y, "k-")
+    save(fig, "grid_ratios")
 
     # 78 named formatters and a locator
     fig, ax = setup_fig()

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -12,7 +12,8 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 from matplotlib.colors import LogNorm, BoundaryNorm
 import matplotlib.dates as mdates
-from matplotlib.patches import Rectangle, Circle, Ellipse, Polygon
+from matplotlib.patches import Rectangle, Circle, Ellipse, Polygon, Arrow, PathPatch
+from matplotlib.path import Path as MPath
 import datetime
 import io
 
@@ -75,6 +76,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "patches_path",
     "cmap_discrete",
     "hist_stacked",
     "grid_ratios",
@@ -851,6 +853,18 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 82 an arrow patch and a path of cubic curves
+    fig, ax = setup_fig()
+    ax.set_xlim(0.0, 1.0)
+    ax.set_ylim(0.0, 1.2)
+    ax.add_patch(Arrow(0.1, 0.1, 0.6, 0.4, width=0.2,
+                       facecolor="tab:blue", edgecolor="k"))
+    pp = MPath([(0.1, 0.8), (0.3, 1.1), (0.6, 0.5), (0.9, 0.8)],
+               [MPath.MOVETO, MPath.CURVE4, MPath.CURVE4, MPath.CURVE4])
+    ax.add_patch(PathPatch(pp, facecolor="tab:orange", edgecolor="k", lw=2.0))
+    ax.set_title("an arrow and a path")
+    save(fig, "patches_path")
 
     # 81 bands of a discrete norm, and the qualitative maps
     fig = plt.figure(figsize=(6.4, 4.8))

--- a/tests/gen_mpl_refs.py
+++ b/tests/gen_mpl_refs.py
@@ -75,6 +75,7 @@ OUT_NAMES = [
     "broken_barh",
     "streamplot",
     "table",
+    "hist_stacked",
     "grid_ratios",
     "formatters",
     "offset_text",
@@ -474,6 +475,8 @@ def main() -> None:
     k = np.arange(1, 41, dtype=float)
     dist1 = np.sin(k) + 0.3 * np.cos(2.7 * k)
     dist2 = 1.0 + 2.0 * np.sin(0.7 * k) ** 3
+    wts = 0.5 + 0.02 * k
+    hedges = [-3.0, -1.0, 0.0, 1.5, 3.0]
 
     fig, ax = setup_fig()
     ax.boxplot([dist1, dist2])
@@ -847,6 +850,17 @@ def main() -> None:
     ax.set_yticks([])
     ax.set_title("table")
     save(fig, "table")
+
+    # 80 a stacked histogram, and one whose samples carry weights
+    fig = plt.figure(figsize=(6.4, 4.8))
+    a1 = fig.add_subplot(1, 2, 1)
+    a1.hist([dist1, dist2], bins=hedges, stacked=True, label=["one", "two"])
+    a1.legend()
+    a1.set_title("stacked")
+    a2 = fig.add_subplot(1, 2, 2)
+    a2.hist(dist1, bins=hedges, weights=wts, color="tab:purple")
+    a2.set_title("weighted")
+    save(fig, "hist_stacked")
 
     # 79 a grid whose columns and rows are not equal
     fig = plt.figure(figsize=(6.4, 4.8))

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -846,6 +846,18 @@ program test_plots
     call title("table")
     call save_all("table")
 
+! 81) bands of a discrete norm, and the qualitative maps
+    call clf()
+    call subplot(1, 2, 1)
+    call imshow(zimg, cmap="viridis", &
+                boundaries=[-2.0_dp, -1.0_dp, 0.0_dp, 1.0_dp, 2.0_dp])
+    call colorbar()
+    call title("bands")
+    call subplot(1, 2, 2)
+    call imshow(zimg, cmap="tab20")
+    call title("tab20")
+    call save_all("cmap_discrete")
+
 ! 80) a stacked histogram, and one whose samples carry weights
     call clf()
     call subplot(1, 2, 1)

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -40,6 +40,7 @@ program test_plots
     real(dp), parameter :: PI_T = 3.14159265358979323846_dp
     real(dp) :: s3x(n3), s3y(n3), s3z(n3, n3)
     real(dp) :: t3(nl3), l3x(nl3), l3y(nl3), l3z(nl3)
+    real(dp) :: big(n), bigy(n)
     character(len=8), parameter :: fruit(4) = &
         ["apple ", "banana", "cherry", "date  "]
     real(dp), parameter :: hedges(5) = [-3.0_dp, -1.0_dp, 0.0_dp, 1.5_dp, 3.0_dp]
@@ -842,6 +843,17 @@ program test_plots
     call yticks([real(dp) ::])
     call title("table")
     call save_all("table")
+
+! 77) a large y axis and an offset x axis: what the tick labels leave out
+!     is written once at the end of each axis
+    call clf()
+    do i = 1, n
+        big(i) = 1.0e5_dp + real(i - 1, dp)*3.0_dp/real(n - 1, dp)
+        bigy(i) = 2.0e6_dp*y(i)
+    end do
+    call plot(big, bigy)
+    call title("offset text")
+    call save_all("offset_text")
 
 ! 75) a 3D surface
     call clf()

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -846,6 +846,18 @@ program test_plots
     call title("table")
     call save_all("table")
 
+! 82) an arrow patch and a path of cubic curves
+    call clf()
+    call xlim(0.0_dp, 1.0_dp)
+    call ylim(0.0_dp, 1.2_dp)
+    call add_arrow(0.1_dp, 0.1_dp, 0.6_dp, 0.4_dp, width=0.2_dp, &
+                   facecolor="tab:blue", edgecolor="k")
+    call add_path([0.1_dp, 0.3_dp, 0.6_dp, 0.9_dp], &
+                  [0.8_dp, 1.1_dp, 0.5_dp, 0.8_dp], "MC", &
+                  facecolor="tab:orange", edgecolor="k", lw=2.0_dp)
+    call title("an arrow and a path")
+    call save_all("patches_path")
+
 ! 81) bands of a discrete norm, and the qualitative maps
     call clf()
     call subplot(1, 2, 1)

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -844,6 +844,21 @@ program test_plots
     call title("table")
     call save_all("table")
 
+! 79) a grid whose columns and rows are not equal
+    call clf()
+    call gridspec(width_ratios=[2.0_dp, 1.0_dp], height_ratios=[1.0_dp, 2.0_dp])
+    call subplot(2, 2, 1)
+    call plot(x, y, "b-")
+    call title("wide")
+    call subplot(2, 2, 2)
+    call plot(x, y2, "r-")
+    call title("narrow")
+    call subplot(2, 2, 3)
+    call plot(x, y2, "g-")
+    call subplot(2, 2, 4)
+    call plot(x, y, "k-")
+    call save_all("grid_ratios")
+
 ! 78) named formatters and a locator: a percentage on y, thousands on x,
 !     and ticks every 250 units
     call clf()

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -44,6 +44,7 @@ program test_plots
     character(len=8), parameter :: fruit(4) = &
         ["apple ", "banana", "cherry", "date  "]
     real(dp), parameter :: hedges(5) = [-3.0_dp, -1.0_dp, 0.0_dp, 1.5_dp, 3.0_dp]
+    real(dp) :: wts(nd)
     integer, parameter :: nzr = 8, nzc = 16
     real(dp) :: zimg(nzr, nzc), zlog(nzr, nzc)
     real(dp), parameter :: xedge(nzc + 1) = [ &
@@ -426,6 +427,7 @@ program test_plots
     do i = 1, nd
         dist1(i) = sin(real(i, dp)) + 0.3_dp * cos(2.7_dp * real(i, dp))
         dist2(i) = 1.0_dp + 2.0_dp * sin(0.7_dp * real(i, dp))**3
+        wts(i) = 0.5_dp + 0.02_dp * real(i, dp)
     end do
 
     ! 31) boxplot
@@ -843,6 +845,18 @@ program test_plots
     call yticks([real(dp) ::])
     call title("table")
     call save_all("table")
+
+! 80) a stacked histogram, and one whose samples carry weights
+    call clf()
+    call subplot(1, 2, 1)
+    call hist(dist1, bin_edges=hedges, stacked=.true., label="one")
+    call hist(dist2, bin_edges=hedges, stacked=.true., label="two")
+    call legend()
+    call title("stacked")
+    call subplot(1, 2, 2)
+    call hist(dist1, bin_edges=hedges, weights=wts, color="tab:purple")
+    call title("weighted")
+    call save_all("hist_stacked")
 
 ! 79) a grid whose columns and rows are not equal
     call clf()

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -844,6 +844,20 @@ program test_plots
     call title("table")
     call save_all("table")
 
+! 78) named formatters and a locator: a percentage on y, thousands on x,
+!     and ticks every 250 units
+    call clf()
+    do i = 1, n
+        big(i) = 1000.0_dp*real(i - 1, dp)
+        bigy(i) = 50.0_dp + 40.0_dp*y(i)
+    end do
+    call plot(big, bigy)
+    call tick_format("y", "percent")
+    call tick_format("x", "comma")
+    call tick_locator("y", base=25.0_dp)
+    call title("formatters")
+    call save_all("formatters")
+
 ! 77) a large y axis and an offset x axis: what the tick labels leave out
 !     is written once at the end of each axis
     call clf()


### PR DESCRIPTION
The audit of `main` against the roadmap left five things undone. This
finishes all of them, one commit each, plus two README corrections.

- **Offset text.** matplotlib writes the part every tick label shares
  once, at the end of the axis: `1e6` for a common exponent, `+1.5e5`
  for a common offset. `ScalarFormatter`'s rules are reproduced, so the
  labels leave out exactly what matplotlib leaves out.
- **Formatters and locators.** `tick_format` picks a percentage or a
  thousands-separated formatter, `tick_locator` puts a tick at every
  multiple of a number, and `ticklabel_format` turns scientific
  notation on or off.
- **Grid ratios.** `gridspec(width_ratios=, height_ratios=)`, so a wide
  panel can sit beside a narrow one. The cell space is divided in
  proportion and the separators are left alone, which is what
  matplotlib's `get_grid_positions` does.
- **Histograms.** `weights=` counts each sample as much as its weight,
  and `stacked=.true.` starts the bars where the last stacked histogram
  in the same axes ended.
- **Colors.** The qualitative maps `tab10`, `tab20` and `Set1`, which
  are lists of colors rather than ramps and so get a table of their own;
  and `imshow(boundaries=)`, matplotlib's `BoundaryNorm`, with a
  colorbar of blocks and a tick at every band edge.
- **Patches.** `add_arrow` is matplotlib's `Arrow`, and `add_path` takes
  a string of verbs (`M`, `L`, `C`, `Z`) so a patch can be any run of
  lines and cubic curves.

README: the "Comparison note" said the output was only visually similar;
it now says what the comparison actually measures, with the numbers. The
features heading no longer calls this an MVP.

Five new cases, 76 through 82 in `tests/test_plots.f90` and
`tests/gen_mpl_refs.py`. All five harnesses pass: SVG structural, PNG
1.55/255 over 81 cases, PDF 2.02, EPS 3.52, GIF per frame.