### PR TITLE
Let another project depend on fplot with fpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: pixi run test-flang
       - name: Test with LFortran
         run: pixi run test-lfortran
+      - name: Build as an fpm package
+        run: pixi run fpm-flang && pixi run fpm-lfortran
       - name: Compare against matplotlib references
         run: pixi run compare
       - name: Compare PNG output against matplotlib

--- a/README.md
+++ b/README.md
@@ -206,6 +206,28 @@ call suptitle("figure title")
   single letters, `C0`-`C9`, or a greyscale fraction such as `"0.5"`
 - SVG defaults aligned with matplotlib (6.4×4.8 in, tab10 colors, subplot margins)
 
+## Using fplot in your project
+
+fplot is an [fpm](https://fpm.fortran-lang.org) package with no dependencies
+outside the Fortran standard library, so a project picks it up with one entry
+in its `fpm.toml`:
+
+```toml
+[dependencies]
+fplot = { git = "https://github.com/certik/fplot" }
+```
+
+and then `use fplot` and call `plot`, `title`, `savefig` as the examples below
+do. It builds with both flang and LFortran:
+
+```bash
+fpm build --compiler flang
+fpm build --compiler lfortran
+```
+
+The pixi tasks below are for developing fplot itself, where the build scripts
+give finer control over compile and link order.
+
 ## Build
 
 Requires [pixi](https://pixi.sh). LFortran is installed by pixi on all platforms.

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,23 @@
+name = "fplot"
+version = "0.1.0"
+description = "Pure Fortran pylab-style plotting: SVG, PNG, PDF, EPS and GIF"
+categories = ["graphics"]
+keywords = ["plotting", "matplotlib", "svg", "png", "pdf"]
+
+[build]
+auto-executables = false
+auto-examples = false
+auto-tests = false
+
+[library]
+source-dir = "src"
+
+[[example]]
+name = "demo"
+source-dir = "examples"
+main = "demo.f90"
+
+[[test]]
+name = "test_plots"
+source-dir = "tests"
+main = "test_plots.f90"

--- a/pixi.lock
+++ b/pixi.lock
@@ -47,6 +47,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flang_impl_linux-64-22.1.8-h0f0ccf8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/flang_linux-64-22.1.8-h2033497_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fpm-0.13.0-hb1d0f04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ghostscript-10.07.1-hecca717_0.conda
@@ -251,6 +252,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.1-py314h7bede21_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py314hf8a3a22_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.2-h2b252f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fpm-0.13.0-h00726df_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-h84a0fba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ghostscript-10.04.0-hf9b8971_0.conda
@@ -828,6 +830,20 @@ packages:
     - fonts-conda-ecosystem
   size: 296288
   timestamp: 1786667377340
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fpm-0.13.0-hb1d0f04_0.conda
+  sha256: e1ccea7f33618ad13c4bcdcfa65723b37d15b8065b46d5f3ca702ee8c58e048a
+  md5: 295102acc432b94629cc195d79e6df06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1605505
+  timestamp: 1771425780400
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
   sha256: 612a8e0c1a6ecae23da54d81ef395f6ebb5c8e4468ec2611593ebce75876a4e0
   md5: 2d0ea23b23603e07ca47f23f949f67b6
@@ -3455,6 +3471,19 @@ packages:
     - fonts-conda-ecosystem
   size: 262776
   timestamp: 1784754851028
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fpm-0.13.0-h00726df_0.conda
+  sha256: 3c36a16901ac65852ea6a9c03077d14de3e0c27fab8e540ee637736a07506e08
+  md5: d8af5a4b1a791f2902122220b167cb08
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 1126641
+  timestamp: 1771426377724
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
   sha256: 96b33f1e2a32c602b167f43719e3acf89ec742b4a1e25e99ffd0e6f99b38d277
   md5: 7bd06ab4ed807154c2d9031eb5ebf025

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,6 +15,10 @@ build-lfortran = "bash scripts/build_lfortran.sh"
 test-lfortran = "bash scripts/build_lfortran.sh && mkdir -p tests/out && ./build/lfortran/test_plots"
 demo-lfortran = "bash scripts/build_lfortran.sh && ./build/lfortran/demo"
 
+# fpm is how another project depends on fplot, so build it that way too.
+fpm-flang = "fpm build --compiler flang"
+fpm-lfortran = "fpm build --compiler lfortran"
+
 mpl-refs = "python tests/gen_mpl_refs.py"
 
 # The five comparisons share their setup, so it is expressed once as a
@@ -50,6 +54,7 @@ poppler = "*"
 lfortran = ">=0.64.0,<0.65"
 # gs, for rasterizing EPS in tests/compare_eps.py
 ghostscript = ">=10.4.0,<11"
+fpm = ">=0.13.0,<0.14"
 
 [target.linux-64.dependencies]
 flang_linux-64 = ">=22,<23"


### PR DESCRIPTION
The one thing standing between fplot and being used in another project was that there was no way to depend on it: the build was two hand-written scripts that know the compile and link order.

This adds `fpm.toml`, so a project can write

```toml
[dependencies]
fplot = { git = "https://github.com/certik/fplot" }
```

and nothing else. `fpm build --compiler flang`, `fpm build --compiler lfortran` and `fpm test --compiler flang` (which writes all 124 test plots) all work; the two builds are added to CI as `pixi run fpm-flang` / `fpm-lfortran` so the manifest cannot rot.

The pixi scripts stay as they are for developing fplot itself, and the README says which is which.