### PR TITLE
CI (ENH): allow multiple compilers and use hash references for fast comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,41 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Linux (flang + lfortran)
+  compilers:
+    name: ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Every compiler is a gate, so report all four rather than stopping at
+      # the first one that breaks.
+      fail-fast: false
+      matrix:
+        compiler: [gfortran, ifx, lfortran, flang] 
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up ${{ matrix.compiler }}
+        id: fortran
+        uses: fortran-lang/setup-fortran@v2.0.0-beta.8
+        with:
+          compiler: ${{ matrix.compiler }}
+          version: latest
+
+      - uses: fortran-lang/setup-fpm@v10
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build with ${{ matrix.compiler }}
+        run: fpm build --compiler ${{ steps.fortran.outputs.fc }}
+
+      # test_plots writes to tests/out with paths relative to the repo root,
+      # which is where fpm runs it from.
+      - name: Test with ${{ matrix.compiler }}
+        run: |
+          mkdir -p tests/out
+          fpm test --compiler ${{ steps.fortran.outputs.fc }}
+
+  compare:
+    name: Compare against matplotlib
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,13 +56,10 @@ jobs:
           pixi-version: v0.76.1
           cache: true
           locked: true
-      - name: Test with Flang
-        run: pixi run test-flang
-      - name: Test with LFortran
-        run: pixi run test-lfortran
-      - name: Build as an fpm package
-        run: pixi run fpm-flang && pixi run fpm-lfortran
-      - name: Compare against matplotlib references
+      # Each compare task pulls in mpl-refs and test-flang through its
+      # depends-on, so the reference images and the fplot output are generated
+      # once between them.
+      - name: Compare SVG output against matplotlib
         run: pixi run compare
       - name: Compare PNG output against matplotlib
         run: pixi run compare-png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
   compilers:
     name: ${{ matrix.compiler }}
     runs-on: ubuntu-latest
+    env:
+      FPLOT_TEST_PYTHON: python3
     strategy:
       # Every compiler is a gate, so report all four rather than stopping at
       # the first one that breaks.
@@ -40,32 +42,7 @@ jobs:
         run: fpm build --compiler ${{ steps.fortran.outputs.fc }}
 
       # test_plots writes to tests/out with paths relative to the repo root,
-      # which is where fpm runs it from.
+      # then verifies the committed reference hashes.
       - name: Test with ${{ matrix.compiler }}
         run: |
-          mkdir -p tests/out
           fpm test --compiler ${{ steps.fortran.outputs.fc }}
-
-  compare:
-    name: Compare against matplotlib
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.10.1
-        with:
-          pixi-version: v0.76.1
-          cache: true
-          locked: true
-      # Each compare task pulls in mpl-refs and test-flang through its
-      # depends-on, so the reference images and the fplot output are generated
-      # once between them.
-      - name: Compare SVG output against matplotlib
-        run: pixi run compare
-      - name: Compare PNG output against matplotlib
-        run: pixi run compare-png
-      - name: Compare PDF output against matplotlib
-        run: pixi run compare-pdf
-      - name: Compare EPS output against matplotlib
-        run: pixi run compare-eps
-      - name: Compare GIF output against matplotlib
-        run: pixi run compare-gif

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             verify_hashes: true
           - compiler: ifx
             hash_profile: linux-ifx
-            verify_hashes: false
+            verify_hashes: true
           - compiler: lfortran
             hash_profile: linux-lfortran
             verify_hashes: true
@@ -57,16 +57,7 @@ jobs:
       # selected compiler profile.
       - name: Test with ${{ matrix.compiler }}
         id: test
-        continue-on-error: ${{ !matrix.verify_hashes }}
         env:
           FPLOT_HASH_PROFILE: ${{ matrix.hash_profile }}
         run: |
           fpm test --compiler ${{ steps.fortran.outputs.fc }}
-
-      - name: Upload candidate hash manifest for ${{ matrix.compiler }}
-        if: ${{ !matrix.verify_hashes }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.hash_profile }}-candidate
-          path: tests/reference_hashes.${{ matrix.hash_profile }}.candidate.json
-          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,19 @@ jobs:
       # the first one that breaks.
       fail-fast: false
       matrix:
-        compiler: [gfortran, ifx, lfortran, flang] 
+        include:
+          - compiler: gfortran
+            hash_profile: linux-gfortran
+            verify_hashes: true
+          - compiler: ifx
+            hash_profile: linux-ifx
+            verify_hashes: false
+          - compiler: lfortran
+            hash_profile: linux-lfortran
+            verify_hashes: true
+          - compiler: flang
+            hash_profile: linux-flang
+            verify_hashes: true
     steps:
       - uses: actions/checkout@v4
 
@@ -41,8 +53,20 @@ jobs:
       - name: Build with ${{ matrix.compiler }}
         run: fpm build --compiler ${{ steps.fortran.outputs.fc }}
 
-      # test_plots writes to tests/out with paths relative to the repo root,
-      # then verifies the committed reference hashes.
+      # test_plots writes to tests/out, then verifies the hashes for the
+      # selected compiler profile.
       - name: Test with ${{ matrix.compiler }}
+        id: test
+        continue-on-error: ${{ !matrix.verify_hashes }}
+        env:
+          FPLOT_HASH_PROFILE: ${{ matrix.hash_profile }}
         run: |
           fpm test --compiler ${{ steps.fortran.outputs.fc }}
+
+      - name: Upload candidate hash manifest for ${{ matrix.compiler }}
+        if: ${{ !matrix.verify_hashes }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.hash_profile }}-candidate
+          path: tests/reference_hashes.${{ matrix.hash_profile }}.candidate.json
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 !.pixi/config.toml
 
 # build artifacts
-build/
+*build/
 *.mod
 *.o
 *.a

--- a/README.md
+++ b/README.md
@@ -275,10 +275,9 @@ SVG looks like. PNG, PDF and EPS are compared as pixels, since there fplot
 decides.
 
 CI (Linux) runs `fpm test` across the compiler matrix and selects a hash
-profile per compiler. `gfortran`, `lfortran` and `flang` are verified against
-committed profiles; `ifx` currently uploads a candidate manifest so its
-compiler-specific baseline can be reviewed and added intentionally. The
-matplotlib comparison scripts remain available for deeper fidelity audits.
+profile per compiler. `gfortran`, `ifx`, `lfortran` and `flang` are verified
+against committed profiles. The matplotlib comparison scripts remain available
+for deeper fidelity audits.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,13 @@ pixi run demo-flang
 pixi run build-lfortran
 pixi run test-lfortran
 
-# Compare against matplotlib references
+# fpm uses the committed reference hashes too
+fpm test
+
+# Refresh the committed hashes after intentionally changing plot output
+python tests/update_reference_hashes.py
+
+# Optional: compare against matplotlib references when auditing fidelity
 pixi run compare       # SVG, structurally
 pixi run compare-png   # PNG, pixel by pixel
 pixi run compare-pdf   # PDF, rasterized by pdftoppm
@@ -254,12 +260,18 @@ pixi run compare-eps   # EPS, rasterized by ghostscript
 pixi run compare-gif   # GIF, frame by frame
 ```
 
+`fpm test` now generates all reference artifacts and verifies them against the
+committed hashes in `tests/reference_hashes.json`. When a plotting change is
+intentional, regenerate `tests/out` with `fpm test`, refresh the manifest with
+`python tests/update_reference_hashes.py`, and commit the updated JSON.
+
 The SVG comparison is structural because a viewer, not fplot, decides what an
 SVG looks like. PNG, PDF and EPS are compared as pixels, since there fplot
 decides.
 
-CI (Linux) runs `pixi run test-flang` and `pixi run test-lfortran`, then all
-five comparisons.
+CI (Linux) runs `fpm test` across the compiler matrix, so hash verification is
+the main gate. The matplotlib comparison scripts remain available for deeper
+fidelity audits.
 
 ## Layout
 
@@ -270,7 +282,7 @@ src/           library modules
                fplot_draw.f90    layout, axes decoration, one renderer per plot type
                fplot.f90         the plotting API
 examples/      demo.f90
-tests/         Fortran test plots, matplotlib refs, compare scripts
+tests/         Fortran test plots, hash manifest, matplotlib refs, compare scripts
 scripts/       build_flang.sh, build_lfortran.sh
 ```
 
@@ -302,8 +314,10 @@ call display_data("image/svg+xml", render_svg())
 
 fplot is measured against matplotlib rather than described as similar to it:
 every feature has a case in `tests/test_plots.f90` and a matplotlib reference
-in `tests/gen_mpl_refs.py`, and the comparisons above put a number on the
-difference. As of this writing, over 100 cases:
+in `tests/gen_mpl_refs.py`. The committed hash manifest in
+`tests/reference_hashes.json` locks in the accepted native output for those
+cases, while the comparison scripts above still put a number on the remaining
+difference from matplotlib. As of this writing, over 100 cases:
 
 | format | cases | mean difference |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -249,8 +249,11 @@ pixi run test-lfortran
 # fpm uses the committed reference hashes too
 fpm test
 
-# Refresh the committed hashes after intentionally changing plot output
+# Refresh the local platform/compiler profile after intentionally changing plot output
 python tests/update_reference_hashes.py
+
+# Refresh a specific CI profile explicitly
+FPLOT_HASH_PROFILE=linux-gfortran python tests/update_reference_hashes.py
 
 # Optional: compare against matplotlib references when auditing fidelity
 pixi run compare       # SVG, structurally
@@ -261,17 +264,21 @@ pixi run compare-gif   # GIF, frame by frame
 ```
 
 `fpm test` now generates all reference artifacts and verifies them against the
-committed hashes in `tests/reference_hashes.json`. When a plotting change is
-intentional, regenerate `tests/out` with `fpm test`, refresh the manifest with
-`python tests/update_reference_hashes.py`, and commit the updated JSON.
+committed hashes in `tests/reference_hashes.json`. That manifest is profile
+aware: each compiler/platform combination can carry its own accepted hashes.
+When a plotting change is intentional, regenerate `tests/out` with `fpm test`,
+refresh the matching profile with `python tests/update_reference_hashes.py`,
+and commit the updated JSON.
 
 The SVG comparison is structural because a viewer, not fplot, decides what an
 SVG looks like. PNG, PDF and EPS are compared as pixels, since there fplot
 decides.
 
-CI (Linux) runs `fpm test` across the compiler matrix, so hash verification is
-the main gate. The matplotlib comparison scripts remain available for deeper
-fidelity audits.
+CI (Linux) runs `fpm test` across the compiler matrix and selects a hash
+profile per compiler. `gfortran`, `lfortran` and `flang` are verified against
+committed profiles; `ifx` currently uploads a candidate manifest so its
+compiler-specific baseline can be reviewed and added intentionally. The
+matplotlib comparison scripts remain available for deeper fidelity audits.
 
 ## Layout
 
@@ -316,8 +323,9 @@ fplot is measured against matplotlib rather than described as similar to it:
 every feature has a case in `tests/test_plots.f90` and a matplotlib reference
 in `tests/gen_mpl_refs.py`. The committed hash manifest in
 `tests/reference_hashes.json` locks in the accepted native output for those
-cases, while the comparison scripts above still put a number on the remaining
-difference from matplotlib. As of this writing, over 100 cases:
+cases, with separate profiles where compilers render differently, while the
+comparison scripts above still put a number on the remaining difference from
+matplotlib. As of this writing, over 100 cases:
 
 | format | cases | mean difference |
 | --- | --- | --- |

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -1,2491 +1,9965 @@
 {
-  "files": [
-    {
-      "path": "alpha.eps",
-      "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
-      "size": 80981
-    },
-    {
-      "path": "alpha.pdf",
-      "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
-      "size": 58537
-    },
-    {
-      "path": "alpha.png",
-      "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
-      "size": 60468
-    },
-    {
-      "path": "alpha.svg",
-      "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
-      "size": 29813
-    },
-    {
-      "path": "anim_sine.gif",
-      "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
-      "size": 146758
-    },
-    {
-      "path": "annotate_arrow.eps",
-      "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
-      "size": 9706
-    },
-    {
-      "path": "annotate_arrow.pdf",
-      "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
-      "size": 6618
-    },
-    {
-      "path": "annotate_arrow.png",
-      "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
-      "size": 35121
-    },
-    {
-      "path": "annotate_arrow.svg",
-      "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
-      "size": 7557
-    },
-    {
-      "path": "annotate_curve.eps",
-      "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
-      "size": 9940
-    },
-    {
-      "path": "annotate_curve.pdf",
-      "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
-      "size": 6765
-    },
-    {
-      "path": "annotate_curve.png",
-      "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
-      "size": 35035
-    },
-    {
-      "path": "annotate_curve.svg",
-      "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
-      "size": 7615
-    },
-    {
-      "path": "axes_facecolor.eps",
-      "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
-      "size": 17496
-    },
-    {
-      "path": "axes_facecolor.pdf",
-      "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
-      "size": 11466
-    },
-    {
-      "path": "axes_facecolor.png",
-      "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
-      "size": 40471
-    },
-    {
-      "path": "axes_facecolor.svg",
-      "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
-      "size": 13174
-    },
-    {
-      "path": "axes_handles2.eps",
-      "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
-      "size": 26227
-    },
-    {
-      "path": "axes_handles2.pdf",
-      "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
-      "size": 16957
-    },
-    {
-      "path": "axes_handles2.png",
-      "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
-      "size": 32163
-    },
-    {
-      "path": "axes_handles2.svg",
-      "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
-      "size": 19863
-    },
-    {
-      "path": "axis_equal.eps",
-      "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
-      "size": 8082
-    },
-    {
-      "path": "axis_equal.pdf",
-      "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
-      "size": 5385
-    },
-    {
-      "path": "axis_equal.png",
-      "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
-      "size": 18657
-    },
-    {
-      "path": "axis_equal.svg",
-      "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
-      "size": 4733
-    },
-    {
-      "path": "bar.eps",
-      "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
-      "size": 7532
-    },
-    {
-      "path": "bar.pdf",
-      "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
-      "size": 4363
-    },
-    {
-      "path": "bar.png",
-      "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
-      "size": 17029
-    },
-    {
-      "path": "bar.svg",
-      "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
-      "size": 5255
-    },
-    {
-      "path": "bar3d.eps",
-      "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
-      "size": 34185
-    },
-    {
-      "path": "bar3d.pdf",
-      "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
-      "size": 20605
-    },
-    {
-      "path": "bar3d.png",
-      "sha256": "6cb71a60a5b74a3808f6999efc211284a3b49b290c790d20f4907320785d46c1",
-      "size": 57527
-    },
-    {
-      "path": "bar3d.svg",
-      "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
-      "size": 20023
-    },
-    {
-      "path": "bar_colors.eps",
-      "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
-      "size": 7530
-    },
-    {
-      "path": "bar_colors.pdf",
-      "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
-      "size": 4571
-    },
-    {
-      "path": "bar_colors.png",
-      "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
-      "size": 17074
-    },
-    {
-      "path": "bar_colors.svg",
-      "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
-      "size": 5449
-    },
-    {
-      "path": "bar_err.eps",
-      "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
-      "size": 10265
-    },
-    {
-      "path": "bar_err.pdf",
-      "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
-      "size": 5894
-    },
-    {
-      "path": "bar_err.png",
-      "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
-      "size": 16414
-    },
-    {
-      "path": "bar_err.svg",
-      "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
-      "size": 7040
-    },
-    {
-      "path": "bar_stacked.eps",
-      "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
-      "size": 10296
-    },
-    {
-      "path": "bar_stacked.pdf",
-      "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
-      "size": 5771
-    },
-    {
-      "path": "bar_stacked.png",
-      "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
-      "size": 18411
-    },
-    {
-      "path": "bar_stacked.svg",
-      "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
-      "size": 6771
-    },
-    {
-      "path": "barh.eps",
-      "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
-      "size": 6714
-    },
-    {
-      "path": "barh.pdf",
-      "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
-      "size": 4007
-    },
-    {
-      "path": "barh.png",
-      "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
-      "size": 13399
-    },
-    {
-      "path": "barh.svg",
-      "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
-      "size": 4634
-    },
-    {
-      "path": "basic_line.eps",
-      "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
-      "size": 10559
-    },
-    {
-      "path": "basic_line.pdf",
-      "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
-      "size": 7090
-    },
-    {
-      "path": "basic_line.png",
-      "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
-      "size": 27135
-    },
-    {
-      "path": "basic_line.svg",
-      "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
-      "size": 7592
-    },
-    {
-      "path": "box_opts.eps",
-      "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
-      "size": 12228
-    },
-    {
-      "path": "box_opts.pdf",
-      "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
-      "size": 7789
-    },
-    {
-      "path": "box_opts.png",
-      "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
-      "size": 19358
-    },
-    {
-      "path": "box_opts.svg",
-      "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
-      "size": 8234
-    },
-    {
-      "path": "boxplot.eps",
-      "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
-      "size": 7338
-    },
-    {
-      "path": "boxplot.pdf",
-      "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
-      "size": 4561
-    },
-    {
-      "path": "boxplot.png",
-      "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
-      "size": 14315
-    },
-    {
-      "path": "boxplot.svg",
-      "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
-      "size": 5158
-    },
-    {
-      "path": "broken_barh.eps",
-      "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
-      "size": 4871
-    },
-    {
-      "path": "broken_barh.pdf",
-      "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
-      "size": 3421
-    },
-    {
-      "path": "broken_barh.png",
-      "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
-      "size": 14714
-    },
-    {
-      "path": "broken_barh.svg",
-      "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
-      "size": 3619
-    },
-    {
-      "path": "categorical.eps",
-      "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
-      "size": 5691
-    },
-    {
-      "path": "categorical.pdf",
-      "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
-      "size": 3529
-    },
-    {
-      "path": "categorical.png",
-      "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
-      "size": 17291
-    },
-    {
-      "path": "categorical.svg",
-      "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
-      "size": 4113
-    },
-    {
-      "path": "clabel.eps",
-      "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
-      "size": 14848
-    },
-    {
-      "path": "clabel.pdf",
-      "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
-      "size": 10428
-    },
-    {
-      "path": "clabel.png",
-      "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
-      "size": 62827
-    },
-    {
-      "path": "clabel.svg",
-      "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
-      "size": 11171
-    },
-    {
-      "path": "cmap_discrete.eps",
-      "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
-      "size": 165754
-    },
-    {
-      "path": "cmap_discrete.pdf",
-      "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
-      "size": 6561
-    },
-    {
-      "path": "cmap_discrete.png",
-      "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
-      "size": 17689
-    },
-    {
-      "path": "cmap_discrete.svg",
-      "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
-      "size": 9074
-    },
-    {
-      "path": "cmap_lognorm.eps",
-      "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
-      "size": 495916
-    },
-    {
-      "path": "cmap_lognorm.pdf",
-      "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
-      "size": 13628
-    },
-    {
-      "path": "cmap_lognorm.png",
-      "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
-      "size": 18530
-    },
-    {
-      "path": "cmap_lognorm.svg",
-      "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
-      "size": 15377
-    },
-    {
-      "path": "cmap_reversed.eps",
-      "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
-      "size": 496738
-    },
-    {
-      "path": "cmap_reversed.pdf",
-      "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
-      "size": 14516
-    },
-    {
-      "path": "cmap_reversed.png",
-      "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
-      "size": 19713
-    },
-    {
-      "path": "cmap_reversed.svg",
-      "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
-      "size": 15977
-    },
-    {
-      "path": "cmap_special.eps",
-      "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
-      "size": 385887
-    },
-    {
-      "path": "cmap_special.pdf",
-      "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
-      "size": 8509
-    },
-    {
-      "path": "cmap_special.png",
-      "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
-      "size": 22036
-    },
-    {
-      "path": "cmap_special.svg",
-      "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
-      "size": 10971
-    },
-    {
-      "path": "colorbar_orient.eps",
-      "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
-      "size": 481251
-    },
-    {
-      "path": "colorbar_orient.pdf",
-      "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
-      "size": 24888
-    },
-    {
-      "path": "colorbar_orient.png",
-      "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
-      "size": 23198
-    },
-    {
-      "path": "colorbar_orient.svg",
-      "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
-      "size": 25679
-    },
-    {
-      "path": "colors.eps",
-      "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
-      "size": 5537
-    },
-    {
-      "path": "colors.pdf",
-      "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
-      "size": 3660
-    },
-    {
-      "path": "colors.png",
-      "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
-      "size": 15230
-    },
-    {
-      "path": "colors.svg",
-      "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
-      "size": 4189
-    },
-    {
-      "path": "constrained.eps",
-      "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
-      "size": 15645
-    },
-    {
-      "path": "constrained.pdf",
-      "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
-      "size": 10197
-    },
-    {
-      "path": "constrained.png",
-      "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
-      "size": 46857
-    },
-    {
-      "path": "constrained.svg",
-      "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
-      "size": 12564
-    },
-    {
-      "path": "contour.eps",
-      "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
-      "size": 12891
-    },
-    {
-      "path": "contour.pdf",
-      "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
-      "size": 8839
-    },
-    {
-      "path": "contour.png",
-      "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
-      "size": 65492
-    },
-    {
-      "path": "contour.svg",
-      "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
-      "size": 9576
-    },
-    {
-      "path": "contour3d.eps",
-      "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
-      "size": 36513
-    },
-    {
-      "path": "contour3d.pdf",
-      "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
-      "size": 26115
-    },
-    {
-      "path": "contour3d.png",
-      "sha256": "f0237ea244826fcfcc9ae30e9abf1f63f3157c5a05bfd70c7287ad26a993de4c",
-      "size": 94817
-    },
-    {
-      "path": "contour3d.svg",
-      "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
-      "size": 27643
-    },
-    {
-      "path": "contourf.eps",
-      "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
-      "size": 148542
-    },
-    {
-      "path": "contourf.pdf",
-      "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
-      "size": 88734
-    },
-    {
-      "path": "contourf.png",
-      "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
-      "size": 65324
-    },
-    {
-      "path": "contourf.svg",
-      "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
-      "size": 66386
-    },
-    {
-      "path": "dates.eps",
-      "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
-      "size": 16170
-    },
-    {
-      "path": "dates.pdf",
-      "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
-      "size": 12158
-    },
-    {
-      "path": "dates.png",
-      "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
-      "size": 33847
-    },
-    {
-      "path": "dates.svg",
-      "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
-      "size": 13055
-    },
-    {
-      "path": "errorbar.eps",
-      "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
-      "size": 18677
-    },
-    {
-      "path": "errorbar.pdf",
-      "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
-      "size": 12254
-    },
-    {
-      "path": "errorbar.png",
-      "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
-      "size": 26603
-    },
-    {
-      "path": "errorbar.svg",
-      "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
-      "size": 9685
-    },
-    {
-      "path": "errorbar_xy.eps",
-      "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
-      "size": 19492
-    },
-    {
-      "path": "errorbar_xy.pdf",
-      "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
-      "size": 12891
-    },
-    {
-      "path": "errorbar_xy.png",
-      "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
-      "size": 18310
-    },
-    {
-      "path": "errorbar_xy.svg",
-      "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
-      "size": 9803
-    },
-    {
-      "path": "eventplot.eps",
-      "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
-      "size": 14362
-    },
-    {
-      "path": "eventplot.pdf",
-      "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
-      "size": 8864
-    },
-    {
-      "path": "eventplot.png",
-      "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
-      "size": 19220
-    },
-    {
-      "path": "eventplot.svg",
-      "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
-      "size": 8618
-    },
-    {
-      "path": "facecolor.eps",
-      "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
-      "size": 12235
-    },
-    {
-      "path": "facecolor.pdf",
-      "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
-      "size": 8108
-    },
-    {
-      "path": "facecolor.png",
-      "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
-      "size": 32314
-    },
-    {
-      "path": "facecolor.svg",
-      "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
-      "size": 8675
-    },
-    {
-      "path": "figlegend.eps",
-      "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
-      "size": 15657
-    },
-    {
-      "path": "figlegend.pdf",
-      "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
-      "size": 10220
-    },
-    {
-      "path": "figlegend.png",
-      "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
-      "size": 38060
-    },
-    {
-      "path": "figlegend.svg",
-      "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
-      "size": 12445
-    },
-    {
-      "path": "figsize.eps",
-      "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
-      "size": 10482
-    },
-    {
-      "path": "figsize.pdf",
-      "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
-      "size": 7028
-    },
-    {
-      "path": "figsize.png",
-      "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
-      "size": 24009
-    },
-    {
-      "path": "figsize.svg",
-      "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
-      "size": 7577
-    },
-    {
-      "path": "figures.eps",
-      "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
-      "size": 4606
-    },
-    {
-      "path": "figures.pdf",
-      "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
-      "size": 3048
-    },
-    {
-      "path": "figures.png",
-      "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
-      "size": 25900
-    },
-    {
-      "path": "figures.svg",
-      "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
-      "size": 3628
-    },
-    {
-      "path": "fill_between.eps",
-      "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
-      "size": 18796
-    },
-    {
-      "path": "fill_between.pdf",
-      "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
-      "size": 13247
-    },
-    {
-      "path": "fill_between.png",
-      "sha256": "cf27a182ddb40781a17423b809123e735b38104c094496bea53089f0fe588bc4",
-      "size": 39611
-    },
-    {
-      "path": "fill_between.svg",
-      "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
-      "size": 13950
-    },
-    {
-      "path": "fill_where.eps",
-      "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
-      "size": 14886
-    },
-    {
-      "path": "fill_where.pdf",
-      "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
-      "size": 10790
-    },
-    {
-      "path": "fill_where.png",
-      "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
-      "size": 33717
-    },
-    {
-      "path": "fill_where.svg",
-      "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
-      "size": 11789
-    },
-    {
-      "path": "fills.eps",
-      "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
-      "size": 17109
-    },
-    {
-      "path": "fills.pdf",
-      "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
-      "size": 11768
-    },
-    {
-      "path": "fills.png",
-      "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
-      "size": 37226
-    },
-    {
-      "path": "fills.svg",
-      "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
-      "size": 13423
-    },
-    {
-      "path": "font_faces.eps",
-      "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
-      "size": 9227
-    },
-    {
-      "path": "font_faces.pdf",
-      "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
-      "size": 6271
-    },
-    {
-      "path": "font_faces.png",
-      "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
-      "size": 36737
-    },
-    {
-      "path": "font_faces.svg",
-      "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
-      "size": 7508
-    },
-    {
-      "path": "fontsize.eps",
-      "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
-      "size": 5477
-    },
-    {
-      "path": "fontsize.pdf",
-      "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
-      "size": 3444
-    },
-    {
-      "path": "fontsize.png",
-      "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
-      "size": 32705
-    },
-    {
-      "path": "fontsize.svg",
-      "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
-      "size": 4266
-    },
-    {
-      "path": "formatters.eps",
-      "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
-      "size": 6509
-    },
-    {
-      "path": "formatters.pdf",
-      "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
-      "size": 4947
-    },
-    {
-      "path": "formatters.png",
-      "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
-      "size": 29499
-    },
-    {
-      "path": "formatters.svg",
-      "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
-      "size": 5254
-    },
-    {
-      "path": "grid_options.eps",
-      "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
-      "size": 36975
-    },
-    {
-      "path": "grid_options.pdf",
-      "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
-      "size": 23143
-    },
-    {
-      "path": "grid_options.png",
-      "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
-      "size": 63085
-    },
-    {
-      "path": "grid_options.svg",
-      "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
-      "size": 25186
-    },
-    {
-      "path": "grid_ratios.eps",
-      "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
-      "size": 24813
-    },
-    {
-      "path": "grid_ratios.pdf",
-      "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
-      "size": 16526
-    },
-    {
-      "path": "grid_ratios.png",
-      "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
-      "size": 40356
-    },
-    {
-      "path": "grid_ratios.svg",
-      "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
-      "size": 19980
-    },
-    {
-      "path": "gridspec.eps",
-      "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
-      "size": 20006
-    },
-    {
-      "path": "gridspec.pdf",
-      "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
-      "size": 13384
-    },
-    {
-      "path": "gridspec.png",
-      "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
-      "size": 38342
-    },
-    {
-      "path": "gridspec.svg",
-      "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
-      "size": 16082
-    },
-    {
-      "path": "hatch.eps",
-      "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
-      "size": 43560
-    },
-    {
-      "path": "hatch.pdf",
-      "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
-      "size": 26971
-    },
-    {
-      "path": "hatch.png",
-      "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
-      "size": 42010
-    },
-    {
-      "path": "hatch.svg",
-      "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
-      "size": 26350
-    },
-    {
-      "path": "hexbin.eps",
-      "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
-      "size": 75718
-    },
-    {
-      "path": "hexbin.pdf",
-      "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
-      "size": 54711
-    },
-    {
-      "path": "hexbin.png",
-      "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
-      "size": 87042
-    },
-    {
-      "path": "hexbin.svg",
-      "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
-      "size": 44436
-    },
-    {
-      "path": "hist.eps",
-      "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
-      "size": 8501
-    },
-    {
-      "path": "hist.pdf",
-      "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
-      "size": 4854
-    },
-    {
-      "path": "hist.png",
-      "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
-      "size": 20119
-    },
-    {
-      "path": "hist.svg",
-      "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
-      "size": 5634
-    },
-    {
-      "path": "hist2d.eps",
-      "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
-      "size": 31502
-    },
-    {
-      "path": "hist2d.pdf",
-      "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
-      "size": 17621
-    },
-    {
-      "path": "hist2d.png",
-      "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
-      "size": 20491
-    },
-    {
-      "path": "hist2d.svg",
-      "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
-      "size": 14830
-    },
-    {
-      "path": "hist_bins.eps",
-      "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
-      "size": 6748
-    },
-    {
-      "path": "hist_bins.pdf",
-      "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
-      "size": 4027
-    },
-    {
-      "path": "hist_bins.png",
-      "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
-      "size": 17959
-    },
-    {
-      "path": "hist_bins.svg",
-      "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
-      "size": 4773
-    },
-    {
-      "path": "hist_opts.eps",
-      "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
-      "size": 9129
-    },
-    {
-      "path": "hist_opts.pdf",
-      "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
-      "size": 5639
-    },
-    {
-      "path": "hist_opts.png",
-      "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
-      "size": 19359
-    },
-    {
-      "path": "hist_opts.svg",
-      "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
-      "size": 5852
-    },
-    {
-      "path": "hist_orient.eps",
-      "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
-      "size": 21335
-    },
-    {
-      "path": "hist_orient.pdf",
-      "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
-      "size": 11396
-    },
-    {
-      "path": "hist_orient.png",
-      "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
-      "size": 24932
-    },
-    {
-      "path": "hist_orient.svg",
-      "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
-      "size": 13132
-    },
-    {
-      "path": "hist_stacked.eps",
-      "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
-      "size": 12928
-    },
-    {
-      "path": "hist_stacked.pdf",
-      "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
-      "size": 7090
-    },
-    {
-      "path": "hist_stacked.png",
-      "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
-      "size": 23306
-    },
-    {
-      "path": "hist_stacked.svg",
-      "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
-      "size": 8591
-    },
-    {
-      "path": "hv_lines.eps",
-      "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
-      "size": 13110
-    },
-    {
-      "path": "hv_lines.pdf",
-      "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
-      "size": 8518
-    },
-    {
-      "path": "hv_lines.png",
-      "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
-      "size": 36338
-    },
-    {
-      "path": "hv_lines.svg",
-      "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
-      "size": 9248
-    },
-    {
-      "path": "imshow.eps",
-      "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
-      "size": 417463
-    },
-    {
-      "path": "imshow.pdf",
-      "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
-      "size": 6278
-    },
-    {
-      "path": "imshow.png",
-      "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
-      "size": 15228
-    },
-    {
-      "path": "imshow.svg",
-      "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
-      "size": 8275
-    },
-    {
-      "path": "imshow_cbar.eps",
-      "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
-      "size": 272389
-    },
-    {
-      "path": "imshow_cbar.pdf",
-      "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
-      "size": 13336
-    },
-    {
-      "path": "imshow_cbar.png",
-      "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
-      "size": 24453
-    },
-    {
-      "path": "imshow_cbar.svg",
-      "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
-      "size": 14287
-    },
-    {
-      "path": "imshow_log.eps",
-      "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
-      "size": 33713
-    },
-    {
-      "path": "imshow_log.pdf",
-      "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
-      "size": 18741
-    },
-    {
-      "path": "imshow_log.png",
-      "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
-      "size": 19144
-    },
-    {
-      "path": "imshow_log.svg",
-      "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
-      "size": 17077
-    },
-    {
-      "path": "imshow_rgb.eps",
-      "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
-      "size": 530576
-    },
-    {
-      "path": "imshow_rgb.pdf",
-      "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
-      "size": 6334
-    },
-    {
-      "path": "imshow_rgb.png",
-      "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
-      "size": 16457
-    },
-    {
-      "path": "imshow_rgb.svg",
-      "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
-      "size": 7768
-    },
-    {
-      "path": "inset.eps",
-      "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
-      "size": 16312
-    },
-    {
-      "path": "inset.pdf",
-      "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
-      "size": 10519
-    },
-    {
-      "path": "inset.png",
-      "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
-      "size": 36630
-    },
-    {
-      "path": "inset.svg",
-      "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
-      "size": 12927
-    },
-    {
-      "path": "interp.eps",
-      "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
-      "size": 394292
-    },
-    {
-      "path": "interp.pdf",
-      "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
-      "size": 28040
-    },
-    {
-      "path": "interp.png",
-      "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
-      "size": 62490
-    },
-    {
-      "path": "interp.svg",
-      "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
-      "size": 50239
-    },
-    {
-      "path": "invert_axes.eps",
-      "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
-      "size": 8720
-    },
-    {
-      "path": "invert_axes.pdf",
-      "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
-      "size": 6008
-    },
-    {
-      "path": "invert_axes.png",
-      "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
-      "size": 31964
-    },
-    {
-      "path": "invert_axes.svg",
-      "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
-      "size": 6957
-    },
-    {
-      "path": "legend_labels.eps",
-      "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
-      "size": 15431
-    },
-    {
-      "path": "legend_labels.pdf",
-      "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
-      "size": 11163
-    },
-    {
-      "path": "legend_labels.png",
-      "sha256": "e92c4d496445bd933dc3afcbcb7393d0b3ad28d013fc06ee59ecdc512ad60746",
-      "size": 50734
-    },
-    {
-      "path": "legend_labels.svg",
-      "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
-      "size": 12229
-    },
-    {
-      "path": "legend_opts.eps",
-      "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
-      "size": 7371
-    },
-    {
-      "path": "legend_opts.pdf",
-      "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
-      "size": 4574
-    },
-    {
-      "path": "legend_opts.png",
-      "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
-      "size": 44992
-    },
-    {
-      "path": "legend_opts.svg",
-      "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
-      "size": 5558
-    },
-    {
-      "path": "line3d.eps",
-      "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
-      "size": 18473
-    },
-    {
-      "path": "line3d.pdf",
-      "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
-      "size": 13089
-    },
-    {
-      "path": "line3d.png",
-      "sha256": "10bd8a3f33c90577ddccf73e7b9c833695428e8b4f16357f9a5f91a3072d6e3e",
-      "size": 67870
-    },
-    {
-      "path": "line3d.svg",
-      "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
-      "size": 13293
-    },
-    {
-      "path": "log_minor_labels.eps",
-      "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
-      "size": 8625
-    },
-    {
-      "path": "log_minor_labels.pdf",
-      "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
-      "size": 5528
-    },
-    {
-      "path": "log_minor_labels.png",
-      "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
-      "size": 23529
-    },
-    {
-      "path": "log_minor_labels.svg",
-      "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
-      "size": 6874
-    },
-    {
-      "path": "loglog.eps",
-      "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
-      "size": 14649
-    },
-    {
-      "path": "loglog.pdf",
-      "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
-      "size": 8171
-    },
-    {
-      "path": "loglog.png",
-      "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
-      "size": 25190
-    },
-    {
-      "path": "loglog.svg",
-      "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
-      "size": 10116
-    },
-    {
-      "path": "many_series.eps",
-      "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
-      "size": 126003
-    },
-    {
-      "path": "many_series.pdf",
-      "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
-      "size": 100906
-    },
-    {
-      "path": "many_series.png",
-      "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
-      "size": 286478
-    },
-    {
-      "path": "many_series.svg",
-      "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
-      "size": 101725
-    },
-    {
-      "path": "margins.eps",
-      "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
-      "size": 17663
-    },
-    {
-      "path": "margins.pdf",
-      "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
-      "size": 12271
-    },
-    {
-      "path": "margins.png",
-      "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
-      "size": 42437
-    },
-    {
-      "path": "margins.svg",
-      "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
-      "size": 14135
-    },
-    {
-      "path": "marker_detail.eps",
-      "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
-      "size": 18574
-    },
-    {
-      "path": "marker_detail.pdf",
-      "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
-      "size": 13643
-    },
-    {
-      "path": "marker_detail.png",
-      "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
-      "size": 34522
-    },
-    {
-      "path": "marker_detail.svg",
-      "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
-      "size": 10883
-    },
-    {
-      "path": "markers_gallery.eps",
-      "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
-      "size": 23435
-    },
-    {
-      "path": "markers_gallery.pdf",
-      "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
-      "size": 16547
-    },
-    {
-      "path": "markers_gallery.png",
-      "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
-      "size": 22165
-    },
-    {
-      "path": "markers_gallery.svg",
-      "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
-      "size": 10058
-    },
-    {
-      "path": "markers_only.eps",
-      "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
-      "size": 30048
-    },
-    {
-      "path": "markers_only.pdf",
-      "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
-      "size": 21481
-    },
-    {
-      "path": "markers_only.png",
-      "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
-      "size": 30486
-    },
-    {
-      "path": "markers_only.svg",
-      "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
-      "size": 11142
-    },
-    {
-      "path": "mathtext.eps",
-      "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
-      "size": 10620
-    },
-    {
-      "path": "mathtext.pdf",
-      "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
-      "size": 6839
-    },
-    {
-      "path": "mathtext.png",
-      "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
-      "size": 32840
-    },
-    {
-      "path": "mathtext.svg",
-      "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
-      "size": 8901
-    },
-    {
-      "path": "mathtext_frac.eps",
-      "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
-      "size": 16086
-    },
-    {
-      "path": "mathtext_frac.pdf",
-      "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
-      "size": 11400
-    },
-    {
-      "path": "mathtext_frac.png",
-      "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
-      "size": 32506
-    },
-    {
-      "path": "mathtext_frac.svg",
-      "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
-      "size": 9515
-    },
-    {
-      "path": "matshow.eps",
-      "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
-      "size": 447767
-    },
-    {
-      "path": "matshow.pdf",
-      "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
-      "size": 5415
-    },
-    {
-      "path": "matshow.png",
-      "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
-      "size": 12239
-    },
-    {
-      "path": "matshow.svg",
-      "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
-      "size": 7206
-    },
-    {
-      "path": "mosaic.eps",
-      "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
-      "size": 19753
-    },
-    {
-      "path": "mosaic.pdf",
-      "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
-      "size": 13130
-    },
-    {
-      "path": "mosaic.png",
-      "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
-      "size": 37933
-    },
-    {
-      "path": "mosaic.svg",
-      "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
-      "size": 15857
-    },
-    {
-      "path": "multi_style.eps",
-      "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
-      "size": 107472
-    },
-    {
-      "path": "multi_style.pdf",
-      "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
-      "size": 81820
-    },
-    {
-      "path": "multi_style.png",
-      "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
-      "size": 47468
-    },
-    {
-      "path": "multi_style.svg",
-      "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
-      "size": 28914
-    },
-    {
-      "path": "nan_gap.eps",
-      "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
-      "size": 27755
-    },
-    {
-      "path": "nan_gap.pdf",
-      "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
-      "size": 19760
-    },
-    {
-      "path": "nan_gap.png",
-      "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
-      "size": 34425
-    },
-    {
-      "path": "nan_gap.svg",
-      "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
-      "size": 11312
-    },
-    {
-      "path": "norms.eps",
-      "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
-      "size": 236860
-    },
-    {
-      "path": "norms.pdf",
-      "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
-      "size": 9153
-    },
-    {
-      "path": "norms.png",
-      "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
-      "size": 21488
-    },
-    {
-      "path": "norms.svg",
-      "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
-      "size": 12345
-    },
-    {
-      "path": "offset_text.eps",
-      "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
-      "size": 8853
-    },
-    {
-      "path": "offset_text.pdf",
-      "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
-      "size": 6025
-    },
-    {
-      "path": "offset_text.png",
-      "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
-      "size": 31008
-    },
-    {
-      "path": "offset_text.svg",
-      "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
-      "size": 7054
-    },
-    {
-      "path": "patches.eps",
-      "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
-      "size": 9242
-    },
-    {
-      "path": "patches.pdf",
-      "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
-      "size": 6797
-    },
-    {
-      "path": "patches.png",
-      "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
-      "size": 25198
-    },
-    {
-      "path": "patches.svg",
-      "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
-      "size": 7157
-    },
-    {
-      "path": "patches_path.eps",
-      "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
-      "size": 5626
-    },
-    {
-      "path": "patches_path.pdf",
-      "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
-      "size": 3692
-    },
-    {
-      "path": "patches_path.png",
-      "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
-      "size": 30023
-    },
-    {
-      "path": "patches_path.svg",
-      "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
-      "size": 4249
-    },
-    {
-      "path": "pcolormesh.eps",
-      "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
-      "size": 44989
-    },
-    {
-      "path": "pcolormesh.pdf",
-      "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
-      "size": 25245
-    },
-    {
-      "path": "pcolormesh.png",
-      "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
-      "size": 21262
-    },
-    {
-      "path": "pcolormesh.svg",
-      "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
-      "size": 21696
-    },
-    {
-      "path": "pie.eps",
-      "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
-      "size": 2987
-    },
-    {
-      "path": "pie.pdf",
-      "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
-      "size": 2936
-    },
-    {
-      "path": "pie.png",
-      "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
-      "size": 23571
-    },
-    {
-      "path": "pie.svg",
-      "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
-      "size": 2476
-    },
-    {
-      "path": "pie_opts.eps",
-      "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
-      "size": 3945
-    },
-    {
-      "path": "pie_opts.pdf",
-      "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
-      "size": 3612
-    },
-    {
-      "path": "pie_opts.png",
-      "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
-      "size": 32364
-    },
-    {
-      "path": "pie_opts.svg",
-      "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
-      "size": 3469
-    },
-    {
-      "path": "plot_y.eps",
-      "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
-      "size": 64767
-    },
-    {
-      "path": "plot_y.pdf",
-      "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
-      "size": 47987
-    },
-    {
-      "path": "plot_y.png",
-      "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
-      "size": 40207
-    },
-    {
-      "path": "plot_y.svg",
-      "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
-      "size": 19461
-    },
-    {
-      "path": "polar.eps",
-      "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
-      "size": 54459
-    },
-    {
-      "path": "polar.pdf",
-      "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
-      "size": 43857
-    },
-    {
-      "path": "polar.png",
-      "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
-      "size": 72845
-    },
-    {
-      "path": "polar.svg",
-      "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
-      "size": 44319
-    },
-    {
-      "path": "quiver.eps",
-      "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
-      "size": 24007
-    },
-    {
-      "path": "quiver.pdf",
-      "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
-      "size": 17046
-    },
-    {
-      "path": "quiver.png",
-      "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
-      "size": 39122
-    },
-    {
-      "path": "quiver.svg",
-      "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
-      "size": 16554
-    },
-    {
-      "path": "quiver3d.eps",
-      "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
-      "size": 16864
-    },
-    {
-      "path": "quiver3d.pdf",
-      "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
-      "size": 10205
-    },
-    {
-      "path": "quiver3d.png",
-      "sha256": "9a1adedd15b285273be9136f6733412bdc012e860a213e8eb85d65d5c6a7457a",
-      "size": 83816
-    },
-    {
-      "path": "quiver3d.svg",
-      "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
-      "size": 11387
-    },
-    {
-      "path": "savefig_tight.eps",
-      "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
-      "size": 4931
-    },
-    {
-      "path": "savefig_tight.pdf",
-      "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
-      "size": 3211
-    },
-    {
-      "path": "savefig_tight.png",
-      "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
-      "size": 68856
-    },
-    {
-      "path": "savefig_tight.svg",
-      "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
-      "size": 3941
-    },
-    {
-      "path": "scatter.eps",
-      "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
-      "size": 23854
-    },
-    {
-      "path": "scatter.pdf",
-      "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
-      "size": 17031
-    },
-    {
-      "path": "scatter.png",
-      "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
-      "size": 24876
-    },
-    {
-      "path": "scatter.svg",
-      "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
-      "size": 8371
-    },
-    {
-      "path": "scatter_cmap.eps",
-      "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
-      "size": 36048
-    },
-    {
-      "path": "scatter_cmap.pdf",
-      "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
-      "size": 23357
-    },
-    {
-      "path": "scatter_cmap.png",
-      "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
-      "size": 34752
-    },
-    {
-      "path": "scatter_cmap.svg",
-      "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
-      "size": 21482
-    },
-    {
-      "path": "scatter_edge.eps",
-      "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
-      "size": 26390
-    },
-    {
-      "path": "scatter_edge.pdf",
-      "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
-      "size": 18737
-    },
-    {
-      "path": "scatter_edge.png",
-      "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
-      "size": 47476
-    },
-    {
-      "path": "scatter_edge.svg",
-      "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
-      "size": 16259
-    },
-    {
-      "path": "semilogx.eps",
-      "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
-      "size": 10132
-    },
-    {
-      "path": "semilogx.pdf",
-      "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
-      "size": 6063
-    },
-    {
-      "path": "semilogx.png",
-      "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
-      "size": 22201
-    },
-    {
-      "path": "semilogx.svg",
-      "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
-      "size": 7013
-    },
-    {
-      "path": "semilogy.eps",
-      "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
-      "size": 25097
-    },
-    {
-      "path": "semilogy.pdf",
-      "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
-      "size": 15725
-    },
-    {
-      "path": "semilogy.png",
-      "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
-      "size": 28573
-    },
-    {
-      "path": "semilogy.svg",
-      "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
-      "size": 12650
-    },
-    {
-      "path": "spans.eps",
-      "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
-      "size": 9679
-    },
-    {
-      "path": "spans.pdf",
-      "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
-      "size": 6618
-    },
-    {
-      "path": "spans.png",
-      "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
-      "size": 32647
-    },
-    {
-      "path": "spans.svg",
-      "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
-      "size": 7407
-    },
-    {
-      "path": "stem.eps",
-      "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
-      "size": 8915
-    },
-    {
-      "path": "stem.pdf",
-      "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
-      "size": 6069
-    },
-    {
-      "path": "stem.png",
-      "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
-      "size": 14320
-    },
-    {
-      "path": "stem.svg",
-      "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
-      "size": 5699
-    },
-    {
-      "path": "step.eps",
-      "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
-      "size": 4766
-    },
-    {
-      "path": "step.pdf",
-      "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
-      "size": 3178
-    },
-    {
-      "path": "step.png",
-      "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
-      "size": 13186
-    },
-    {
-      "path": "step.svg",
-      "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
-      "size": 3738
-    },
-    {
-      "path": "streamplot.eps",
-      "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
-      "size": 81375
-    },
-    {
-      "path": "streamplot.pdf",
-      "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
-      "size": 58212
-    },
-    {
-      "path": "streamplot.png",
-      "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
-      "size": 121548
-    },
-    {
-      "path": "streamplot.svg",
-      "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
-      "size": 52950
-    },
-    {
-      "path": "style_ggplot.eps",
-      "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
-      "size": 16495
-    },
-    {
-      "path": "style_ggplot.pdf",
-      "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
-      "size": 11341
-    },
-    {
-      "path": "style_ggplot.png",
-      "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
-      "size": 44679
-    },
-    {
-      "path": "style_ggplot.svg",
-      "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
-      "size": 11595
-    },
-    {
-      "path": "subplots_2x1.eps",
-      "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
-      "size": 21216
-    },
-    {
-      "path": "subplots_2x1.pdf",
-      "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
-      "size": 13468
-    },
-    {
-      "path": "subplots_2x1.png",
-      "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
-      "size": 39291
-    },
-    {
-      "path": "subplots_2x1.svg",
-      "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
-      "size": 15344
-    },
-    {
-      "path": "subplots_2x2.eps",
-      "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
-      "size": 34200
-    },
-    {
-      "path": "subplots_2x2.pdf",
-      "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
-      "size": 21509
-    },
-    {
-      "path": "subplots_2x2.png",
-      "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
-      "size": 51598
-    },
-    {
-      "path": "subplots_2x2.svg",
-      "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
-      "size": 24426
-    },
-    {
-      "path": "subplots_adjust.eps",
-      "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
-      "size": 7016
-    },
-    {
-      "path": "subplots_adjust.pdf",
-      "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
-      "size": 4268
-    },
-    {
-      "path": "subplots_adjust.png",
-      "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
-      "size": 30126
-    },
-    {
-      "path": "subplots_adjust.svg",
-      "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
-      "size": 5528
-    },
-    {
-      "path": "subplots_shared.eps",
-      "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
-      "size": 38590
-    },
-    {
-      "path": "subplots_shared.pdf",
-      "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
-      "size": 25381
-    },
-    {
-      "path": "subplots_shared.png",
-      "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
-      "size": 43211
-    },
-    {
-      "path": "subplots_shared.svg",
-      "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
-      "size": 20390
-    },
-    {
-      "path": "surface3d.eps",
-      "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
-      "size": 291685
-    },
-    {
-      "path": "surface3d.pdf",
-      "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
-      "size": 173038
-    },
-    {
-      "path": "surface3d.png",
-      "sha256": "641b388d9280d1eaae87949e9a5973767eb165ee103332c44cc0884ecde729cf",
-      "size": 86896
-    },
-    {
-      "path": "surface3d.svg",
-      "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
-      "size": 153557
-    },
-    {
-      "path": "surface3d_extra.eps",
-      "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
-      "size": 359363
-    },
-    {
-      "path": "surface3d_extra.pdf",
-      "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
-      "size": 224681
-    },
-    {
-      "path": "surface3d_extra.png",
-      "sha256": "e0296bfcc363b006c82cfe98ae573382718734789d06123d3edb1738d3a1dba9",
-      "size": 109161
-    },
-    {
-      "path": "surface3d_extra.svg",
-      "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
-      "size": 206292
-    },
-    {
-      "path": "symlog.eps",
-      "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
-      "size": 11340
-    },
-    {
-      "path": "symlog.pdf",
-      "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
-      "size": 8163
-    },
-    {
-      "path": "symlog.png",
-      "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
-      "size": 22352
-    },
-    {
-      "path": "symlog.svg",
-      "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
-      "size": 9070
-    },
-    {
-      "path": "table.eps",
-      "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
-      "size": 6280
-    },
-    {
-      "path": "table.pdf",
-      "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
-      "size": 4165
-    },
-    {
-      "path": "table.png",
-      "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
-      "size": 14863
-    },
-    {
-      "path": "table.svg",
-      "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
-      "size": 4641
-    },
-    {
-      "path": "text_annotate.eps",
-      "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
-      "size": 12522
-    },
-    {
-      "path": "text_annotate.pdf",
-      "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
-      "size": 8311
-    },
-    {
-      "path": "text_annotate.png",
-      "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
-      "size": 34868
-    },
-    {
-      "path": "text_annotate.svg",
-      "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
-      "size": 8957
-    },
-    {
-      "path": "text_options.eps",
-      "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
-      "size": 9611
-    },
-    {
-      "path": "text_options.pdf",
-      "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
-      "size": 6578
-    },
-    {
-      "path": "text_options.png",
-      "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
-      "size": 33984
-    },
-    {
-      "path": "text_options.svg",
-      "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
-      "size": 7763
-    },
-    {
-      "path": "tick_locator.eps",
-      "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
-      "size": 13359
-    },
-    {
-      "path": "tick_locator.pdf",
-      "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
-      "size": 9119
-    },
-    {
-      "path": "tick_locator.png",
-      "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
-      "size": 32671
-    },
-    {
-      "path": "tick_locator.svg",
-      "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
-      "size": 10692
-    },
-    {
-      "path": "tick_style.eps",
-      "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
-      "size": 4743
-    },
-    {
-      "path": "tick_style.pdf",
-      "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
-      "size": 3327
-    },
-    {
-      "path": "tick_style.png",
-      "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
-      "size": 27448
-    },
-    {
-      "path": "tick_style.svg",
-      "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
-      "size": 3947
-    },
-    {
-      "path": "ticks_legend.eps",
-      "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
-      "size": 13957
-    },
-    {
-      "path": "ticks_legend.pdf",
-      "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
-      "size": 9476
-    },
-    {
-      "path": "ticks_legend.png",
-      "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
-      "size": 35711
-    },
-    {
-      "path": "ticks_legend.svg",
-      "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
-      "size": 10721
-    },
-    {
-      "path": "tight_layout.eps",
-      "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
-      "size": 9091
-    },
-    {
-      "path": "tight_layout.pdf",
-      "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
-      "size": 5147
-    },
-    {
-      "path": "tight_layout.png",
-      "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
-      "size": 40701
-    },
-    {
-      "path": "tight_layout.svg",
-      "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
-      "size": 7137
-    },
-    {
-      "path": "title_loc.eps",
-      "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
-      "size": 8834
-    },
-    {
-      "path": "title_loc.pdf",
-      "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
-      "size": 6008
-    },
-    {
-      "path": "title_loc.png",
-      "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
-      "size": 28887
-    },
-    {
-      "path": "title_loc.svg",
-      "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
-      "size": 7093
-    },
-    {
-      "path": "transform_axes.eps",
-      "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
-      "size": 8885
-    },
-    {
-      "path": "transform_axes.pdf",
-      "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
-      "size": 6124
-    },
-    {
-      "path": "transform_axes.png",
-      "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
-      "size": 33813
-    },
-    {
-      "path": "transform_axes.svg",
-      "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
-      "size": 7107
-    },
-    {
-      "path": "tricontour.eps",
-      "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
-      "size": 73430
-    },
-    {
-      "path": "tricontour.pdf",
-      "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
-      "size": 46453
-    },
-    {
-      "path": "tricontour.png",
-      "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
-      "size": 82284
-    },
-    {
-      "path": "tricontour.svg",
-      "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
-      "size": 44665
-    },
-    {
-      "path": "tricontourf.eps",
-      "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
-      "size": 196467
-    },
-    {
-      "path": "tricontourf.pdf",
-      "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
-      "size": 120784
-    },
-    {
-      "path": "tricontourf.png",
-      "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
-      "size": 100624
-    },
-    {
-      "path": "tricontourf.svg",
-      "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
-      "size": 89950
-    },
-    {
-      "path": "tripcolor.eps",
-      "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
-      "size": 31920
-    },
-    {
-      "path": "tripcolor.pdf",
-      "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
-      "size": 18630
-    },
-    {
-      "path": "tripcolor.png",
-      "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
-      "size": 55772
-    },
-    {
-      "path": "tripcolor.svg",
-      "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
-      "size": 16074
-    },
-    {
-      "path": "triplot.eps",
-      "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
-      "size": 28434
-    },
-    {
-      "path": "triplot.pdf",
-      "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
-      "size": 19818
-    },
-    {
-      "path": "triplot.png",
-      "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
-      "size": 81306
-    },
-    {
-      "path": "triplot.svg",
-      "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
-      "size": 13460
-    },
-    {
-      "path": "trisurf.eps",
-      "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
-      "size": 42561
-    },
-    {
-      "path": "trisurf.pdf",
-      "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
-      "size": 24733
-    },
-    {
-      "path": "trisurf.png",
-      "sha256": "e22fdf4a34bfeb3ee1a8e2982c5996583355eb15d70e9a2e256b4c404bd64615",
-      "size": 78115
-    },
-    {
-      "path": "trisurf.svg",
-      "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
-      "size": 23721
-    },
-    {
-      "path": "twinx.eps",
-      "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
-      "size": 7293
-    },
-    {
-      "path": "twinx.pdf",
-      "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
-      "size": 4337
-    },
-    {
-      "path": "twinx.png",
-      "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
-      "size": 35700
-    },
-    {
-      "path": "twinx.svg",
-      "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
-      "size": 5886
-    },
-    {
-      "path": "violin_opts.eps",
-      "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
-      "size": 30952
-    },
-    {
-      "path": "violin_opts.pdf",
-      "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
-      "size": 23990
-    },
-    {
-      "path": "violin_opts.png",
-      "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
-      "size": 24826
-    },
-    {
-      "path": "violin_opts.svg",
-      "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
-      "size": 24473
-    },
-    {
-      "path": "violinplot.eps",
-      "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
-      "size": 17583
-    },
-    {
-      "path": "violinplot.pdf",
-      "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
-      "size": 13475
-    },
-    {
-      "path": "violinplot.png",
-      "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
-      "size": 20863
-    },
-    {
-      "path": "violinplot.svg",
-      "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
-      "size": 13823
-    },
-    {
-      "path": "zorder.eps",
-      "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
-      "size": 10414
-    },
-    {
-      "path": "zorder.pdf",
-      "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
-      "size": 6442
-    },
-    {
-      "path": "zorder.png",
-      "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
-      "size": 31537
-    },
-    {
-      "path": "zorder.svg",
-      "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
-      "size": 6551
+  "profiles": {
+    "linux-flang": {
+      "files": [
+        {
+          "path": "alpha.eps",
+          "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+          "size": 80981
+        },
+        {
+          "path": "alpha.pdf",
+          "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+          "size": 58537
+        },
+        {
+          "path": "alpha.png",
+          "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
+          "size": 60468
+        },
+        {
+          "path": "alpha.svg",
+          "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+          "size": 29813
+        },
+        {
+          "path": "anim_sine.gif",
+          "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
+          "size": 146758
+        },
+        {
+          "path": "annotate_arrow.eps",
+          "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+          "size": 9706
+        },
+        {
+          "path": "annotate_arrow.pdf",
+          "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+          "size": 6618
+        },
+        {
+          "path": "annotate_arrow.png",
+          "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
+          "size": 35121
+        },
+        {
+          "path": "annotate_arrow.svg",
+          "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+          "size": 7557
+        },
+        {
+          "path": "annotate_curve.eps",
+          "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+          "size": 9940
+        },
+        {
+          "path": "annotate_curve.pdf",
+          "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+          "size": 6765
+        },
+        {
+          "path": "annotate_curve.png",
+          "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
+          "size": 35035
+        },
+        {
+          "path": "annotate_curve.svg",
+          "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+          "size": 7615
+        },
+        {
+          "path": "axes_facecolor.eps",
+          "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+          "size": 17496
+        },
+        {
+          "path": "axes_facecolor.pdf",
+          "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+          "size": 11466
+        },
+        {
+          "path": "axes_facecolor.png",
+          "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
+          "size": 40471
+        },
+        {
+          "path": "axes_facecolor.svg",
+          "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+          "size": 13174
+        },
+        {
+          "path": "axes_handles2.eps",
+          "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+          "size": 26227
+        },
+        {
+          "path": "axes_handles2.pdf",
+          "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+          "size": 16957
+        },
+        {
+          "path": "axes_handles2.png",
+          "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
+          "size": 32163
+        },
+        {
+          "path": "axes_handles2.svg",
+          "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+          "size": 19863
+        },
+        {
+          "path": "axis_equal.eps",
+          "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+          "size": 8082
+        },
+        {
+          "path": "axis_equal.pdf",
+          "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+          "size": 5385
+        },
+        {
+          "path": "axis_equal.png",
+          "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
+          "size": 18657
+        },
+        {
+          "path": "axis_equal.svg",
+          "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+          "size": 4733
+        },
+        {
+          "path": "bar.eps",
+          "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+          "size": 7532
+        },
+        {
+          "path": "bar.pdf",
+          "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+          "size": 4363
+        },
+        {
+          "path": "bar.png",
+          "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
+          "size": 17029
+        },
+        {
+          "path": "bar.svg",
+          "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+          "size": 5255
+        },
+        {
+          "path": "bar3d.eps",
+          "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+          "size": 34185
+        },
+        {
+          "path": "bar3d.pdf",
+          "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+          "size": 20605
+        },
+        {
+          "path": "bar3d.png",
+          "sha256": "dc3a377149ec13f6051916fef70bf2769f3b5b64faffbe7678d056a59d4d0e86",
+          "size": 57527
+        },
+        {
+          "path": "bar3d.svg",
+          "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+          "size": 20023
+        },
+        {
+          "path": "bar_colors.eps",
+          "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+          "size": 7530
+        },
+        {
+          "path": "bar_colors.pdf",
+          "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+          "size": 4571
+        },
+        {
+          "path": "bar_colors.png",
+          "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
+          "size": 17074
+        },
+        {
+          "path": "bar_colors.svg",
+          "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+          "size": 5449
+        },
+        {
+          "path": "bar_err.eps",
+          "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+          "size": 10265
+        },
+        {
+          "path": "bar_err.pdf",
+          "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+          "size": 5894
+        },
+        {
+          "path": "bar_err.png",
+          "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
+          "size": 16414
+        },
+        {
+          "path": "bar_err.svg",
+          "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+          "size": 7040
+        },
+        {
+          "path": "bar_stacked.eps",
+          "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+          "size": 10296
+        },
+        {
+          "path": "bar_stacked.pdf",
+          "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+          "size": 5771
+        },
+        {
+          "path": "bar_stacked.png",
+          "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
+          "size": 18411
+        },
+        {
+          "path": "bar_stacked.svg",
+          "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+          "size": 6771
+        },
+        {
+          "path": "barh.eps",
+          "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+          "size": 6714
+        },
+        {
+          "path": "barh.pdf",
+          "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+          "size": 4007
+        },
+        {
+          "path": "barh.png",
+          "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
+          "size": 13399
+        },
+        {
+          "path": "barh.svg",
+          "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+          "size": 4634
+        },
+        {
+          "path": "basic_line.eps",
+          "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+          "size": 10559
+        },
+        {
+          "path": "basic_line.pdf",
+          "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+          "size": 7090
+        },
+        {
+          "path": "basic_line.png",
+          "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
+          "size": 27135
+        },
+        {
+          "path": "basic_line.svg",
+          "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+          "size": 7592
+        },
+        {
+          "path": "box_opts.eps",
+          "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+          "size": 12228
+        },
+        {
+          "path": "box_opts.pdf",
+          "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+          "size": 7789
+        },
+        {
+          "path": "box_opts.png",
+          "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+          "size": 19358
+        },
+        {
+          "path": "box_opts.svg",
+          "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+          "size": 8234
+        },
+        {
+          "path": "boxplot.eps",
+          "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+          "size": 7338
+        },
+        {
+          "path": "boxplot.pdf",
+          "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+          "size": 4561
+        },
+        {
+          "path": "boxplot.png",
+          "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+          "size": 14315
+        },
+        {
+          "path": "boxplot.svg",
+          "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+          "size": 5158
+        },
+        {
+          "path": "broken_barh.eps",
+          "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+          "size": 4871
+        },
+        {
+          "path": "broken_barh.pdf",
+          "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+          "size": 3421
+        },
+        {
+          "path": "broken_barh.png",
+          "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
+          "size": 14714
+        },
+        {
+          "path": "broken_barh.svg",
+          "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+          "size": 3619
+        },
+        {
+          "path": "categorical.eps",
+          "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+          "size": 5691
+        },
+        {
+          "path": "categorical.pdf",
+          "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+          "size": 3529
+        },
+        {
+          "path": "categorical.png",
+          "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
+          "size": 17291
+        },
+        {
+          "path": "categorical.svg",
+          "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+          "size": 4113
+        },
+        {
+          "path": "clabel.eps",
+          "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+          "size": 14848
+        },
+        {
+          "path": "clabel.pdf",
+          "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+          "size": 10428
+        },
+        {
+          "path": "clabel.png",
+          "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
+          "size": 62827
+        },
+        {
+          "path": "clabel.svg",
+          "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+          "size": 11171
+        },
+        {
+          "path": "cmap_discrete.eps",
+          "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+          "size": 165754
+        },
+        {
+          "path": "cmap_discrete.pdf",
+          "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+          "size": 6561
+        },
+        {
+          "path": "cmap_discrete.png",
+          "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
+          "size": 17689
+        },
+        {
+          "path": "cmap_discrete.svg",
+          "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+          "size": 9074
+        },
+        {
+          "path": "cmap_lognorm.eps",
+          "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+          "size": 495916
+        },
+        {
+          "path": "cmap_lognorm.pdf",
+          "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+          "size": 13628
+        },
+        {
+          "path": "cmap_lognorm.png",
+          "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
+          "size": 18530
+        },
+        {
+          "path": "cmap_lognorm.svg",
+          "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+          "size": 15377
+        },
+        {
+          "path": "cmap_reversed.eps",
+          "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+          "size": 496738
+        },
+        {
+          "path": "cmap_reversed.pdf",
+          "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+          "size": 14516
+        },
+        {
+          "path": "cmap_reversed.png",
+          "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
+          "size": 19713
+        },
+        {
+          "path": "cmap_reversed.svg",
+          "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+          "size": 15977
+        },
+        {
+          "path": "cmap_special.eps",
+          "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+          "size": 385887
+        },
+        {
+          "path": "cmap_special.pdf",
+          "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+          "size": 8509
+        },
+        {
+          "path": "cmap_special.png",
+          "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
+          "size": 22036
+        },
+        {
+          "path": "cmap_special.svg",
+          "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+          "size": 10971
+        },
+        {
+          "path": "colorbar_orient.eps",
+          "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+          "size": 481251
+        },
+        {
+          "path": "colorbar_orient.pdf",
+          "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+          "size": 24888
+        },
+        {
+          "path": "colorbar_orient.png",
+          "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
+          "size": 23198
+        },
+        {
+          "path": "colorbar_orient.svg",
+          "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+          "size": 25679
+        },
+        {
+          "path": "colors.eps",
+          "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+          "size": 5537
+        },
+        {
+          "path": "colors.pdf",
+          "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+          "size": 3660
+        },
+        {
+          "path": "colors.png",
+          "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
+          "size": 15230
+        },
+        {
+          "path": "colors.svg",
+          "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+          "size": 4189
+        },
+        {
+          "path": "constrained.eps",
+          "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+          "size": 15645
+        },
+        {
+          "path": "constrained.pdf",
+          "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+          "size": 10197
+        },
+        {
+          "path": "constrained.png",
+          "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
+          "size": 46857
+        },
+        {
+          "path": "constrained.svg",
+          "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+          "size": 12564
+        },
+        {
+          "path": "contour.eps",
+          "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+          "size": 12891
+        },
+        {
+          "path": "contour.pdf",
+          "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+          "size": 8839
+        },
+        {
+          "path": "contour.png",
+          "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
+          "size": 65492
+        },
+        {
+          "path": "contour.svg",
+          "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+          "size": 9576
+        },
+        {
+          "path": "contour3d.eps",
+          "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
+          "size": 36513
+        },
+        {
+          "path": "contour3d.pdf",
+          "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
+          "size": 26115
+        },
+        {
+          "path": "contour3d.png",
+          "sha256": "71dd132e75866432b67b2f26f0ae2b8c7bdce5cea15a136a469891b85d702ad9",
+          "size": 94817
+        },
+        {
+          "path": "contour3d.svg",
+          "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
+          "size": 27643
+        },
+        {
+          "path": "contourf.eps",
+          "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+          "size": 148542
+        },
+        {
+          "path": "contourf.pdf",
+          "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+          "size": 88734
+        },
+        {
+          "path": "contourf.png",
+          "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
+          "size": 65324
+        },
+        {
+          "path": "contourf.svg",
+          "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+          "size": 66386
+        },
+        {
+          "path": "dates.eps",
+          "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+          "size": 16170
+        },
+        {
+          "path": "dates.pdf",
+          "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+          "size": 12158
+        },
+        {
+          "path": "dates.png",
+          "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
+          "size": 33847
+        },
+        {
+          "path": "dates.svg",
+          "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+          "size": 13055
+        },
+        {
+          "path": "errorbar.eps",
+          "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+          "size": 18677
+        },
+        {
+          "path": "errorbar.pdf",
+          "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+          "size": 12254
+        },
+        {
+          "path": "errorbar.png",
+          "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
+          "size": 26603
+        },
+        {
+          "path": "errorbar.svg",
+          "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+          "size": 9685
+        },
+        {
+          "path": "errorbar_xy.eps",
+          "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+          "size": 19492
+        },
+        {
+          "path": "errorbar_xy.pdf",
+          "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+          "size": 12891
+        },
+        {
+          "path": "errorbar_xy.png",
+          "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
+          "size": 18310
+        },
+        {
+          "path": "errorbar_xy.svg",
+          "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+          "size": 9803
+        },
+        {
+          "path": "eventplot.eps",
+          "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+          "size": 14362
+        },
+        {
+          "path": "eventplot.pdf",
+          "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+          "size": 8864
+        },
+        {
+          "path": "eventplot.png",
+          "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
+          "size": 19220
+        },
+        {
+          "path": "eventplot.svg",
+          "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+          "size": 8618
+        },
+        {
+          "path": "facecolor.eps",
+          "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+          "size": 12235
+        },
+        {
+          "path": "facecolor.pdf",
+          "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+          "size": 8108
+        },
+        {
+          "path": "facecolor.png",
+          "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+          "size": 32314
+        },
+        {
+          "path": "facecolor.svg",
+          "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+          "size": 8675
+        },
+        {
+          "path": "figlegend.eps",
+          "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+          "size": 15657
+        },
+        {
+          "path": "figlegend.pdf",
+          "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+          "size": 10220
+        },
+        {
+          "path": "figlegend.png",
+          "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
+          "size": 38060
+        },
+        {
+          "path": "figlegend.svg",
+          "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+          "size": 12445
+        },
+        {
+          "path": "figsize.eps",
+          "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+          "size": 10482
+        },
+        {
+          "path": "figsize.pdf",
+          "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+          "size": 7028
+        },
+        {
+          "path": "figsize.png",
+          "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
+          "size": 24009
+        },
+        {
+          "path": "figsize.svg",
+          "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+          "size": 7577
+        },
+        {
+          "path": "figures.eps",
+          "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+          "size": 4606
+        },
+        {
+          "path": "figures.pdf",
+          "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+          "size": 3048
+        },
+        {
+          "path": "figures.png",
+          "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
+          "size": 25900
+        },
+        {
+          "path": "figures.svg",
+          "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+          "size": 3628
+        },
+        {
+          "path": "fill_between.eps",
+          "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+          "size": 18796
+        },
+        {
+          "path": "fill_between.pdf",
+          "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+          "size": 13247
+        },
+        {
+          "path": "fill_between.png",
+          "sha256": "2b0dbdfcc28c43b2c1f5a2262b9a0ac29a3ac37989feb423b5af88030b367415",
+          "size": 39611
+        },
+        {
+          "path": "fill_between.svg",
+          "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+          "size": 13950
+        },
+        {
+          "path": "fill_where.eps",
+          "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
+          "size": 14886
+        },
+        {
+          "path": "fill_where.pdf",
+          "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
+          "size": 10790
+        },
+        {
+          "path": "fill_where.png",
+          "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
+          "size": 33717
+        },
+        {
+          "path": "fill_where.svg",
+          "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
+          "size": 11789
+        },
+        {
+          "path": "fills.eps",
+          "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+          "size": 17109
+        },
+        {
+          "path": "fills.pdf",
+          "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+          "size": 11768
+        },
+        {
+          "path": "fills.png",
+          "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
+          "size": 37226
+        },
+        {
+          "path": "fills.svg",
+          "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+          "size": 13423
+        },
+        {
+          "path": "font_faces.eps",
+          "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+          "size": 9227
+        },
+        {
+          "path": "font_faces.pdf",
+          "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+          "size": 6271
+        },
+        {
+          "path": "font_faces.png",
+          "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
+          "size": 36737
+        },
+        {
+          "path": "font_faces.svg",
+          "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+          "size": 7508
+        },
+        {
+          "path": "fontsize.eps",
+          "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+          "size": 5477
+        },
+        {
+          "path": "fontsize.pdf",
+          "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+          "size": 3444
+        },
+        {
+          "path": "fontsize.png",
+          "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
+          "size": 32705
+        },
+        {
+          "path": "fontsize.svg",
+          "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+          "size": 4266
+        },
+        {
+          "path": "formatters.eps",
+          "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+          "size": 6509
+        },
+        {
+          "path": "formatters.pdf",
+          "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+          "size": 4947
+        },
+        {
+          "path": "formatters.png",
+          "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
+          "size": 29499
+        },
+        {
+          "path": "formatters.svg",
+          "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+          "size": 5254
+        },
+        {
+          "path": "grid_options.eps",
+          "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+          "size": 36975
+        },
+        {
+          "path": "grid_options.pdf",
+          "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+          "size": 23143
+        },
+        {
+          "path": "grid_options.png",
+          "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
+          "size": 63085
+        },
+        {
+          "path": "grid_options.svg",
+          "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+          "size": 25186
+        },
+        {
+          "path": "grid_ratios.eps",
+          "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+          "size": 24813
+        },
+        {
+          "path": "grid_ratios.pdf",
+          "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+          "size": 16526
+        },
+        {
+          "path": "grid_ratios.png",
+          "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
+          "size": 40356
+        },
+        {
+          "path": "grid_ratios.svg",
+          "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+          "size": 19980
+        },
+        {
+          "path": "gridspec.eps",
+          "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+          "size": 20006
+        },
+        {
+          "path": "gridspec.pdf",
+          "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+          "size": 13384
+        },
+        {
+          "path": "gridspec.png",
+          "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
+          "size": 38342
+        },
+        {
+          "path": "gridspec.svg",
+          "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+          "size": 16082
+        },
+        {
+          "path": "hatch.eps",
+          "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+          "size": 43560
+        },
+        {
+          "path": "hatch.pdf",
+          "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+          "size": 26971
+        },
+        {
+          "path": "hatch.png",
+          "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
+          "size": 42010
+        },
+        {
+          "path": "hatch.svg",
+          "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+          "size": 26350
+        },
+        {
+          "path": "hexbin.eps",
+          "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+          "size": 75718
+        },
+        {
+          "path": "hexbin.pdf",
+          "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+          "size": 54711
+        },
+        {
+          "path": "hexbin.png",
+          "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
+          "size": 87042
+        },
+        {
+          "path": "hexbin.svg",
+          "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+          "size": 44436
+        },
+        {
+          "path": "hist.eps",
+          "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+          "size": 8501
+        },
+        {
+          "path": "hist.pdf",
+          "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+          "size": 4854
+        },
+        {
+          "path": "hist.png",
+          "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
+          "size": 20119
+        },
+        {
+          "path": "hist.svg",
+          "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+          "size": 5634
+        },
+        {
+          "path": "hist2d.eps",
+          "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+          "size": 31502
+        },
+        {
+          "path": "hist2d.pdf",
+          "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+          "size": 17621
+        },
+        {
+          "path": "hist2d.png",
+          "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
+          "size": 20491
+        },
+        {
+          "path": "hist2d.svg",
+          "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+          "size": 14830
+        },
+        {
+          "path": "hist_bins.eps",
+          "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+          "size": 6748
+        },
+        {
+          "path": "hist_bins.pdf",
+          "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+          "size": 4027
+        },
+        {
+          "path": "hist_bins.png",
+          "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
+          "size": 17959
+        },
+        {
+          "path": "hist_bins.svg",
+          "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+          "size": 4773
+        },
+        {
+          "path": "hist_opts.eps",
+          "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+          "size": 9129
+        },
+        {
+          "path": "hist_opts.pdf",
+          "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+          "size": 5639
+        },
+        {
+          "path": "hist_opts.png",
+          "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
+          "size": 19359
+        },
+        {
+          "path": "hist_opts.svg",
+          "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+          "size": 5852
+        },
+        {
+          "path": "hist_orient.eps",
+          "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+          "size": 21335
+        },
+        {
+          "path": "hist_orient.pdf",
+          "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+          "size": 11396
+        },
+        {
+          "path": "hist_orient.png",
+          "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
+          "size": 24932
+        },
+        {
+          "path": "hist_orient.svg",
+          "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+          "size": 13132
+        },
+        {
+          "path": "hist_stacked.eps",
+          "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+          "size": 12928
+        },
+        {
+          "path": "hist_stacked.pdf",
+          "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+          "size": 7090
+        },
+        {
+          "path": "hist_stacked.png",
+          "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
+          "size": 23306
+        },
+        {
+          "path": "hist_stacked.svg",
+          "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+          "size": 8591
+        },
+        {
+          "path": "hv_lines.eps",
+          "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+          "size": 13110
+        },
+        {
+          "path": "hv_lines.pdf",
+          "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+          "size": 8518
+        },
+        {
+          "path": "hv_lines.png",
+          "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
+          "size": 36338
+        },
+        {
+          "path": "hv_lines.svg",
+          "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+          "size": 9248
+        },
+        {
+          "path": "imshow.eps",
+          "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+          "size": 417463
+        },
+        {
+          "path": "imshow.pdf",
+          "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+          "size": 6278
+        },
+        {
+          "path": "imshow.png",
+          "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
+          "size": 15228
+        },
+        {
+          "path": "imshow.svg",
+          "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+          "size": 8275
+        },
+        {
+          "path": "imshow_cbar.eps",
+          "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+          "size": 272389
+        },
+        {
+          "path": "imshow_cbar.pdf",
+          "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+          "size": 13336
+        },
+        {
+          "path": "imshow_cbar.png",
+          "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
+          "size": 24453
+        },
+        {
+          "path": "imshow_cbar.svg",
+          "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+          "size": 14287
+        },
+        {
+          "path": "imshow_log.eps",
+          "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+          "size": 33713
+        },
+        {
+          "path": "imshow_log.pdf",
+          "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+          "size": 18741
+        },
+        {
+          "path": "imshow_log.png",
+          "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
+          "size": 19144
+        },
+        {
+          "path": "imshow_log.svg",
+          "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+          "size": 17077
+        },
+        {
+          "path": "imshow_rgb.eps",
+          "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+          "size": 530576
+        },
+        {
+          "path": "imshow_rgb.pdf",
+          "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+          "size": 6334
+        },
+        {
+          "path": "imshow_rgb.png",
+          "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
+          "size": 16457
+        },
+        {
+          "path": "imshow_rgb.svg",
+          "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+          "size": 7768
+        },
+        {
+          "path": "inset.eps",
+          "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+          "size": 16312
+        },
+        {
+          "path": "inset.pdf",
+          "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+          "size": 10519
+        },
+        {
+          "path": "inset.png",
+          "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
+          "size": 36630
+        },
+        {
+          "path": "inset.svg",
+          "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+          "size": 12927
+        },
+        {
+          "path": "interp.eps",
+          "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+          "size": 394292
+        },
+        {
+          "path": "interp.pdf",
+          "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+          "size": 28040
+        },
+        {
+          "path": "interp.png",
+          "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
+          "size": 62490
+        },
+        {
+          "path": "interp.svg",
+          "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+          "size": 50239
+        },
+        {
+          "path": "invert_axes.eps",
+          "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+          "size": 8720
+        },
+        {
+          "path": "invert_axes.pdf",
+          "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+          "size": 6008
+        },
+        {
+          "path": "invert_axes.png",
+          "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
+          "size": 31964
+        },
+        {
+          "path": "invert_axes.svg",
+          "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+          "size": 6957
+        },
+        {
+          "path": "legend_labels.eps",
+          "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
+          "size": 15431
+        },
+        {
+          "path": "legend_labels.pdf",
+          "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
+          "size": 11163
+        },
+        {
+          "path": "legend_labels.png",
+          "sha256": "e92c4d496445bd933dc3afcbcb7393d0b3ad28d013fc06ee59ecdc512ad60746",
+          "size": 50734
+        },
+        {
+          "path": "legend_labels.svg",
+          "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
+          "size": 12229
+        },
+        {
+          "path": "legend_opts.eps",
+          "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+          "size": 7371
+        },
+        {
+          "path": "legend_opts.pdf",
+          "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+          "size": 4574
+        },
+        {
+          "path": "legend_opts.png",
+          "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
+          "size": 44992
+        },
+        {
+          "path": "legend_opts.svg",
+          "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+          "size": 5558
+        },
+        {
+          "path": "line3d.eps",
+          "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+          "size": 18473
+        },
+        {
+          "path": "line3d.pdf",
+          "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+          "size": 13089
+        },
+        {
+          "path": "line3d.png",
+          "sha256": "a96fbd35f6633ff3985f0786345908f145d93d06c30213858b8fb8fab0a007d0",
+          "size": 67870
+        },
+        {
+          "path": "line3d.svg",
+          "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+          "size": 13293
+        },
+        {
+          "path": "log_minor_labels.eps",
+          "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+          "size": 8625
+        },
+        {
+          "path": "log_minor_labels.pdf",
+          "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+          "size": 5528
+        },
+        {
+          "path": "log_minor_labels.png",
+          "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+          "size": 23529
+        },
+        {
+          "path": "log_minor_labels.svg",
+          "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+          "size": 6874
+        },
+        {
+          "path": "loglog.eps",
+          "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+          "size": 14649
+        },
+        {
+          "path": "loglog.pdf",
+          "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+          "size": 8171
+        },
+        {
+          "path": "loglog.png",
+          "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
+          "size": 25190
+        },
+        {
+          "path": "loglog.svg",
+          "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+          "size": 10116
+        },
+        {
+          "path": "many_series.eps",
+          "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+          "size": 126003
+        },
+        {
+          "path": "many_series.pdf",
+          "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+          "size": 100906
+        },
+        {
+          "path": "many_series.png",
+          "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
+          "size": 286478
+        },
+        {
+          "path": "many_series.svg",
+          "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+          "size": 101725
+        },
+        {
+          "path": "margins.eps",
+          "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+          "size": 17663
+        },
+        {
+          "path": "margins.pdf",
+          "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+          "size": 12271
+        },
+        {
+          "path": "margins.png",
+          "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
+          "size": 42437
+        },
+        {
+          "path": "margins.svg",
+          "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+          "size": 14135
+        },
+        {
+          "path": "marker_detail.eps",
+          "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+          "size": 18574
+        },
+        {
+          "path": "marker_detail.pdf",
+          "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+          "size": 13643
+        },
+        {
+          "path": "marker_detail.png",
+          "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
+          "size": 34522
+        },
+        {
+          "path": "marker_detail.svg",
+          "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+          "size": 10883
+        },
+        {
+          "path": "markers_gallery.eps",
+          "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+          "size": 23435
+        },
+        {
+          "path": "markers_gallery.pdf",
+          "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+          "size": 16547
+        },
+        {
+          "path": "markers_gallery.png",
+          "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
+          "size": 22165
+        },
+        {
+          "path": "markers_gallery.svg",
+          "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+          "size": 10058
+        },
+        {
+          "path": "markers_only.eps",
+          "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+          "size": 30048
+        },
+        {
+          "path": "markers_only.pdf",
+          "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+          "size": 21481
+        },
+        {
+          "path": "markers_only.png",
+          "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
+          "size": 30486
+        },
+        {
+          "path": "markers_only.svg",
+          "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+          "size": 11142
+        },
+        {
+          "path": "mathtext.eps",
+          "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+          "size": 10620
+        },
+        {
+          "path": "mathtext.pdf",
+          "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+          "size": 6839
+        },
+        {
+          "path": "mathtext.png",
+          "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
+          "size": 32840
+        },
+        {
+          "path": "mathtext.svg",
+          "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+          "size": 8901
+        },
+        {
+          "path": "mathtext_frac.eps",
+          "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+          "size": 16086
+        },
+        {
+          "path": "mathtext_frac.pdf",
+          "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+          "size": 11400
+        },
+        {
+          "path": "mathtext_frac.png",
+          "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
+          "size": 32506
+        },
+        {
+          "path": "mathtext_frac.svg",
+          "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+          "size": 9515
+        },
+        {
+          "path": "matshow.eps",
+          "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+          "size": 447767
+        },
+        {
+          "path": "matshow.pdf",
+          "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+          "size": 5415
+        },
+        {
+          "path": "matshow.png",
+          "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
+          "size": 12239
+        },
+        {
+          "path": "matshow.svg",
+          "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+          "size": 7206
+        },
+        {
+          "path": "mosaic.eps",
+          "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+          "size": 19753
+        },
+        {
+          "path": "mosaic.pdf",
+          "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+          "size": 13130
+        },
+        {
+          "path": "mosaic.png",
+          "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
+          "size": 37933
+        },
+        {
+          "path": "mosaic.svg",
+          "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+          "size": 15857
+        },
+        {
+          "path": "multi_style.eps",
+          "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+          "size": 107472
+        },
+        {
+          "path": "multi_style.pdf",
+          "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+          "size": 81820
+        },
+        {
+          "path": "multi_style.png",
+          "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
+          "size": 47468
+        },
+        {
+          "path": "multi_style.svg",
+          "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+          "size": 28914
+        },
+        {
+          "path": "nan_gap.eps",
+          "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+          "size": 27755
+        },
+        {
+          "path": "nan_gap.pdf",
+          "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+          "size": 19760
+        },
+        {
+          "path": "nan_gap.png",
+          "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
+          "size": 34425
+        },
+        {
+          "path": "nan_gap.svg",
+          "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+          "size": 11312
+        },
+        {
+          "path": "norms.eps",
+          "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+          "size": 236860
+        },
+        {
+          "path": "norms.pdf",
+          "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+          "size": 9153
+        },
+        {
+          "path": "norms.png",
+          "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
+          "size": 21488
+        },
+        {
+          "path": "norms.svg",
+          "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+          "size": 12345
+        },
+        {
+          "path": "offset_text.eps",
+          "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+          "size": 8853
+        },
+        {
+          "path": "offset_text.pdf",
+          "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+          "size": 6025
+        },
+        {
+          "path": "offset_text.png",
+          "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
+          "size": 31008
+        },
+        {
+          "path": "offset_text.svg",
+          "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+          "size": 7054
+        },
+        {
+          "path": "patches.eps",
+          "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+          "size": 9242
+        },
+        {
+          "path": "patches.pdf",
+          "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+          "size": 6797
+        },
+        {
+          "path": "patches.png",
+          "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
+          "size": 25198
+        },
+        {
+          "path": "patches.svg",
+          "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+          "size": 7157
+        },
+        {
+          "path": "patches_path.eps",
+          "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+          "size": 5626
+        },
+        {
+          "path": "patches_path.pdf",
+          "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+          "size": 3692
+        },
+        {
+          "path": "patches_path.png",
+          "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
+          "size": 30023
+        },
+        {
+          "path": "patches_path.svg",
+          "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+          "size": 4249
+        },
+        {
+          "path": "pcolormesh.eps",
+          "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+          "size": 44989
+        },
+        {
+          "path": "pcolormesh.pdf",
+          "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+          "size": 25245
+        },
+        {
+          "path": "pcolormesh.png",
+          "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
+          "size": 21262
+        },
+        {
+          "path": "pcolormesh.svg",
+          "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+          "size": 21696
+        },
+        {
+          "path": "pie.eps",
+          "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+          "size": 2987
+        },
+        {
+          "path": "pie.pdf",
+          "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+          "size": 2936
+        },
+        {
+          "path": "pie.png",
+          "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+          "size": 23571
+        },
+        {
+          "path": "pie.svg",
+          "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+          "size": 2476
+        },
+        {
+          "path": "pie_opts.eps",
+          "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+          "size": 3945
+        },
+        {
+          "path": "pie_opts.pdf",
+          "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+          "size": 3612
+        },
+        {
+          "path": "pie_opts.png",
+          "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+          "size": 32364
+        },
+        {
+          "path": "pie_opts.svg",
+          "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+          "size": 3469
+        },
+        {
+          "path": "plot_y.eps",
+          "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+          "size": 64767
+        },
+        {
+          "path": "plot_y.pdf",
+          "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+          "size": 47987
+        },
+        {
+          "path": "plot_y.png",
+          "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
+          "size": 40207
+        },
+        {
+          "path": "plot_y.svg",
+          "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+          "size": 19461
+        },
+        {
+          "path": "polar.eps",
+          "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+          "size": 54459
+        },
+        {
+          "path": "polar.pdf",
+          "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+          "size": 43857
+        },
+        {
+          "path": "polar.png",
+          "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+          "size": 72845
+        },
+        {
+          "path": "polar.svg",
+          "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+          "size": 44319
+        },
+        {
+          "path": "quiver.eps",
+          "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+          "size": 24007
+        },
+        {
+          "path": "quiver.pdf",
+          "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+          "size": 17046
+        },
+        {
+          "path": "quiver.png",
+          "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
+          "size": 39122
+        },
+        {
+          "path": "quiver.svg",
+          "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+          "size": 16554
+        },
+        {
+          "path": "quiver3d.eps",
+          "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+          "size": 16864
+        },
+        {
+          "path": "quiver3d.pdf",
+          "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+          "size": 10205
+        },
+        {
+          "path": "quiver3d.png",
+          "sha256": "98e9828aa3f73ecf38e797cfa0c838f907ad19a05ce27d9030a3a3ba464c0935",
+          "size": 83816
+        },
+        {
+          "path": "quiver3d.svg",
+          "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+          "size": 11387
+        },
+        {
+          "path": "savefig_tight.eps",
+          "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+          "size": 4931
+        },
+        {
+          "path": "savefig_tight.pdf",
+          "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+          "size": 3211
+        },
+        {
+          "path": "savefig_tight.png",
+          "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+          "size": 68856
+        },
+        {
+          "path": "savefig_tight.svg",
+          "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+          "size": 3941
+        },
+        {
+          "path": "scatter.eps",
+          "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+          "size": 23854
+        },
+        {
+          "path": "scatter.pdf",
+          "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+          "size": 17031
+        },
+        {
+          "path": "scatter.png",
+          "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
+          "size": 24876
+        },
+        {
+          "path": "scatter.svg",
+          "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+          "size": 8371
+        },
+        {
+          "path": "scatter_cmap.eps",
+          "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+          "size": 36048
+        },
+        {
+          "path": "scatter_cmap.pdf",
+          "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+          "size": 23357
+        },
+        {
+          "path": "scatter_cmap.png",
+          "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
+          "size": 34752
+        },
+        {
+          "path": "scatter_cmap.svg",
+          "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+          "size": 21482
+        },
+        {
+          "path": "scatter_edge.eps",
+          "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+          "size": 26390
+        },
+        {
+          "path": "scatter_edge.pdf",
+          "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+          "size": 18737
+        },
+        {
+          "path": "scatter_edge.png",
+          "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
+          "size": 47476
+        },
+        {
+          "path": "scatter_edge.svg",
+          "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+          "size": 16259
+        },
+        {
+          "path": "semilogx.eps",
+          "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+          "size": 10132
+        },
+        {
+          "path": "semilogx.pdf",
+          "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+          "size": 6063
+        },
+        {
+          "path": "semilogx.png",
+          "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
+          "size": 22201
+        },
+        {
+          "path": "semilogx.svg",
+          "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+          "size": 7013
+        },
+        {
+          "path": "semilogy.eps",
+          "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+          "size": 25097
+        },
+        {
+          "path": "semilogy.pdf",
+          "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+          "size": 15725
+        },
+        {
+          "path": "semilogy.png",
+          "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
+          "size": 28573
+        },
+        {
+          "path": "semilogy.svg",
+          "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+          "size": 12650
+        },
+        {
+          "path": "spans.eps",
+          "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+          "size": 9679
+        },
+        {
+          "path": "spans.pdf",
+          "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+          "size": 6618
+        },
+        {
+          "path": "spans.png",
+          "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
+          "size": 32647
+        },
+        {
+          "path": "spans.svg",
+          "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+          "size": 7407
+        },
+        {
+          "path": "stem.eps",
+          "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+          "size": 8915
+        },
+        {
+          "path": "stem.pdf",
+          "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+          "size": 6069
+        },
+        {
+          "path": "stem.png",
+          "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
+          "size": 14320
+        },
+        {
+          "path": "stem.svg",
+          "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+          "size": 5699
+        },
+        {
+          "path": "step.eps",
+          "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+          "size": 4766
+        },
+        {
+          "path": "step.pdf",
+          "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+          "size": 3178
+        },
+        {
+          "path": "step.png",
+          "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
+          "size": 13186
+        },
+        {
+          "path": "step.svg",
+          "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+          "size": 3738
+        },
+        {
+          "path": "streamplot.eps",
+          "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+          "size": 81375
+        },
+        {
+          "path": "streamplot.pdf",
+          "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+          "size": 58212
+        },
+        {
+          "path": "streamplot.png",
+          "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
+          "size": 121548
+        },
+        {
+          "path": "streamplot.svg",
+          "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+          "size": 52950
+        },
+        {
+          "path": "style_ggplot.eps",
+          "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+          "size": 16495
+        },
+        {
+          "path": "style_ggplot.pdf",
+          "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+          "size": 11341
+        },
+        {
+          "path": "style_ggplot.png",
+          "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+          "size": 44679
+        },
+        {
+          "path": "style_ggplot.svg",
+          "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+          "size": 11595
+        },
+        {
+          "path": "subplots_2x1.eps",
+          "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+          "size": 21216
+        },
+        {
+          "path": "subplots_2x1.pdf",
+          "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+          "size": 13468
+        },
+        {
+          "path": "subplots_2x1.png",
+          "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
+          "size": 39291
+        },
+        {
+          "path": "subplots_2x1.svg",
+          "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+          "size": 15344
+        },
+        {
+          "path": "subplots_2x2.eps",
+          "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+          "size": 34200
+        },
+        {
+          "path": "subplots_2x2.pdf",
+          "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+          "size": 21509
+        },
+        {
+          "path": "subplots_2x2.png",
+          "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
+          "size": 51598
+        },
+        {
+          "path": "subplots_2x2.svg",
+          "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+          "size": 24426
+        },
+        {
+          "path": "subplots_adjust.eps",
+          "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+          "size": 7016
+        },
+        {
+          "path": "subplots_adjust.pdf",
+          "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+          "size": 4268
+        },
+        {
+          "path": "subplots_adjust.png",
+          "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+          "size": 30126
+        },
+        {
+          "path": "subplots_adjust.svg",
+          "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+          "size": 5528
+        },
+        {
+          "path": "subplots_shared.eps",
+          "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+          "size": 38590
+        },
+        {
+          "path": "subplots_shared.pdf",
+          "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+          "size": 25381
+        },
+        {
+          "path": "subplots_shared.png",
+          "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
+          "size": 43211
+        },
+        {
+          "path": "subplots_shared.svg",
+          "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+          "size": 20390
+        },
+        {
+          "path": "surface3d.eps",
+          "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+          "size": 291685
+        },
+        {
+          "path": "surface3d.pdf",
+          "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+          "size": 173038
+        },
+        {
+          "path": "surface3d.png",
+          "sha256": "36c84e5488b7710c407b2d60d99f66befe41dfb9e1fad02f5c65716652c1a32c",
+          "size": 86896
+        },
+        {
+          "path": "surface3d.svg",
+          "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+          "size": 153557
+        },
+        {
+          "path": "surface3d_extra.eps",
+          "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+          "size": 359363
+        },
+        {
+          "path": "surface3d_extra.pdf",
+          "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+          "size": 224681
+        },
+        {
+          "path": "surface3d_extra.png",
+          "sha256": "7fd904babec4b4ce32367a0cd29c3a8808fa240f1d493ce24d09fde5da68dc52",
+          "size": 109161
+        },
+        {
+          "path": "surface3d_extra.svg",
+          "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+          "size": 206292
+        },
+        {
+          "path": "symlog.eps",
+          "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+          "size": 11340
+        },
+        {
+          "path": "symlog.pdf",
+          "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+          "size": 8163
+        },
+        {
+          "path": "symlog.png",
+          "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
+          "size": 22352
+        },
+        {
+          "path": "symlog.svg",
+          "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+          "size": 9070
+        },
+        {
+          "path": "table.eps",
+          "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
+          "size": 6280
+        },
+        {
+          "path": "table.pdf",
+          "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
+          "size": 4165
+        },
+        {
+          "path": "table.png",
+          "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+          "size": 14863
+        },
+        {
+          "path": "table.svg",
+          "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
+          "size": 4641
+        },
+        {
+          "path": "text_annotate.eps",
+          "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+          "size": 12522
+        },
+        {
+          "path": "text_annotate.pdf",
+          "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+          "size": 8311
+        },
+        {
+          "path": "text_annotate.png",
+          "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
+          "size": 34868
+        },
+        {
+          "path": "text_annotate.svg",
+          "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+          "size": 8957
+        },
+        {
+          "path": "text_options.eps",
+          "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+          "size": 9611
+        },
+        {
+          "path": "text_options.pdf",
+          "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+          "size": 6578
+        },
+        {
+          "path": "text_options.png",
+          "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
+          "size": 33984
+        },
+        {
+          "path": "text_options.svg",
+          "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+          "size": 7763
+        },
+        {
+          "path": "tick_locator.eps",
+          "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+          "size": 13359
+        },
+        {
+          "path": "tick_locator.pdf",
+          "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+          "size": 9119
+        },
+        {
+          "path": "tick_locator.png",
+          "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+          "size": 32671
+        },
+        {
+          "path": "tick_locator.svg",
+          "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+          "size": 10692
+        },
+        {
+          "path": "tick_style.eps",
+          "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+          "size": 4743
+        },
+        {
+          "path": "tick_style.pdf",
+          "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+          "size": 3327
+        },
+        {
+          "path": "tick_style.png",
+          "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
+          "size": 27448
+        },
+        {
+          "path": "tick_style.svg",
+          "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+          "size": 3947
+        },
+        {
+          "path": "ticks_legend.eps",
+          "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+          "size": 13957
+        },
+        {
+          "path": "ticks_legend.pdf",
+          "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+          "size": 9476
+        },
+        {
+          "path": "ticks_legend.png",
+          "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+          "size": 35711
+        },
+        {
+          "path": "ticks_legend.svg",
+          "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+          "size": 10721
+        },
+        {
+          "path": "tight_layout.eps",
+          "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+          "size": 9091
+        },
+        {
+          "path": "tight_layout.pdf",
+          "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+          "size": 5147
+        },
+        {
+          "path": "tight_layout.png",
+          "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
+          "size": 40701
+        },
+        {
+          "path": "tight_layout.svg",
+          "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+          "size": 7137
+        },
+        {
+          "path": "title_loc.eps",
+          "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+          "size": 8834
+        },
+        {
+          "path": "title_loc.pdf",
+          "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+          "size": 6008
+        },
+        {
+          "path": "title_loc.png",
+          "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
+          "size": 28887
+        },
+        {
+          "path": "title_loc.svg",
+          "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+          "size": 7093
+        },
+        {
+          "path": "transform_axes.eps",
+          "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+          "size": 8885
+        },
+        {
+          "path": "transform_axes.pdf",
+          "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+          "size": 6124
+        },
+        {
+          "path": "transform_axes.png",
+          "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
+          "size": 33813
+        },
+        {
+          "path": "transform_axes.svg",
+          "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+          "size": 7107
+        },
+        {
+          "path": "tricontour.eps",
+          "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+          "size": 73430
+        },
+        {
+          "path": "tricontour.pdf",
+          "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+          "size": 46453
+        },
+        {
+          "path": "tricontour.png",
+          "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
+          "size": 82284
+        },
+        {
+          "path": "tricontour.svg",
+          "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+          "size": 44665
+        },
+        {
+          "path": "tricontourf.eps",
+          "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+          "size": 196467
+        },
+        {
+          "path": "tricontourf.pdf",
+          "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+          "size": 120784
+        },
+        {
+          "path": "tricontourf.png",
+          "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
+          "size": 100624
+        },
+        {
+          "path": "tricontourf.svg",
+          "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+          "size": 89950
+        },
+        {
+          "path": "tripcolor.eps",
+          "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+          "size": 31920
+        },
+        {
+          "path": "tripcolor.pdf",
+          "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+          "size": 18630
+        },
+        {
+          "path": "tripcolor.png",
+          "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
+          "size": 55772
+        },
+        {
+          "path": "tripcolor.svg",
+          "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+          "size": 16074
+        },
+        {
+          "path": "triplot.eps",
+          "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+          "size": 28434
+        },
+        {
+          "path": "triplot.pdf",
+          "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+          "size": 19818
+        },
+        {
+          "path": "triplot.png",
+          "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
+          "size": 81306
+        },
+        {
+          "path": "triplot.svg",
+          "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+          "size": 13460
+        },
+        {
+          "path": "trisurf.eps",
+          "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+          "size": 42561
+        },
+        {
+          "path": "trisurf.pdf",
+          "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+          "size": 24733
+        },
+        {
+          "path": "trisurf.png",
+          "sha256": "2a5e99c7e4afff663b23dc5ce2176c41b27be090485c64699315d16f8291a087",
+          "size": 78115
+        },
+        {
+          "path": "trisurf.svg",
+          "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+          "size": 23721
+        },
+        {
+          "path": "twinx.eps",
+          "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+          "size": 7293
+        },
+        {
+          "path": "twinx.pdf",
+          "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+          "size": 4337
+        },
+        {
+          "path": "twinx.png",
+          "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
+          "size": 35700
+        },
+        {
+          "path": "twinx.svg",
+          "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+          "size": 5886
+        },
+        {
+          "path": "violin_opts.eps",
+          "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+          "size": 30952
+        },
+        {
+          "path": "violin_opts.pdf",
+          "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+          "size": 23990
+        },
+        {
+          "path": "violin_opts.png",
+          "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
+          "size": 24826
+        },
+        {
+          "path": "violin_opts.svg",
+          "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+          "size": 24473
+        },
+        {
+          "path": "violinplot.eps",
+          "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+          "size": 17583
+        },
+        {
+          "path": "violinplot.pdf",
+          "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+          "size": 13475
+        },
+        {
+          "path": "violinplot.png",
+          "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
+          "size": 20863
+        },
+        {
+          "path": "violinplot.svg",
+          "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+          "size": 13823
+        },
+        {
+          "path": "zorder.eps",
+          "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+          "size": 10414
+        },
+        {
+          "path": "zorder.pdf",
+          "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+          "size": 6442
+        },
+        {
+          "path": "zorder.png",
+          "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
+          "size": 31537
+        },
+        {
+          "path": "zorder.svg",
+          "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+          "size": 6551
+        }
+      ],
+      "generated_from": "tests/out"
+    },
+    "linux-gfortran": {
+      "files": [
+        {
+          "path": "alpha.eps",
+          "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+          "size": 80981
+        },
+        {
+          "path": "alpha.pdf",
+          "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+          "size": 58537
+        },
+        {
+          "path": "alpha.png",
+          "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
+          "size": 60468
+        },
+        {
+          "path": "alpha.svg",
+          "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+          "size": 29813
+        },
+        {
+          "path": "anim_sine.gif",
+          "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
+          "size": 146758
+        },
+        {
+          "path": "annotate_arrow.eps",
+          "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+          "size": 9706
+        },
+        {
+          "path": "annotate_arrow.pdf",
+          "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+          "size": 6618
+        },
+        {
+          "path": "annotate_arrow.png",
+          "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
+          "size": 35121
+        },
+        {
+          "path": "annotate_arrow.svg",
+          "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+          "size": 7557
+        },
+        {
+          "path": "annotate_curve.eps",
+          "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+          "size": 9940
+        },
+        {
+          "path": "annotate_curve.pdf",
+          "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+          "size": 6765
+        },
+        {
+          "path": "annotate_curve.png",
+          "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
+          "size": 35035
+        },
+        {
+          "path": "annotate_curve.svg",
+          "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+          "size": 7615
+        },
+        {
+          "path": "axes_facecolor.eps",
+          "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+          "size": 17496
+        },
+        {
+          "path": "axes_facecolor.pdf",
+          "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+          "size": 11466
+        },
+        {
+          "path": "axes_facecolor.png",
+          "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
+          "size": 40471
+        },
+        {
+          "path": "axes_facecolor.svg",
+          "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+          "size": 13174
+        },
+        {
+          "path": "axes_handles2.eps",
+          "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+          "size": 26227
+        },
+        {
+          "path": "axes_handles2.pdf",
+          "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+          "size": 16957
+        },
+        {
+          "path": "axes_handles2.png",
+          "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
+          "size": 32163
+        },
+        {
+          "path": "axes_handles2.svg",
+          "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+          "size": 19863
+        },
+        {
+          "path": "axis_equal.eps",
+          "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+          "size": 8082
+        },
+        {
+          "path": "axis_equal.pdf",
+          "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+          "size": 5385
+        },
+        {
+          "path": "axis_equal.png",
+          "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
+          "size": 18657
+        },
+        {
+          "path": "axis_equal.svg",
+          "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+          "size": 4733
+        },
+        {
+          "path": "bar.eps",
+          "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+          "size": 7532
+        },
+        {
+          "path": "bar.pdf",
+          "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+          "size": 4363
+        },
+        {
+          "path": "bar.png",
+          "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
+          "size": 17029
+        },
+        {
+          "path": "bar.svg",
+          "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+          "size": 5255
+        },
+        {
+          "path": "bar3d.eps",
+          "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+          "size": 34185
+        },
+        {
+          "path": "bar3d.pdf",
+          "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+          "size": 20605
+        },
+        {
+          "path": "bar3d.png",
+          "sha256": "98e25a939fb6602ec8e51ff3a5e781cc5507572b5b929aebb2f03f261e44361e",
+          "size": 57527
+        },
+        {
+          "path": "bar3d.svg",
+          "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+          "size": 20023
+        },
+        {
+          "path": "bar_colors.eps",
+          "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+          "size": 7530
+        },
+        {
+          "path": "bar_colors.pdf",
+          "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+          "size": 4571
+        },
+        {
+          "path": "bar_colors.png",
+          "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
+          "size": 17074
+        },
+        {
+          "path": "bar_colors.svg",
+          "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+          "size": 5449
+        },
+        {
+          "path": "bar_err.eps",
+          "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+          "size": 10265
+        },
+        {
+          "path": "bar_err.pdf",
+          "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+          "size": 5894
+        },
+        {
+          "path": "bar_err.png",
+          "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
+          "size": 16414
+        },
+        {
+          "path": "bar_err.svg",
+          "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+          "size": 7040
+        },
+        {
+          "path": "bar_stacked.eps",
+          "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+          "size": 10296
+        },
+        {
+          "path": "bar_stacked.pdf",
+          "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+          "size": 5771
+        },
+        {
+          "path": "bar_stacked.png",
+          "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
+          "size": 18411
+        },
+        {
+          "path": "bar_stacked.svg",
+          "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+          "size": 6771
+        },
+        {
+          "path": "barh.eps",
+          "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+          "size": 6714
+        },
+        {
+          "path": "barh.pdf",
+          "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+          "size": 4007
+        },
+        {
+          "path": "barh.png",
+          "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
+          "size": 13399
+        },
+        {
+          "path": "barh.svg",
+          "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+          "size": 4634
+        },
+        {
+          "path": "basic_line.eps",
+          "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+          "size": 10559
+        },
+        {
+          "path": "basic_line.pdf",
+          "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+          "size": 7090
+        },
+        {
+          "path": "basic_line.png",
+          "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
+          "size": 27135
+        },
+        {
+          "path": "basic_line.svg",
+          "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+          "size": 7592
+        },
+        {
+          "path": "box_opts.eps",
+          "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+          "size": 12228
+        },
+        {
+          "path": "box_opts.pdf",
+          "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+          "size": 7789
+        },
+        {
+          "path": "box_opts.png",
+          "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+          "size": 19358
+        },
+        {
+          "path": "box_opts.svg",
+          "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+          "size": 8234
+        },
+        {
+          "path": "boxplot.eps",
+          "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+          "size": 7338
+        },
+        {
+          "path": "boxplot.pdf",
+          "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+          "size": 4561
+        },
+        {
+          "path": "boxplot.png",
+          "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+          "size": 14315
+        },
+        {
+          "path": "boxplot.svg",
+          "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+          "size": 5158
+        },
+        {
+          "path": "broken_barh.eps",
+          "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+          "size": 4871
+        },
+        {
+          "path": "broken_barh.pdf",
+          "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+          "size": 3421
+        },
+        {
+          "path": "broken_barh.png",
+          "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
+          "size": 14714
+        },
+        {
+          "path": "broken_barh.svg",
+          "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+          "size": 3619
+        },
+        {
+          "path": "categorical.eps",
+          "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+          "size": 5691
+        },
+        {
+          "path": "categorical.pdf",
+          "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+          "size": 3529
+        },
+        {
+          "path": "categorical.png",
+          "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
+          "size": 17291
+        },
+        {
+          "path": "categorical.svg",
+          "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+          "size": 4113
+        },
+        {
+          "path": "clabel.eps",
+          "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+          "size": 14848
+        },
+        {
+          "path": "clabel.pdf",
+          "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+          "size": 10428
+        },
+        {
+          "path": "clabel.png",
+          "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
+          "size": 62827
+        },
+        {
+          "path": "clabel.svg",
+          "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+          "size": 11171
+        },
+        {
+          "path": "cmap_discrete.eps",
+          "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+          "size": 165754
+        },
+        {
+          "path": "cmap_discrete.pdf",
+          "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+          "size": 6561
+        },
+        {
+          "path": "cmap_discrete.png",
+          "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
+          "size": 17689
+        },
+        {
+          "path": "cmap_discrete.svg",
+          "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+          "size": 9074
+        },
+        {
+          "path": "cmap_lognorm.eps",
+          "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+          "size": 495916
+        },
+        {
+          "path": "cmap_lognorm.pdf",
+          "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+          "size": 13628
+        },
+        {
+          "path": "cmap_lognorm.png",
+          "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
+          "size": 18530
+        },
+        {
+          "path": "cmap_lognorm.svg",
+          "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+          "size": 15377
+        },
+        {
+          "path": "cmap_reversed.eps",
+          "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+          "size": 496738
+        },
+        {
+          "path": "cmap_reversed.pdf",
+          "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+          "size": 14516
+        },
+        {
+          "path": "cmap_reversed.png",
+          "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
+          "size": 19713
+        },
+        {
+          "path": "cmap_reversed.svg",
+          "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+          "size": 15977
+        },
+        {
+          "path": "cmap_special.eps",
+          "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+          "size": 385887
+        },
+        {
+          "path": "cmap_special.pdf",
+          "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+          "size": 8509
+        },
+        {
+          "path": "cmap_special.png",
+          "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
+          "size": 22036
+        },
+        {
+          "path": "cmap_special.svg",
+          "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+          "size": 10971
+        },
+        {
+          "path": "colorbar_orient.eps",
+          "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+          "size": 481251
+        },
+        {
+          "path": "colorbar_orient.pdf",
+          "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+          "size": 24888
+        },
+        {
+          "path": "colorbar_orient.png",
+          "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
+          "size": 23198
+        },
+        {
+          "path": "colorbar_orient.svg",
+          "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+          "size": 25679
+        },
+        {
+          "path": "colors.eps",
+          "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+          "size": 5537
+        },
+        {
+          "path": "colors.pdf",
+          "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+          "size": 3660
+        },
+        {
+          "path": "colors.png",
+          "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
+          "size": 15230
+        },
+        {
+          "path": "colors.svg",
+          "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+          "size": 4189
+        },
+        {
+          "path": "constrained.eps",
+          "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+          "size": 15645
+        },
+        {
+          "path": "constrained.pdf",
+          "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+          "size": 10197
+        },
+        {
+          "path": "constrained.png",
+          "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
+          "size": 46857
+        },
+        {
+          "path": "constrained.svg",
+          "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+          "size": 12564
+        },
+        {
+          "path": "contour.eps",
+          "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+          "size": 12891
+        },
+        {
+          "path": "contour.pdf",
+          "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+          "size": 8839
+        },
+        {
+          "path": "contour.png",
+          "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
+          "size": 65492
+        },
+        {
+          "path": "contour.svg",
+          "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+          "size": 9576
+        },
+        {
+          "path": "contour3d.eps",
+          "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
+          "size": 36513
+        },
+        {
+          "path": "contour3d.pdf",
+          "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
+          "size": 26115
+        },
+        {
+          "path": "contour3d.png",
+          "sha256": "593521ccb984587658a7d29741c1e555916c9b2404e45cf27af717c929951b05",
+          "size": 94817
+        },
+        {
+          "path": "contour3d.svg",
+          "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
+          "size": 27643
+        },
+        {
+          "path": "contourf.eps",
+          "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+          "size": 148542
+        },
+        {
+          "path": "contourf.pdf",
+          "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+          "size": 88734
+        },
+        {
+          "path": "contourf.png",
+          "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
+          "size": 65324
+        },
+        {
+          "path": "contourf.svg",
+          "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+          "size": 66386
+        },
+        {
+          "path": "dates.eps",
+          "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+          "size": 16170
+        },
+        {
+          "path": "dates.pdf",
+          "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+          "size": 12158
+        },
+        {
+          "path": "dates.png",
+          "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
+          "size": 33847
+        },
+        {
+          "path": "dates.svg",
+          "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+          "size": 13055
+        },
+        {
+          "path": "errorbar.eps",
+          "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+          "size": 18677
+        },
+        {
+          "path": "errorbar.pdf",
+          "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+          "size": 12254
+        },
+        {
+          "path": "errorbar.png",
+          "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
+          "size": 26603
+        },
+        {
+          "path": "errorbar.svg",
+          "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+          "size": 9685
+        },
+        {
+          "path": "errorbar_xy.eps",
+          "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+          "size": 19492
+        },
+        {
+          "path": "errorbar_xy.pdf",
+          "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+          "size": 12891
+        },
+        {
+          "path": "errorbar_xy.png",
+          "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
+          "size": 18310
+        },
+        {
+          "path": "errorbar_xy.svg",
+          "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+          "size": 9803
+        },
+        {
+          "path": "eventplot.eps",
+          "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+          "size": 14362
+        },
+        {
+          "path": "eventplot.pdf",
+          "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+          "size": 8864
+        },
+        {
+          "path": "eventplot.png",
+          "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
+          "size": 19220
+        },
+        {
+          "path": "eventplot.svg",
+          "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+          "size": 8618
+        },
+        {
+          "path": "facecolor.eps",
+          "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+          "size": 12235
+        },
+        {
+          "path": "facecolor.pdf",
+          "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+          "size": 8108
+        },
+        {
+          "path": "facecolor.png",
+          "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+          "size": 32314
+        },
+        {
+          "path": "facecolor.svg",
+          "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+          "size": 8675
+        },
+        {
+          "path": "figlegend.eps",
+          "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+          "size": 15657
+        },
+        {
+          "path": "figlegend.pdf",
+          "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+          "size": 10220
+        },
+        {
+          "path": "figlegend.png",
+          "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
+          "size": 38060
+        },
+        {
+          "path": "figlegend.svg",
+          "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+          "size": 12445
+        },
+        {
+          "path": "figsize.eps",
+          "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+          "size": 10482
+        },
+        {
+          "path": "figsize.pdf",
+          "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+          "size": 7028
+        },
+        {
+          "path": "figsize.png",
+          "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
+          "size": 24009
+        },
+        {
+          "path": "figsize.svg",
+          "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+          "size": 7577
+        },
+        {
+          "path": "figures.eps",
+          "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+          "size": 4606
+        },
+        {
+          "path": "figures.pdf",
+          "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+          "size": 3048
+        },
+        {
+          "path": "figures.png",
+          "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
+          "size": 25900
+        },
+        {
+          "path": "figures.svg",
+          "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+          "size": 3628
+        },
+        {
+          "path": "fill_between.eps",
+          "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+          "size": 18796
+        },
+        {
+          "path": "fill_between.pdf",
+          "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+          "size": 13247
+        },
+        {
+          "path": "fill_between.png",
+          "sha256": "2b0dbdfcc28c43b2c1f5a2262b9a0ac29a3ac37989feb423b5af88030b367415",
+          "size": 39611
+        },
+        {
+          "path": "fill_between.svg",
+          "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+          "size": 13950
+        },
+        {
+          "path": "fill_where.eps",
+          "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
+          "size": 14886
+        },
+        {
+          "path": "fill_where.pdf",
+          "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
+          "size": 10790
+        },
+        {
+          "path": "fill_where.png",
+          "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
+          "size": 33717
+        },
+        {
+          "path": "fill_where.svg",
+          "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
+          "size": 11789
+        },
+        {
+          "path": "fills.eps",
+          "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+          "size": 17109
+        },
+        {
+          "path": "fills.pdf",
+          "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+          "size": 11768
+        },
+        {
+          "path": "fills.png",
+          "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
+          "size": 37226
+        },
+        {
+          "path": "fills.svg",
+          "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+          "size": 13423
+        },
+        {
+          "path": "font_faces.eps",
+          "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+          "size": 9227
+        },
+        {
+          "path": "font_faces.pdf",
+          "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+          "size": 6271
+        },
+        {
+          "path": "font_faces.png",
+          "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
+          "size": 36737
+        },
+        {
+          "path": "font_faces.svg",
+          "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+          "size": 7508
+        },
+        {
+          "path": "fontsize.eps",
+          "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+          "size": 5477
+        },
+        {
+          "path": "fontsize.pdf",
+          "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+          "size": 3444
+        },
+        {
+          "path": "fontsize.png",
+          "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
+          "size": 32705
+        },
+        {
+          "path": "fontsize.svg",
+          "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+          "size": 4266
+        },
+        {
+          "path": "formatters.eps",
+          "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+          "size": 6509
+        },
+        {
+          "path": "formatters.pdf",
+          "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+          "size": 4947
+        },
+        {
+          "path": "formatters.png",
+          "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
+          "size": 29499
+        },
+        {
+          "path": "formatters.svg",
+          "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+          "size": 5254
+        },
+        {
+          "path": "grid_options.eps",
+          "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+          "size": 36975
+        },
+        {
+          "path": "grid_options.pdf",
+          "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+          "size": 23143
+        },
+        {
+          "path": "grid_options.png",
+          "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
+          "size": 63085
+        },
+        {
+          "path": "grid_options.svg",
+          "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+          "size": 25186
+        },
+        {
+          "path": "grid_ratios.eps",
+          "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+          "size": 24813
+        },
+        {
+          "path": "grid_ratios.pdf",
+          "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+          "size": 16526
+        },
+        {
+          "path": "grid_ratios.png",
+          "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
+          "size": 40356
+        },
+        {
+          "path": "grid_ratios.svg",
+          "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+          "size": 19980
+        },
+        {
+          "path": "gridspec.eps",
+          "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+          "size": 20006
+        },
+        {
+          "path": "gridspec.pdf",
+          "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+          "size": 13384
+        },
+        {
+          "path": "gridspec.png",
+          "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
+          "size": 38342
+        },
+        {
+          "path": "gridspec.svg",
+          "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+          "size": 16082
+        },
+        {
+          "path": "hatch.eps",
+          "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+          "size": 43560
+        },
+        {
+          "path": "hatch.pdf",
+          "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+          "size": 26971
+        },
+        {
+          "path": "hatch.png",
+          "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
+          "size": 42010
+        },
+        {
+          "path": "hatch.svg",
+          "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+          "size": 26350
+        },
+        {
+          "path": "hexbin.eps",
+          "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+          "size": 75718
+        },
+        {
+          "path": "hexbin.pdf",
+          "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+          "size": 54711
+        },
+        {
+          "path": "hexbin.png",
+          "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
+          "size": 87042
+        },
+        {
+          "path": "hexbin.svg",
+          "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+          "size": 44436
+        },
+        {
+          "path": "hist.eps",
+          "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+          "size": 8501
+        },
+        {
+          "path": "hist.pdf",
+          "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+          "size": 4854
+        },
+        {
+          "path": "hist.png",
+          "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
+          "size": 20119
+        },
+        {
+          "path": "hist.svg",
+          "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+          "size": 5634
+        },
+        {
+          "path": "hist2d.eps",
+          "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+          "size": 31502
+        },
+        {
+          "path": "hist2d.pdf",
+          "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+          "size": 17621
+        },
+        {
+          "path": "hist2d.png",
+          "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
+          "size": 20491
+        },
+        {
+          "path": "hist2d.svg",
+          "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+          "size": 14830
+        },
+        {
+          "path": "hist_bins.eps",
+          "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+          "size": 6748
+        },
+        {
+          "path": "hist_bins.pdf",
+          "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+          "size": 4027
+        },
+        {
+          "path": "hist_bins.png",
+          "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
+          "size": 17959
+        },
+        {
+          "path": "hist_bins.svg",
+          "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+          "size": 4773
+        },
+        {
+          "path": "hist_opts.eps",
+          "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+          "size": 9129
+        },
+        {
+          "path": "hist_opts.pdf",
+          "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+          "size": 5639
+        },
+        {
+          "path": "hist_opts.png",
+          "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
+          "size": 19359
+        },
+        {
+          "path": "hist_opts.svg",
+          "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+          "size": 5852
+        },
+        {
+          "path": "hist_orient.eps",
+          "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+          "size": 21335
+        },
+        {
+          "path": "hist_orient.pdf",
+          "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+          "size": 11396
+        },
+        {
+          "path": "hist_orient.png",
+          "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
+          "size": 24932
+        },
+        {
+          "path": "hist_orient.svg",
+          "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+          "size": 13132
+        },
+        {
+          "path": "hist_stacked.eps",
+          "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+          "size": 12928
+        },
+        {
+          "path": "hist_stacked.pdf",
+          "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+          "size": 7090
+        },
+        {
+          "path": "hist_stacked.png",
+          "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
+          "size": 23306
+        },
+        {
+          "path": "hist_stacked.svg",
+          "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+          "size": 8591
+        },
+        {
+          "path": "hv_lines.eps",
+          "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+          "size": 13110
+        },
+        {
+          "path": "hv_lines.pdf",
+          "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+          "size": 8518
+        },
+        {
+          "path": "hv_lines.png",
+          "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
+          "size": 36338
+        },
+        {
+          "path": "hv_lines.svg",
+          "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+          "size": 9248
+        },
+        {
+          "path": "imshow.eps",
+          "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+          "size": 417463
+        },
+        {
+          "path": "imshow.pdf",
+          "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+          "size": 6278
+        },
+        {
+          "path": "imshow.png",
+          "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
+          "size": 15228
+        },
+        {
+          "path": "imshow.svg",
+          "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+          "size": 8275
+        },
+        {
+          "path": "imshow_cbar.eps",
+          "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+          "size": 272389
+        },
+        {
+          "path": "imshow_cbar.pdf",
+          "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+          "size": 13336
+        },
+        {
+          "path": "imshow_cbar.png",
+          "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
+          "size": 24453
+        },
+        {
+          "path": "imshow_cbar.svg",
+          "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+          "size": 14287
+        },
+        {
+          "path": "imshow_log.eps",
+          "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+          "size": 33713
+        },
+        {
+          "path": "imshow_log.pdf",
+          "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+          "size": 18741
+        },
+        {
+          "path": "imshow_log.png",
+          "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
+          "size": 19144
+        },
+        {
+          "path": "imshow_log.svg",
+          "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+          "size": 17077
+        },
+        {
+          "path": "imshow_rgb.eps",
+          "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+          "size": 530576
+        },
+        {
+          "path": "imshow_rgb.pdf",
+          "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+          "size": 6334
+        },
+        {
+          "path": "imshow_rgb.png",
+          "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
+          "size": 16457
+        },
+        {
+          "path": "imshow_rgb.svg",
+          "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+          "size": 7768
+        },
+        {
+          "path": "inset.eps",
+          "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+          "size": 16312
+        },
+        {
+          "path": "inset.pdf",
+          "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+          "size": 10519
+        },
+        {
+          "path": "inset.png",
+          "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
+          "size": 36630
+        },
+        {
+          "path": "inset.svg",
+          "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+          "size": 12927
+        },
+        {
+          "path": "interp.eps",
+          "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+          "size": 394292
+        },
+        {
+          "path": "interp.pdf",
+          "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+          "size": 28040
+        },
+        {
+          "path": "interp.png",
+          "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
+          "size": 62490
+        },
+        {
+          "path": "interp.svg",
+          "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+          "size": 50239
+        },
+        {
+          "path": "invert_axes.eps",
+          "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+          "size": 8720
+        },
+        {
+          "path": "invert_axes.pdf",
+          "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+          "size": 6008
+        },
+        {
+          "path": "invert_axes.png",
+          "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
+          "size": 31964
+        },
+        {
+          "path": "invert_axes.svg",
+          "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+          "size": 6957
+        },
+        {
+          "path": "legend_labels.eps",
+          "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
+          "size": 15431
+        },
+        {
+          "path": "legend_labels.pdf",
+          "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
+          "size": 11163
+        },
+        {
+          "path": "legend_labels.png",
+          "sha256": "e92c4d496445bd933dc3afcbcb7393d0b3ad28d013fc06ee59ecdc512ad60746",
+          "size": 50734
+        },
+        {
+          "path": "legend_labels.svg",
+          "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
+          "size": 12229
+        },
+        {
+          "path": "legend_opts.eps",
+          "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+          "size": 7371
+        },
+        {
+          "path": "legend_opts.pdf",
+          "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+          "size": 4574
+        },
+        {
+          "path": "legend_opts.png",
+          "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
+          "size": 44992
+        },
+        {
+          "path": "legend_opts.svg",
+          "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+          "size": 5558
+        },
+        {
+          "path": "line3d.eps",
+          "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+          "size": 18473
+        },
+        {
+          "path": "line3d.pdf",
+          "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+          "size": 13089
+        },
+        {
+          "path": "line3d.png",
+          "sha256": "d2872916de6c86e5ee3350d1368ebcf5ab065ded046bd9154fc235a4368279ba",
+          "size": 67870
+        },
+        {
+          "path": "line3d.svg",
+          "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+          "size": 13293
+        },
+        {
+          "path": "log_minor_labels.eps",
+          "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+          "size": 8625
+        },
+        {
+          "path": "log_minor_labels.pdf",
+          "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+          "size": 5528
+        },
+        {
+          "path": "log_minor_labels.png",
+          "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+          "size": 23529
+        },
+        {
+          "path": "log_minor_labels.svg",
+          "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+          "size": 6874
+        },
+        {
+          "path": "loglog.eps",
+          "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+          "size": 14649
+        },
+        {
+          "path": "loglog.pdf",
+          "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+          "size": 8171
+        },
+        {
+          "path": "loglog.png",
+          "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
+          "size": 25190
+        },
+        {
+          "path": "loglog.svg",
+          "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+          "size": 10116
+        },
+        {
+          "path": "many_series.eps",
+          "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+          "size": 126003
+        },
+        {
+          "path": "many_series.pdf",
+          "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+          "size": 100906
+        },
+        {
+          "path": "many_series.png",
+          "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
+          "size": 286478
+        },
+        {
+          "path": "many_series.svg",
+          "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+          "size": 101725
+        },
+        {
+          "path": "margins.eps",
+          "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+          "size": 17663
+        },
+        {
+          "path": "margins.pdf",
+          "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+          "size": 12271
+        },
+        {
+          "path": "margins.png",
+          "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
+          "size": 42437
+        },
+        {
+          "path": "margins.svg",
+          "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+          "size": 14135
+        },
+        {
+          "path": "marker_detail.eps",
+          "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+          "size": 18574
+        },
+        {
+          "path": "marker_detail.pdf",
+          "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+          "size": 13643
+        },
+        {
+          "path": "marker_detail.png",
+          "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
+          "size": 34522
+        },
+        {
+          "path": "marker_detail.svg",
+          "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+          "size": 10883
+        },
+        {
+          "path": "markers_gallery.eps",
+          "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+          "size": 23435
+        },
+        {
+          "path": "markers_gallery.pdf",
+          "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+          "size": 16547
+        },
+        {
+          "path": "markers_gallery.png",
+          "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
+          "size": 22165
+        },
+        {
+          "path": "markers_gallery.svg",
+          "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+          "size": 10058
+        },
+        {
+          "path": "markers_only.eps",
+          "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+          "size": 30048
+        },
+        {
+          "path": "markers_only.pdf",
+          "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+          "size": 21481
+        },
+        {
+          "path": "markers_only.png",
+          "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
+          "size": 30486
+        },
+        {
+          "path": "markers_only.svg",
+          "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+          "size": 11142
+        },
+        {
+          "path": "mathtext.eps",
+          "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+          "size": 10620
+        },
+        {
+          "path": "mathtext.pdf",
+          "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+          "size": 6839
+        },
+        {
+          "path": "mathtext.png",
+          "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
+          "size": 32840
+        },
+        {
+          "path": "mathtext.svg",
+          "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+          "size": 8901
+        },
+        {
+          "path": "mathtext_frac.eps",
+          "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+          "size": 16086
+        },
+        {
+          "path": "mathtext_frac.pdf",
+          "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+          "size": 11400
+        },
+        {
+          "path": "mathtext_frac.png",
+          "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
+          "size": 32506
+        },
+        {
+          "path": "mathtext_frac.svg",
+          "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+          "size": 9515
+        },
+        {
+          "path": "matshow.eps",
+          "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+          "size": 447767
+        },
+        {
+          "path": "matshow.pdf",
+          "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+          "size": 5415
+        },
+        {
+          "path": "matshow.png",
+          "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
+          "size": 12239
+        },
+        {
+          "path": "matshow.svg",
+          "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+          "size": 7206
+        },
+        {
+          "path": "mosaic.eps",
+          "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+          "size": 19753
+        },
+        {
+          "path": "mosaic.pdf",
+          "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+          "size": 13130
+        },
+        {
+          "path": "mosaic.png",
+          "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
+          "size": 37933
+        },
+        {
+          "path": "mosaic.svg",
+          "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+          "size": 15857
+        },
+        {
+          "path": "multi_style.eps",
+          "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+          "size": 107472
+        },
+        {
+          "path": "multi_style.pdf",
+          "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+          "size": 81820
+        },
+        {
+          "path": "multi_style.png",
+          "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
+          "size": 47468
+        },
+        {
+          "path": "multi_style.svg",
+          "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+          "size": 28914
+        },
+        {
+          "path": "nan_gap.eps",
+          "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+          "size": 27755
+        },
+        {
+          "path": "nan_gap.pdf",
+          "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+          "size": 19760
+        },
+        {
+          "path": "nan_gap.png",
+          "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
+          "size": 34425
+        },
+        {
+          "path": "nan_gap.svg",
+          "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+          "size": 11312
+        },
+        {
+          "path": "norms.eps",
+          "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+          "size": 236860
+        },
+        {
+          "path": "norms.pdf",
+          "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+          "size": 9153
+        },
+        {
+          "path": "norms.png",
+          "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
+          "size": 21488
+        },
+        {
+          "path": "norms.svg",
+          "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+          "size": 12345
+        },
+        {
+          "path": "offset_text.eps",
+          "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+          "size": 8853
+        },
+        {
+          "path": "offset_text.pdf",
+          "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+          "size": 6025
+        },
+        {
+          "path": "offset_text.png",
+          "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
+          "size": 31008
+        },
+        {
+          "path": "offset_text.svg",
+          "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+          "size": 7054
+        },
+        {
+          "path": "patches.eps",
+          "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+          "size": 9242
+        },
+        {
+          "path": "patches.pdf",
+          "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+          "size": 6797
+        },
+        {
+          "path": "patches.png",
+          "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
+          "size": 25198
+        },
+        {
+          "path": "patches.svg",
+          "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+          "size": 7157
+        },
+        {
+          "path": "patches_path.eps",
+          "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+          "size": 5626
+        },
+        {
+          "path": "patches_path.pdf",
+          "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+          "size": 3692
+        },
+        {
+          "path": "patches_path.png",
+          "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
+          "size": 30023
+        },
+        {
+          "path": "patches_path.svg",
+          "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+          "size": 4249
+        },
+        {
+          "path": "pcolormesh.eps",
+          "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+          "size": 44989
+        },
+        {
+          "path": "pcolormesh.pdf",
+          "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+          "size": 25245
+        },
+        {
+          "path": "pcolormesh.png",
+          "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
+          "size": 21262
+        },
+        {
+          "path": "pcolormesh.svg",
+          "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+          "size": 21696
+        },
+        {
+          "path": "pie.eps",
+          "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+          "size": 2987
+        },
+        {
+          "path": "pie.pdf",
+          "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+          "size": 2936
+        },
+        {
+          "path": "pie.png",
+          "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+          "size": 23571
+        },
+        {
+          "path": "pie.svg",
+          "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+          "size": 2476
+        },
+        {
+          "path": "pie_opts.eps",
+          "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+          "size": 3945
+        },
+        {
+          "path": "pie_opts.pdf",
+          "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+          "size": 3612
+        },
+        {
+          "path": "pie_opts.png",
+          "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+          "size": 32364
+        },
+        {
+          "path": "pie_opts.svg",
+          "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+          "size": 3469
+        },
+        {
+          "path": "plot_y.eps",
+          "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+          "size": 64767
+        },
+        {
+          "path": "plot_y.pdf",
+          "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+          "size": 47987
+        },
+        {
+          "path": "plot_y.png",
+          "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
+          "size": 40207
+        },
+        {
+          "path": "plot_y.svg",
+          "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+          "size": 19461
+        },
+        {
+          "path": "polar.eps",
+          "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+          "size": 54459
+        },
+        {
+          "path": "polar.pdf",
+          "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+          "size": 43857
+        },
+        {
+          "path": "polar.png",
+          "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+          "size": 72845
+        },
+        {
+          "path": "polar.svg",
+          "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+          "size": 44319
+        },
+        {
+          "path": "quiver.eps",
+          "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+          "size": 24007
+        },
+        {
+          "path": "quiver.pdf",
+          "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+          "size": 17046
+        },
+        {
+          "path": "quiver.png",
+          "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
+          "size": 39122
+        },
+        {
+          "path": "quiver.svg",
+          "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+          "size": 16554
+        },
+        {
+          "path": "quiver3d.eps",
+          "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+          "size": 16864
+        },
+        {
+          "path": "quiver3d.pdf",
+          "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+          "size": 10205
+        },
+        {
+          "path": "quiver3d.png",
+          "sha256": "7398bbdbf57ff8fac1d7c7c83739f45fa132a279e81ecb00278a361ca0b2013b",
+          "size": 83816
+        },
+        {
+          "path": "quiver3d.svg",
+          "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+          "size": 11387
+        },
+        {
+          "path": "savefig_tight.eps",
+          "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+          "size": 4931
+        },
+        {
+          "path": "savefig_tight.pdf",
+          "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+          "size": 3211
+        },
+        {
+          "path": "savefig_tight.png",
+          "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+          "size": 68856
+        },
+        {
+          "path": "savefig_tight.svg",
+          "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+          "size": 3941
+        },
+        {
+          "path": "scatter.eps",
+          "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+          "size": 23854
+        },
+        {
+          "path": "scatter.pdf",
+          "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+          "size": 17031
+        },
+        {
+          "path": "scatter.png",
+          "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
+          "size": 24876
+        },
+        {
+          "path": "scatter.svg",
+          "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+          "size": 8371
+        },
+        {
+          "path": "scatter_cmap.eps",
+          "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+          "size": 36048
+        },
+        {
+          "path": "scatter_cmap.pdf",
+          "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+          "size": 23357
+        },
+        {
+          "path": "scatter_cmap.png",
+          "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
+          "size": 34752
+        },
+        {
+          "path": "scatter_cmap.svg",
+          "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+          "size": 21482
+        },
+        {
+          "path": "scatter_edge.eps",
+          "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+          "size": 26390
+        },
+        {
+          "path": "scatter_edge.pdf",
+          "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+          "size": 18737
+        },
+        {
+          "path": "scatter_edge.png",
+          "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
+          "size": 47476
+        },
+        {
+          "path": "scatter_edge.svg",
+          "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+          "size": 16259
+        },
+        {
+          "path": "semilogx.eps",
+          "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+          "size": 10132
+        },
+        {
+          "path": "semilogx.pdf",
+          "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+          "size": 6063
+        },
+        {
+          "path": "semilogx.png",
+          "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
+          "size": 22201
+        },
+        {
+          "path": "semilogx.svg",
+          "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+          "size": 7013
+        },
+        {
+          "path": "semilogy.eps",
+          "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+          "size": 25097
+        },
+        {
+          "path": "semilogy.pdf",
+          "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+          "size": 15725
+        },
+        {
+          "path": "semilogy.png",
+          "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
+          "size": 28573
+        },
+        {
+          "path": "semilogy.svg",
+          "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+          "size": 12650
+        },
+        {
+          "path": "spans.eps",
+          "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+          "size": 9679
+        },
+        {
+          "path": "spans.pdf",
+          "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+          "size": 6618
+        },
+        {
+          "path": "spans.png",
+          "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
+          "size": 32647
+        },
+        {
+          "path": "spans.svg",
+          "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+          "size": 7407
+        },
+        {
+          "path": "stem.eps",
+          "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+          "size": 8915
+        },
+        {
+          "path": "stem.pdf",
+          "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+          "size": 6069
+        },
+        {
+          "path": "stem.png",
+          "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
+          "size": 14320
+        },
+        {
+          "path": "stem.svg",
+          "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+          "size": 5699
+        },
+        {
+          "path": "step.eps",
+          "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+          "size": 4766
+        },
+        {
+          "path": "step.pdf",
+          "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+          "size": 3178
+        },
+        {
+          "path": "step.png",
+          "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
+          "size": 13186
+        },
+        {
+          "path": "step.svg",
+          "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+          "size": 3738
+        },
+        {
+          "path": "streamplot.eps",
+          "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+          "size": 81375
+        },
+        {
+          "path": "streamplot.pdf",
+          "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+          "size": 58212
+        },
+        {
+          "path": "streamplot.png",
+          "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
+          "size": 121548
+        },
+        {
+          "path": "streamplot.svg",
+          "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+          "size": 52950
+        },
+        {
+          "path": "style_ggplot.eps",
+          "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+          "size": 16495
+        },
+        {
+          "path": "style_ggplot.pdf",
+          "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+          "size": 11341
+        },
+        {
+          "path": "style_ggplot.png",
+          "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+          "size": 44679
+        },
+        {
+          "path": "style_ggplot.svg",
+          "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+          "size": 11595
+        },
+        {
+          "path": "subplots_2x1.eps",
+          "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+          "size": 21216
+        },
+        {
+          "path": "subplots_2x1.pdf",
+          "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+          "size": 13468
+        },
+        {
+          "path": "subplots_2x1.png",
+          "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
+          "size": 39291
+        },
+        {
+          "path": "subplots_2x1.svg",
+          "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+          "size": 15344
+        },
+        {
+          "path": "subplots_2x2.eps",
+          "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+          "size": 34200
+        },
+        {
+          "path": "subplots_2x2.pdf",
+          "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+          "size": 21509
+        },
+        {
+          "path": "subplots_2x2.png",
+          "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
+          "size": 51598
+        },
+        {
+          "path": "subplots_2x2.svg",
+          "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+          "size": 24426
+        },
+        {
+          "path": "subplots_adjust.eps",
+          "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+          "size": 7016
+        },
+        {
+          "path": "subplots_adjust.pdf",
+          "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+          "size": 4268
+        },
+        {
+          "path": "subplots_adjust.png",
+          "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+          "size": 30126
+        },
+        {
+          "path": "subplots_adjust.svg",
+          "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+          "size": 5528
+        },
+        {
+          "path": "subplots_shared.eps",
+          "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+          "size": 38590
+        },
+        {
+          "path": "subplots_shared.pdf",
+          "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+          "size": 25381
+        },
+        {
+          "path": "subplots_shared.png",
+          "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
+          "size": 43211
+        },
+        {
+          "path": "subplots_shared.svg",
+          "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+          "size": 20390
+        },
+        {
+          "path": "surface3d.eps",
+          "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+          "size": 291685
+        },
+        {
+          "path": "surface3d.pdf",
+          "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+          "size": 173038
+        },
+        {
+          "path": "surface3d.png",
+          "sha256": "2e2c3fc7cc7bf534c379f7f171b2274d43ec69cfa215fa2e4734c7bc424d63ee",
+          "size": 86896
+        },
+        {
+          "path": "surface3d.svg",
+          "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+          "size": 153557
+        },
+        {
+          "path": "surface3d_extra.eps",
+          "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+          "size": 359363
+        },
+        {
+          "path": "surface3d_extra.pdf",
+          "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+          "size": 224681
+        },
+        {
+          "path": "surface3d_extra.png",
+          "sha256": "7e91c273e58ca2b6560704719d71502735e933e82c49292df37332a455aa6570",
+          "size": 109161
+        },
+        {
+          "path": "surface3d_extra.svg",
+          "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+          "size": 206292
+        },
+        {
+          "path": "symlog.eps",
+          "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+          "size": 11340
+        },
+        {
+          "path": "symlog.pdf",
+          "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+          "size": 8163
+        },
+        {
+          "path": "symlog.png",
+          "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
+          "size": 22352
+        },
+        {
+          "path": "symlog.svg",
+          "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+          "size": 9070
+        },
+        {
+          "path": "table.eps",
+          "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
+          "size": 6280
+        },
+        {
+          "path": "table.pdf",
+          "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
+          "size": 4165
+        },
+        {
+          "path": "table.png",
+          "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+          "size": 14863
+        },
+        {
+          "path": "table.svg",
+          "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
+          "size": 4641
+        },
+        {
+          "path": "text_annotate.eps",
+          "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+          "size": 12522
+        },
+        {
+          "path": "text_annotate.pdf",
+          "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+          "size": 8311
+        },
+        {
+          "path": "text_annotate.png",
+          "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
+          "size": 34868
+        },
+        {
+          "path": "text_annotate.svg",
+          "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+          "size": 8957
+        },
+        {
+          "path": "text_options.eps",
+          "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+          "size": 9611
+        },
+        {
+          "path": "text_options.pdf",
+          "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+          "size": 6578
+        },
+        {
+          "path": "text_options.png",
+          "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
+          "size": 33984
+        },
+        {
+          "path": "text_options.svg",
+          "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+          "size": 7763
+        },
+        {
+          "path": "tick_locator.eps",
+          "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+          "size": 13359
+        },
+        {
+          "path": "tick_locator.pdf",
+          "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+          "size": 9119
+        },
+        {
+          "path": "tick_locator.png",
+          "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+          "size": 32671
+        },
+        {
+          "path": "tick_locator.svg",
+          "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+          "size": 10692
+        },
+        {
+          "path": "tick_style.eps",
+          "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+          "size": 4743
+        },
+        {
+          "path": "tick_style.pdf",
+          "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+          "size": 3327
+        },
+        {
+          "path": "tick_style.png",
+          "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
+          "size": 27448
+        },
+        {
+          "path": "tick_style.svg",
+          "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+          "size": 3947
+        },
+        {
+          "path": "ticks_legend.eps",
+          "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+          "size": 13957
+        },
+        {
+          "path": "ticks_legend.pdf",
+          "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+          "size": 9476
+        },
+        {
+          "path": "ticks_legend.png",
+          "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+          "size": 35711
+        },
+        {
+          "path": "ticks_legend.svg",
+          "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+          "size": 10721
+        },
+        {
+          "path": "tight_layout.eps",
+          "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+          "size": 9091
+        },
+        {
+          "path": "tight_layout.pdf",
+          "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+          "size": 5147
+        },
+        {
+          "path": "tight_layout.png",
+          "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
+          "size": 40701
+        },
+        {
+          "path": "tight_layout.svg",
+          "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+          "size": 7137
+        },
+        {
+          "path": "title_loc.eps",
+          "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+          "size": 8834
+        },
+        {
+          "path": "title_loc.pdf",
+          "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+          "size": 6008
+        },
+        {
+          "path": "title_loc.png",
+          "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
+          "size": 28887
+        },
+        {
+          "path": "title_loc.svg",
+          "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+          "size": 7093
+        },
+        {
+          "path": "transform_axes.eps",
+          "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+          "size": 8885
+        },
+        {
+          "path": "transform_axes.pdf",
+          "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+          "size": 6124
+        },
+        {
+          "path": "transform_axes.png",
+          "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
+          "size": 33813
+        },
+        {
+          "path": "transform_axes.svg",
+          "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+          "size": 7107
+        },
+        {
+          "path": "tricontour.eps",
+          "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+          "size": 73430
+        },
+        {
+          "path": "tricontour.pdf",
+          "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+          "size": 46453
+        },
+        {
+          "path": "tricontour.png",
+          "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
+          "size": 82284
+        },
+        {
+          "path": "tricontour.svg",
+          "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+          "size": 44665
+        },
+        {
+          "path": "tricontourf.eps",
+          "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+          "size": 196467
+        },
+        {
+          "path": "tricontourf.pdf",
+          "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+          "size": 120784
+        },
+        {
+          "path": "tricontourf.png",
+          "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
+          "size": 100624
+        },
+        {
+          "path": "tricontourf.svg",
+          "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+          "size": 89950
+        },
+        {
+          "path": "tripcolor.eps",
+          "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+          "size": 31920
+        },
+        {
+          "path": "tripcolor.pdf",
+          "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+          "size": 18630
+        },
+        {
+          "path": "tripcolor.png",
+          "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
+          "size": 55772
+        },
+        {
+          "path": "tripcolor.svg",
+          "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+          "size": 16074
+        },
+        {
+          "path": "triplot.eps",
+          "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+          "size": 28434
+        },
+        {
+          "path": "triplot.pdf",
+          "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+          "size": 19818
+        },
+        {
+          "path": "triplot.png",
+          "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
+          "size": 81306
+        },
+        {
+          "path": "triplot.svg",
+          "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+          "size": 13460
+        },
+        {
+          "path": "trisurf.eps",
+          "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+          "size": 42561
+        },
+        {
+          "path": "trisurf.pdf",
+          "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+          "size": 24733
+        },
+        {
+          "path": "trisurf.png",
+          "sha256": "557d249c446b4aebb28e0db06fb08b880c721f84b94285730e24d1c6adbafdfd",
+          "size": 78115
+        },
+        {
+          "path": "trisurf.svg",
+          "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+          "size": 23721
+        },
+        {
+          "path": "twinx.eps",
+          "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+          "size": 7293
+        },
+        {
+          "path": "twinx.pdf",
+          "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+          "size": 4337
+        },
+        {
+          "path": "twinx.png",
+          "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
+          "size": 35700
+        },
+        {
+          "path": "twinx.svg",
+          "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+          "size": 5886
+        },
+        {
+          "path": "violin_opts.eps",
+          "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+          "size": 30952
+        },
+        {
+          "path": "violin_opts.pdf",
+          "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+          "size": 23990
+        },
+        {
+          "path": "violin_opts.png",
+          "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
+          "size": 24826
+        },
+        {
+          "path": "violin_opts.svg",
+          "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+          "size": 24473
+        },
+        {
+          "path": "violinplot.eps",
+          "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+          "size": 17583
+        },
+        {
+          "path": "violinplot.pdf",
+          "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+          "size": 13475
+        },
+        {
+          "path": "violinplot.png",
+          "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
+          "size": 20863
+        },
+        {
+          "path": "violinplot.svg",
+          "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+          "size": 13823
+        },
+        {
+          "path": "zorder.eps",
+          "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+          "size": 10414
+        },
+        {
+          "path": "zorder.pdf",
+          "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+          "size": 6442
+        },
+        {
+          "path": "zorder.png",
+          "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
+          "size": 31537
+        },
+        {
+          "path": "zorder.svg",
+          "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+          "size": 6551
+        }
+      ],
+      "generated_from": "tests/out"
+    },
+    "linux-lfortran": {
+      "files": [
+        {
+          "path": "alpha.eps",
+          "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+          "size": 80981
+        },
+        {
+          "path": "alpha.pdf",
+          "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+          "size": 58537
+        },
+        {
+          "path": "alpha.png",
+          "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
+          "size": 60468
+        },
+        {
+          "path": "alpha.svg",
+          "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+          "size": 29813
+        },
+        {
+          "path": "anim_sine.gif",
+          "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
+          "size": 146758
+        },
+        {
+          "path": "annotate_arrow.eps",
+          "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+          "size": 9706
+        },
+        {
+          "path": "annotate_arrow.pdf",
+          "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+          "size": 6618
+        },
+        {
+          "path": "annotate_arrow.png",
+          "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
+          "size": 35121
+        },
+        {
+          "path": "annotate_arrow.svg",
+          "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+          "size": 7557
+        },
+        {
+          "path": "annotate_curve.eps",
+          "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+          "size": 9940
+        },
+        {
+          "path": "annotate_curve.pdf",
+          "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+          "size": 6765
+        },
+        {
+          "path": "annotate_curve.png",
+          "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
+          "size": 35035
+        },
+        {
+          "path": "annotate_curve.svg",
+          "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+          "size": 7615
+        },
+        {
+          "path": "axes_facecolor.eps",
+          "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+          "size": 17496
+        },
+        {
+          "path": "axes_facecolor.pdf",
+          "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+          "size": 11466
+        },
+        {
+          "path": "axes_facecolor.png",
+          "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
+          "size": 40471
+        },
+        {
+          "path": "axes_facecolor.svg",
+          "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+          "size": 13174
+        },
+        {
+          "path": "axes_handles2.eps",
+          "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+          "size": 26227
+        },
+        {
+          "path": "axes_handles2.pdf",
+          "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+          "size": 16957
+        },
+        {
+          "path": "axes_handles2.png",
+          "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
+          "size": 32163
+        },
+        {
+          "path": "axes_handles2.svg",
+          "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+          "size": 19863
+        },
+        {
+          "path": "axis_equal.eps",
+          "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+          "size": 8082
+        },
+        {
+          "path": "axis_equal.pdf",
+          "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+          "size": 5385
+        },
+        {
+          "path": "axis_equal.png",
+          "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
+          "size": 18657
+        },
+        {
+          "path": "axis_equal.svg",
+          "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+          "size": 4733
+        },
+        {
+          "path": "bar.eps",
+          "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+          "size": 7532
+        },
+        {
+          "path": "bar.pdf",
+          "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+          "size": 4363
+        },
+        {
+          "path": "bar.png",
+          "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
+          "size": 17029
+        },
+        {
+          "path": "bar.svg",
+          "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+          "size": 5255
+        },
+        {
+          "path": "bar3d.eps",
+          "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+          "size": 34185
+        },
+        {
+          "path": "bar3d.pdf",
+          "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+          "size": 20605
+        },
+        {
+          "path": "bar3d.png",
+          "sha256": "dc3a377149ec13f6051916fef70bf2769f3b5b64faffbe7678d056a59d4d0e86",
+          "size": 57527
+        },
+        {
+          "path": "bar3d.svg",
+          "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+          "size": 20023
+        },
+        {
+          "path": "bar_colors.eps",
+          "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+          "size": 7530
+        },
+        {
+          "path": "bar_colors.pdf",
+          "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+          "size": 4571
+        },
+        {
+          "path": "bar_colors.png",
+          "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
+          "size": 17074
+        },
+        {
+          "path": "bar_colors.svg",
+          "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+          "size": 5449
+        },
+        {
+          "path": "bar_err.eps",
+          "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+          "size": 10265
+        },
+        {
+          "path": "bar_err.pdf",
+          "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+          "size": 5894
+        },
+        {
+          "path": "bar_err.png",
+          "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
+          "size": 16414
+        },
+        {
+          "path": "bar_err.svg",
+          "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+          "size": 7040
+        },
+        {
+          "path": "bar_stacked.eps",
+          "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+          "size": 10296
+        },
+        {
+          "path": "bar_stacked.pdf",
+          "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+          "size": 5771
+        },
+        {
+          "path": "bar_stacked.png",
+          "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
+          "size": 18411
+        },
+        {
+          "path": "bar_stacked.svg",
+          "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+          "size": 6771
+        },
+        {
+          "path": "barh.eps",
+          "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+          "size": 6714
+        },
+        {
+          "path": "barh.pdf",
+          "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+          "size": 4007
+        },
+        {
+          "path": "barh.png",
+          "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
+          "size": 13399
+        },
+        {
+          "path": "barh.svg",
+          "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+          "size": 4634
+        },
+        {
+          "path": "basic_line.eps",
+          "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+          "size": 10559
+        },
+        {
+          "path": "basic_line.pdf",
+          "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+          "size": 7090
+        },
+        {
+          "path": "basic_line.png",
+          "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
+          "size": 27135
+        },
+        {
+          "path": "basic_line.svg",
+          "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+          "size": 7592
+        },
+        {
+          "path": "box_opts.eps",
+          "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+          "size": 12228
+        },
+        {
+          "path": "box_opts.pdf",
+          "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+          "size": 7789
+        },
+        {
+          "path": "box_opts.png",
+          "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+          "size": 19358
+        },
+        {
+          "path": "box_opts.svg",
+          "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+          "size": 8234
+        },
+        {
+          "path": "boxplot.eps",
+          "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+          "size": 7338
+        },
+        {
+          "path": "boxplot.pdf",
+          "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+          "size": 4561
+        },
+        {
+          "path": "boxplot.png",
+          "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+          "size": 14315
+        },
+        {
+          "path": "boxplot.svg",
+          "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+          "size": 5158
+        },
+        {
+          "path": "broken_barh.eps",
+          "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+          "size": 4871
+        },
+        {
+          "path": "broken_barh.pdf",
+          "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+          "size": 3421
+        },
+        {
+          "path": "broken_barh.png",
+          "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
+          "size": 14714
+        },
+        {
+          "path": "broken_barh.svg",
+          "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+          "size": 3619
+        },
+        {
+          "path": "categorical.eps",
+          "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+          "size": 5691
+        },
+        {
+          "path": "categorical.pdf",
+          "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+          "size": 3529
+        },
+        {
+          "path": "categorical.png",
+          "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
+          "size": 17291
+        },
+        {
+          "path": "categorical.svg",
+          "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+          "size": 4113
+        },
+        {
+          "path": "clabel.eps",
+          "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+          "size": 14848
+        },
+        {
+          "path": "clabel.pdf",
+          "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+          "size": 10428
+        },
+        {
+          "path": "clabel.png",
+          "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
+          "size": 62827
+        },
+        {
+          "path": "clabel.svg",
+          "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+          "size": 11171
+        },
+        {
+          "path": "cmap_discrete.eps",
+          "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+          "size": 165754
+        },
+        {
+          "path": "cmap_discrete.pdf",
+          "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+          "size": 6561
+        },
+        {
+          "path": "cmap_discrete.png",
+          "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
+          "size": 17689
+        },
+        {
+          "path": "cmap_discrete.svg",
+          "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+          "size": 9074
+        },
+        {
+          "path": "cmap_lognorm.eps",
+          "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+          "size": 495916
+        },
+        {
+          "path": "cmap_lognorm.pdf",
+          "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+          "size": 13628
+        },
+        {
+          "path": "cmap_lognorm.png",
+          "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
+          "size": 18530
+        },
+        {
+          "path": "cmap_lognorm.svg",
+          "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+          "size": 15377
+        },
+        {
+          "path": "cmap_reversed.eps",
+          "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+          "size": 496738
+        },
+        {
+          "path": "cmap_reversed.pdf",
+          "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+          "size": 14516
+        },
+        {
+          "path": "cmap_reversed.png",
+          "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
+          "size": 19713
+        },
+        {
+          "path": "cmap_reversed.svg",
+          "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+          "size": 15977
+        },
+        {
+          "path": "cmap_special.eps",
+          "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+          "size": 385887
+        },
+        {
+          "path": "cmap_special.pdf",
+          "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+          "size": 8509
+        },
+        {
+          "path": "cmap_special.png",
+          "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
+          "size": 22036
+        },
+        {
+          "path": "cmap_special.svg",
+          "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+          "size": 10971
+        },
+        {
+          "path": "colorbar_orient.eps",
+          "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+          "size": 481251
+        },
+        {
+          "path": "colorbar_orient.pdf",
+          "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+          "size": 24888
+        },
+        {
+          "path": "colorbar_orient.png",
+          "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
+          "size": 23198
+        },
+        {
+          "path": "colorbar_orient.svg",
+          "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+          "size": 25679
+        },
+        {
+          "path": "colors.eps",
+          "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+          "size": 5537
+        },
+        {
+          "path": "colors.pdf",
+          "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+          "size": 3660
+        },
+        {
+          "path": "colors.png",
+          "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
+          "size": 15230
+        },
+        {
+          "path": "colors.svg",
+          "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+          "size": 4189
+        },
+        {
+          "path": "constrained.eps",
+          "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+          "size": 15645
+        },
+        {
+          "path": "constrained.pdf",
+          "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+          "size": 10197
+        },
+        {
+          "path": "constrained.png",
+          "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
+          "size": 46857
+        },
+        {
+          "path": "constrained.svg",
+          "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+          "size": 12564
+        },
+        {
+          "path": "contour.eps",
+          "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+          "size": 12891
+        },
+        {
+          "path": "contour.pdf",
+          "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+          "size": 8839
+        },
+        {
+          "path": "contour.png",
+          "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
+          "size": 65492
+        },
+        {
+          "path": "contour.svg",
+          "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+          "size": 9576
+        },
+        {
+          "path": "contour3d.eps",
+          "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
+          "size": 36513
+        },
+        {
+          "path": "contour3d.pdf",
+          "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
+          "size": 26115
+        },
+        {
+          "path": "contour3d.png",
+          "sha256": "d7db39a0c9f62b1bb0dac1e69c9e9fd22dbbb0eb8a7aa2d8eb5b28a8c4e4053f",
+          "size": 94817
+        },
+        {
+          "path": "contour3d.svg",
+          "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
+          "size": 27643
+        },
+        {
+          "path": "contourf.eps",
+          "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+          "size": 148542
+        },
+        {
+          "path": "contourf.pdf",
+          "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+          "size": 88734
+        },
+        {
+          "path": "contourf.png",
+          "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
+          "size": 65324
+        },
+        {
+          "path": "contourf.svg",
+          "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+          "size": 66386
+        },
+        {
+          "path": "dates.eps",
+          "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+          "size": 16170
+        },
+        {
+          "path": "dates.pdf",
+          "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+          "size": 12158
+        },
+        {
+          "path": "dates.png",
+          "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
+          "size": 33847
+        },
+        {
+          "path": "dates.svg",
+          "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+          "size": 13055
+        },
+        {
+          "path": "errorbar.eps",
+          "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+          "size": 18677
+        },
+        {
+          "path": "errorbar.pdf",
+          "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+          "size": 12254
+        },
+        {
+          "path": "errorbar.png",
+          "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
+          "size": 26603
+        },
+        {
+          "path": "errorbar.svg",
+          "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+          "size": 9685
+        },
+        {
+          "path": "errorbar_xy.eps",
+          "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+          "size": 19492
+        },
+        {
+          "path": "errorbar_xy.pdf",
+          "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+          "size": 12891
+        },
+        {
+          "path": "errorbar_xy.png",
+          "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
+          "size": 18310
+        },
+        {
+          "path": "errorbar_xy.svg",
+          "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+          "size": 9803
+        },
+        {
+          "path": "eventplot.eps",
+          "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+          "size": 14362
+        },
+        {
+          "path": "eventplot.pdf",
+          "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+          "size": 8864
+        },
+        {
+          "path": "eventplot.png",
+          "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
+          "size": 19220
+        },
+        {
+          "path": "eventplot.svg",
+          "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+          "size": 8618
+        },
+        {
+          "path": "facecolor.eps",
+          "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+          "size": 12235
+        },
+        {
+          "path": "facecolor.pdf",
+          "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+          "size": 8108
+        },
+        {
+          "path": "facecolor.png",
+          "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+          "size": 32314
+        },
+        {
+          "path": "facecolor.svg",
+          "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+          "size": 8675
+        },
+        {
+          "path": "figlegend.eps",
+          "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+          "size": 15657
+        },
+        {
+          "path": "figlegend.pdf",
+          "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+          "size": 10220
+        },
+        {
+          "path": "figlegend.png",
+          "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
+          "size": 38060
+        },
+        {
+          "path": "figlegend.svg",
+          "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+          "size": 12445
+        },
+        {
+          "path": "figsize.eps",
+          "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+          "size": 10482
+        },
+        {
+          "path": "figsize.pdf",
+          "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+          "size": 7028
+        },
+        {
+          "path": "figsize.png",
+          "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
+          "size": 24009
+        },
+        {
+          "path": "figsize.svg",
+          "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+          "size": 7577
+        },
+        {
+          "path": "figures.eps",
+          "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+          "size": 4606
+        },
+        {
+          "path": "figures.pdf",
+          "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+          "size": 3048
+        },
+        {
+          "path": "figures.png",
+          "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
+          "size": 25900
+        },
+        {
+          "path": "figures.svg",
+          "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+          "size": 3628
+        },
+        {
+          "path": "fill_between.eps",
+          "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+          "size": 18796
+        },
+        {
+          "path": "fill_between.pdf",
+          "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+          "size": 13247
+        },
+        {
+          "path": "fill_between.png",
+          "sha256": "2b0dbdfcc28c43b2c1f5a2262b9a0ac29a3ac37989feb423b5af88030b367415",
+          "size": 39611
+        },
+        {
+          "path": "fill_between.svg",
+          "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+          "size": 13950
+        },
+        {
+          "path": "fill_where.eps",
+          "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
+          "size": 14886
+        },
+        {
+          "path": "fill_where.pdf",
+          "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
+          "size": 10790
+        },
+        {
+          "path": "fill_where.png",
+          "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
+          "size": 33717
+        },
+        {
+          "path": "fill_where.svg",
+          "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
+          "size": 11789
+        },
+        {
+          "path": "fills.eps",
+          "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+          "size": 17109
+        },
+        {
+          "path": "fills.pdf",
+          "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+          "size": 11768
+        },
+        {
+          "path": "fills.png",
+          "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
+          "size": 37226
+        },
+        {
+          "path": "fills.svg",
+          "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+          "size": 13423
+        },
+        {
+          "path": "font_faces.eps",
+          "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+          "size": 9227
+        },
+        {
+          "path": "font_faces.pdf",
+          "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+          "size": 6271
+        },
+        {
+          "path": "font_faces.png",
+          "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
+          "size": 36737
+        },
+        {
+          "path": "font_faces.svg",
+          "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+          "size": 7508
+        },
+        {
+          "path": "fontsize.eps",
+          "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+          "size": 5477
+        },
+        {
+          "path": "fontsize.pdf",
+          "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+          "size": 3444
+        },
+        {
+          "path": "fontsize.png",
+          "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
+          "size": 32705
+        },
+        {
+          "path": "fontsize.svg",
+          "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+          "size": 4266
+        },
+        {
+          "path": "formatters.eps",
+          "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+          "size": 6509
+        },
+        {
+          "path": "formatters.pdf",
+          "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+          "size": 4947
+        },
+        {
+          "path": "formatters.png",
+          "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
+          "size": 29499
+        },
+        {
+          "path": "formatters.svg",
+          "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+          "size": 5254
+        },
+        {
+          "path": "grid_options.eps",
+          "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+          "size": 36975
+        },
+        {
+          "path": "grid_options.pdf",
+          "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+          "size": 23143
+        },
+        {
+          "path": "grid_options.png",
+          "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
+          "size": 63085
+        },
+        {
+          "path": "grid_options.svg",
+          "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+          "size": 25186
+        },
+        {
+          "path": "grid_ratios.eps",
+          "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+          "size": 24813
+        },
+        {
+          "path": "grid_ratios.pdf",
+          "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+          "size": 16526
+        },
+        {
+          "path": "grid_ratios.png",
+          "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
+          "size": 40356
+        },
+        {
+          "path": "grid_ratios.svg",
+          "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+          "size": 19980
+        },
+        {
+          "path": "gridspec.eps",
+          "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+          "size": 20006
+        },
+        {
+          "path": "gridspec.pdf",
+          "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+          "size": 13384
+        },
+        {
+          "path": "gridspec.png",
+          "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
+          "size": 38342
+        },
+        {
+          "path": "gridspec.svg",
+          "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+          "size": 16082
+        },
+        {
+          "path": "hatch.eps",
+          "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+          "size": 43560
+        },
+        {
+          "path": "hatch.pdf",
+          "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+          "size": 26971
+        },
+        {
+          "path": "hatch.png",
+          "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
+          "size": 42010
+        },
+        {
+          "path": "hatch.svg",
+          "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+          "size": 26350
+        },
+        {
+          "path": "hexbin.eps",
+          "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+          "size": 75718
+        },
+        {
+          "path": "hexbin.pdf",
+          "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+          "size": 54711
+        },
+        {
+          "path": "hexbin.png",
+          "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
+          "size": 87042
+        },
+        {
+          "path": "hexbin.svg",
+          "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+          "size": 44436
+        },
+        {
+          "path": "hist.eps",
+          "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+          "size": 8501
+        },
+        {
+          "path": "hist.pdf",
+          "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+          "size": 4854
+        },
+        {
+          "path": "hist.png",
+          "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
+          "size": 20119
+        },
+        {
+          "path": "hist.svg",
+          "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+          "size": 5634
+        },
+        {
+          "path": "hist2d.eps",
+          "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+          "size": 31502
+        },
+        {
+          "path": "hist2d.pdf",
+          "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+          "size": 17621
+        },
+        {
+          "path": "hist2d.png",
+          "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
+          "size": 20491
+        },
+        {
+          "path": "hist2d.svg",
+          "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+          "size": 14830
+        },
+        {
+          "path": "hist_bins.eps",
+          "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+          "size": 6748
+        },
+        {
+          "path": "hist_bins.pdf",
+          "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+          "size": 4027
+        },
+        {
+          "path": "hist_bins.png",
+          "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
+          "size": 17959
+        },
+        {
+          "path": "hist_bins.svg",
+          "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+          "size": 4773
+        },
+        {
+          "path": "hist_opts.eps",
+          "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+          "size": 9129
+        },
+        {
+          "path": "hist_opts.pdf",
+          "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+          "size": 5639
+        },
+        {
+          "path": "hist_opts.png",
+          "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
+          "size": 19359
+        },
+        {
+          "path": "hist_opts.svg",
+          "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+          "size": 5852
+        },
+        {
+          "path": "hist_orient.eps",
+          "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+          "size": 21335
+        },
+        {
+          "path": "hist_orient.pdf",
+          "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+          "size": 11396
+        },
+        {
+          "path": "hist_orient.png",
+          "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
+          "size": 24932
+        },
+        {
+          "path": "hist_orient.svg",
+          "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+          "size": 13132
+        },
+        {
+          "path": "hist_stacked.eps",
+          "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+          "size": 12928
+        },
+        {
+          "path": "hist_stacked.pdf",
+          "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+          "size": 7090
+        },
+        {
+          "path": "hist_stacked.png",
+          "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
+          "size": 23306
+        },
+        {
+          "path": "hist_stacked.svg",
+          "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+          "size": 8591
+        },
+        {
+          "path": "hv_lines.eps",
+          "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+          "size": 13110
+        },
+        {
+          "path": "hv_lines.pdf",
+          "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+          "size": 8518
+        },
+        {
+          "path": "hv_lines.png",
+          "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
+          "size": 36338
+        },
+        {
+          "path": "hv_lines.svg",
+          "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+          "size": 9248
+        },
+        {
+          "path": "imshow.eps",
+          "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+          "size": 417463
+        },
+        {
+          "path": "imshow.pdf",
+          "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+          "size": 6278
+        },
+        {
+          "path": "imshow.png",
+          "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
+          "size": 15228
+        },
+        {
+          "path": "imshow.svg",
+          "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+          "size": 8275
+        },
+        {
+          "path": "imshow_cbar.eps",
+          "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+          "size": 272389
+        },
+        {
+          "path": "imshow_cbar.pdf",
+          "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+          "size": 13336
+        },
+        {
+          "path": "imshow_cbar.png",
+          "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
+          "size": 24453
+        },
+        {
+          "path": "imshow_cbar.svg",
+          "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+          "size": 14287
+        },
+        {
+          "path": "imshow_log.eps",
+          "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+          "size": 33713
+        },
+        {
+          "path": "imshow_log.pdf",
+          "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+          "size": 18741
+        },
+        {
+          "path": "imshow_log.png",
+          "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
+          "size": 19144
+        },
+        {
+          "path": "imshow_log.svg",
+          "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+          "size": 17077
+        },
+        {
+          "path": "imshow_rgb.eps",
+          "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+          "size": 530576
+        },
+        {
+          "path": "imshow_rgb.pdf",
+          "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+          "size": 6334
+        },
+        {
+          "path": "imshow_rgb.png",
+          "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
+          "size": 16457
+        },
+        {
+          "path": "imshow_rgb.svg",
+          "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+          "size": 7768
+        },
+        {
+          "path": "inset.eps",
+          "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+          "size": 16312
+        },
+        {
+          "path": "inset.pdf",
+          "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+          "size": 10519
+        },
+        {
+          "path": "inset.png",
+          "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
+          "size": 36630
+        },
+        {
+          "path": "inset.svg",
+          "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+          "size": 12927
+        },
+        {
+          "path": "interp.eps",
+          "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+          "size": 394292
+        },
+        {
+          "path": "interp.pdf",
+          "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+          "size": 28040
+        },
+        {
+          "path": "interp.png",
+          "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
+          "size": 62490
+        },
+        {
+          "path": "interp.svg",
+          "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+          "size": 50239
+        },
+        {
+          "path": "invert_axes.eps",
+          "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+          "size": 8720
+        },
+        {
+          "path": "invert_axes.pdf",
+          "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+          "size": 6008
+        },
+        {
+          "path": "invert_axes.png",
+          "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
+          "size": 31964
+        },
+        {
+          "path": "invert_axes.svg",
+          "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+          "size": 6957
+        },
+        {
+          "path": "legend_labels.eps",
+          "sha256": "16eb053c406df8d416dc1265f8ab18387c1c3cb6dc3197cde37d4536d4068156",
+          "size": 15431
+        },
+        {
+          "path": "legend_labels.pdf",
+          "sha256": "e801c0b2260ba818c3b47a818ee2bc70b6e12169c46882087015f01544d2296e",
+          "size": 11163
+        },
+        {
+          "path": "legend_labels.png",
+          "sha256": "dda233614f4d6f4d1aa523b4e2c89d550729d5a48f8c9da76ec1911cf1354a84",
+          "size": 50734
+        },
+        {
+          "path": "legend_labels.svg",
+          "sha256": "77b8d49bbec29d442abbe724e90187b7184bf45532a7cdcec50d533fbcee62f6",
+          "size": 12229
+        },
+        {
+          "path": "legend_opts.eps",
+          "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+          "size": 7371
+        },
+        {
+          "path": "legend_opts.pdf",
+          "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+          "size": 4574
+        },
+        {
+          "path": "legend_opts.png",
+          "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
+          "size": 44992
+        },
+        {
+          "path": "legend_opts.svg",
+          "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+          "size": 5558
+        },
+        {
+          "path": "line3d.eps",
+          "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+          "size": 18473
+        },
+        {
+          "path": "line3d.pdf",
+          "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+          "size": 13089
+        },
+        {
+          "path": "line3d.png",
+          "sha256": "a96fbd35f6633ff3985f0786345908f145d93d06c30213858b8fb8fab0a007d0",
+          "size": 67870
+        },
+        {
+          "path": "line3d.svg",
+          "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+          "size": 13293
+        },
+        {
+          "path": "log_minor_labels.eps",
+          "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+          "size": 8625
+        },
+        {
+          "path": "log_minor_labels.pdf",
+          "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+          "size": 5528
+        },
+        {
+          "path": "log_minor_labels.png",
+          "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+          "size": 23529
+        },
+        {
+          "path": "log_minor_labels.svg",
+          "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+          "size": 6874
+        },
+        {
+          "path": "loglog.eps",
+          "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+          "size": 14649
+        },
+        {
+          "path": "loglog.pdf",
+          "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+          "size": 8171
+        },
+        {
+          "path": "loglog.png",
+          "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
+          "size": 25190
+        },
+        {
+          "path": "loglog.svg",
+          "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+          "size": 10116
+        },
+        {
+          "path": "many_series.eps",
+          "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+          "size": 126003
+        },
+        {
+          "path": "many_series.pdf",
+          "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+          "size": 100906
+        },
+        {
+          "path": "many_series.png",
+          "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
+          "size": 286478
+        },
+        {
+          "path": "many_series.svg",
+          "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+          "size": 101725
+        },
+        {
+          "path": "margins.eps",
+          "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+          "size": 17663
+        },
+        {
+          "path": "margins.pdf",
+          "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+          "size": 12271
+        },
+        {
+          "path": "margins.png",
+          "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
+          "size": 42437
+        },
+        {
+          "path": "margins.svg",
+          "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+          "size": 14135
+        },
+        {
+          "path": "marker_detail.eps",
+          "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+          "size": 18574
+        },
+        {
+          "path": "marker_detail.pdf",
+          "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+          "size": 13643
+        },
+        {
+          "path": "marker_detail.png",
+          "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
+          "size": 34522
+        },
+        {
+          "path": "marker_detail.svg",
+          "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+          "size": 10883
+        },
+        {
+          "path": "markers_gallery.eps",
+          "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+          "size": 23435
+        },
+        {
+          "path": "markers_gallery.pdf",
+          "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+          "size": 16547
+        },
+        {
+          "path": "markers_gallery.png",
+          "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
+          "size": 22165
+        },
+        {
+          "path": "markers_gallery.svg",
+          "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+          "size": 10058
+        },
+        {
+          "path": "markers_only.eps",
+          "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+          "size": 30048
+        },
+        {
+          "path": "markers_only.pdf",
+          "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+          "size": 21481
+        },
+        {
+          "path": "markers_only.png",
+          "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
+          "size": 30486
+        },
+        {
+          "path": "markers_only.svg",
+          "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+          "size": 11142
+        },
+        {
+          "path": "mathtext.eps",
+          "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+          "size": 10620
+        },
+        {
+          "path": "mathtext.pdf",
+          "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+          "size": 6839
+        },
+        {
+          "path": "mathtext.png",
+          "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
+          "size": 32840
+        },
+        {
+          "path": "mathtext.svg",
+          "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+          "size": 8901
+        },
+        {
+          "path": "mathtext_frac.eps",
+          "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+          "size": 16086
+        },
+        {
+          "path": "mathtext_frac.pdf",
+          "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+          "size": 11400
+        },
+        {
+          "path": "mathtext_frac.png",
+          "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
+          "size": 32506
+        },
+        {
+          "path": "mathtext_frac.svg",
+          "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+          "size": 9515
+        },
+        {
+          "path": "matshow.eps",
+          "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+          "size": 447767
+        },
+        {
+          "path": "matshow.pdf",
+          "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+          "size": 5415
+        },
+        {
+          "path": "matshow.png",
+          "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
+          "size": 12239
+        },
+        {
+          "path": "matshow.svg",
+          "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+          "size": 7206
+        },
+        {
+          "path": "mosaic.eps",
+          "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+          "size": 19753
+        },
+        {
+          "path": "mosaic.pdf",
+          "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+          "size": 13130
+        },
+        {
+          "path": "mosaic.png",
+          "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
+          "size": 37933
+        },
+        {
+          "path": "mosaic.svg",
+          "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+          "size": 15857
+        },
+        {
+          "path": "multi_style.eps",
+          "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+          "size": 107472
+        },
+        {
+          "path": "multi_style.pdf",
+          "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+          "size": 81820
+        },
+        {
+          "path": "multi_style.png",
+          "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
+          "size": 47468
+        },
+        {
+          "path": "multi_style.svg",
+          "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+          "size": 28914
+        },
+        {
+          "path": "nan_gap.eps",
+          "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+          "size": 27755
+        },
+        {
+          "path": "nan_gap.pdf",
+          "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+          "size": 19760
+        },
+        {
+          "path": "nan_gap.png",
+          "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
+          "size": 34425
+        },
+        {
+          "path": "nan_gap.svg",
+          "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+          "size": 11312
+        },
+        {
+          "path": "norms.eps",
+          "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+          "size": 236860
+        },
+        {
+          "path": "norms.pdf",
+          "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+          "size": 9153
+        },
+        {
+          "path": "norms.png",
+          "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
+          "size": 21488
+        },
+        {
+          "path": "norms.svg",
+          "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+          "size": 12345
+        },
+        {
+          "path": "offset_text.eps",
+          "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+          "size": 8853
+        },
+        {
+          "path": "offset_text.pdf",
+          "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+          "size": 6025
+        },
+        {
+          "path": "offset_text.png",
+          "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
+          "size": 31008
+        },
+        {
+          "path": "offset_text.svg",
+          "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+          "size": 7054
+        },
+        {
+          "path": "patches.eps",
+          "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+          "size": 9242
+        },
+        {
+          "path": "patches.pdf",
+          "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+          "size": 6797
+        },
+        {
+          "path": "patches.png",
+          "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
+          "size": 25198
+        },
+        {
+          "path": "patches.svg",
+          "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+          "size": 7157
+        },
+        {
+          "path": "patches_path.eps",
+          "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+          "size": 5626
+        },
+        {
+          "path": "patches_path.pdf",
+          "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+          "size": 3692
+        },
+        {
+          "path": "patches_path.png",
+          "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
+          "size": 30023
+        },
+        {
+          "path": "patches_path.svg",
+          "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+          "size": 4249
+        },
+        {
+          "path": "pcolormesh.eps",
+          "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+          "size": 44989
+        },
+        {
+          "path": "pcolormesh.pdf",
+          "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+          "size": 25245
+        },
+        {
+          "path": "pcolormesh.png",
+          "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
+          "size": 21262
+        },
+        {
+          "path": "pcolormesh.svg",
+          "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+          "size": 21696
+        },
+        {
+          "path": "pie.eps",
+          "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+          "size": 2987
+        },
+        {
+          "path": "pie.pdf",
+          "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+          "size": 2936
+        },
+        {
+          "path": "pie.png",
+          "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+          "size": 23571
+        },
+        {
+          "path": "pie.svg",
+          "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+          "size": 2476
+        },
+        {
+          "path": "pie_opts.eps",
+          "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+          "size": 3945
+        },
+        {
+          "path": "pie_opts.pdf",
+          "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+          "size": 3612
+        },
+        {
+          "path": "pie_opts.png",
+          "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+          "size": 32364
+        },
+        {
+          "path": "pie_opts.svg",
+          "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+          "size": 3469
+        },
+        {
+          "path": "plot_y.eps",
+          "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+          "size": 64767
+        },
+        {
+          "path": "plot_y.pdf",
+          "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+          "size": 47987
+        },
+        {
+          "path": "plot_y.png",
+          "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
+          "size": 40207
+        },
+        {
+          "path": "plot_y.svg",
+          "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+          "size": 19461
+        },
+        {
+          "path": "polar.eps",
+          "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+          "size": 54459
+        },
+        {
+          "path": "polar.pdf",
+          "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+          "size": 43857
+        },
+        {
+          "path": "polar.png",
+          "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+          "size": 72845
+        },
+        {
+          "path": "polar.svg",
+          "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+          "size": 44319
+        },
+        {
+          "path": "quiver.eps",
+          "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+          "size": 24007
+        },
+        {
+          "path": "quiver.pdf",
+          "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+          "size": 17046
+        },
+        {
+          "path": "quiver.png",
+          "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
+          "size": 39122
+        },
+        {
+          "path": "quiver.svg",
+          "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+          "size": 16554
+        },
+        {
+          "path": "quiver3d.eps",
+          "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+          "size": 16864
+        },
+        {
+          "path": "quiver3d.pdf",
+          "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+          "size": 10205
+        },
+        {
+          "path": "quiver3d.png",
+          "sha256": "98e9828aa3f73ecf38e797cfa0c838f907ad19a05ce27d9030a3a3ba464c0935",
+          "size": 83816
+        },
+        {
+          "path": "quiver3d.svg",
+          "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+          "size": 11387
+        },
+        {
+          "path": "savefig_tight.eps",
+          "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+          "size": 4931
+        },
+        {
+          "path": "savefig_tight.pdf",
+          "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+          "size": 3211
+        },
+        {
+          "path": "savefig_tight.png",
+          "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+          "size": 68856
+        },
+        {
+          "path": "savefig_tight.svg",
+          "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+          "size": 3941
+        },
+        {
+          "path": "scatter.eps",
+          "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+          "size": 23854
+        },
+        {
+          "path": "scatter.pdf",
+          "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+          "size": 17031
+        },
+        {
+          "path": "scatter.png",
+          "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
+          "size": 24876
+        },
+        {
+          "path": "scatter.svg",
+          "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+          "size": 8371
+        },
+        {
+          "path": "scatter_cmap.eps",
+          "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+          "size": 36048
+        },
+        {
+          "path": "scatter_cmap.pdf",
+          "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+          "size": 23357
+        },
+        {
+          "path": "scatter_cmap.png",
+          "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
+          "size": 34752
+        },
+        {
+          "path": "scatter_cmap.svg",
+          "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+          "size": 21482
+        },
+        {
+          "path": "scatter_edge.eps",
+          "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+          "size": 26390
+        },
+        {
+          "path": "scatter_edge.pdf",
+          "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+          "size": 18737
+        },
+        {
+          "path": "scatter_edge.png",
+          "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
+          "size": 47476
+        },
+        {
+          "path": "scatter_edge.svg",
+          "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+          "size": 16259
+        },
+        {
+          "path": "semilogx.eps",
+          "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+          "size": 10132
+        },
+        {
+          "path": "semilogx.pdf",
+          "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+          "size": 6063
+        },
+        {
+          "path": "semilogx.png",
+          "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
+          "size": 22201
+        },
+        {
+          "path": "semilogx.svg",
+          "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+          "size": 7013
+        },
+        {
+          "path": "semilogy.eps",
+          "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+          "size": 25097
+        },
+        {
+          "path": "semilogy.pdf",
+          "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+          "size": 15725
+        },
+        {
+          "path": "semilogy.png",
+          "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
+          "size": 28573
+        },
+        {
+          "path": "semilogy.svg",
+          "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+          "size": 12650
+        },
+        {
+          "path": "spans.eps",
+          "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+          "size": 9679
+        },
+        {
+          "path": "spans.pdf",
+          "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+          "size": 6618
+        },
+        {
+          "path": "spans.png",
+          "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
+          "size": 32647
+        },
+        {
+          "path": "spans.svg",
+          "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+          "size": 7407
+        },
+        {
+          "path": "stem.eps",
+          "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+          "size": 8915
+        },
+        {
+          "path": "stem.pdf",
+          "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+          "size": 6069
+        },
+        {
+          "path": "stem.png",
+          "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
+          "size": 14320
+        },
+        {
+          "path": "stem.svg",
+          "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+          "size": 5699
+        },
+        {
+          "path": "step.eps",
+          "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+          "size": 4766
+        },
+        {
+          "path": "step.pdf",
+          "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+          "size": 3178
+        },
+        {
+          "path": "step.png",
+          "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
+          "size": 13186
+        },
+        {
+          "path": "step.svg",
+          "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+          "size": 3738
+        },
+        {
+          "path": "streamplot.eps",
+          "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+          "size": 81375
+        },
+        {
+          "path": "streamplot.pdf",
+          "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+          "size": 58212
+        },
+        {
+          "path": "streamplot.png",
+          "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
+          "size": 121548
+        },
+        {
+          "path": "streamplot.svg",
+          "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+          "size": 52950
+        },
+        {
+          "path": "style_ggplot.eps",
+          "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+          "size": 16495
+        },
+        {
+          "path": "style_ggplot.pdf",
+          "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+          "size": 11341
+        },
+        {
+          "path": "style_ggplot.png",
+          "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+          "size": 44679
+        },
+        {
+          "path": "style_ggplot.svg",
+          "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+          "size": 11595
+        },
+        {
+          "path": "subplots_2x1.eps",
+          "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+          "size": 21216
+        },
+        {
+          "path": "subplots_2x1.pdf",
+          "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+          "size": 13468
+        },
+        {
+          "path": "subplots_2x1.png",
+          "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
+          "size": 39291
+        },
+        {
+          "path": "subplots_2x1.svg",
+          "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+          "size": 15344
+        },
+        {
+          "path": "subplots_2x2.eps",
+          "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+          "size": 34200
+        },
+        {
+          "path": "subplots_2x2.pdf",
+          "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+          "size": 21509
+        },
+        {
+          "path": "subplots_2x2.png",
+          "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
+          "size": 51598
+        },
+        {
+          "path": "subplots_2x2.svg",
+          "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+          "size": 24426
+        },
+        {
+          "path": "subplots_adjust.eps",
+          "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+          "size": 7016
+        },
+        {
+          "path": "subplots_adjust.pdf",
+          "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+          "size": 4268
+        },
+        {
+          "path": "subplots_adjust.png",
+          "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+          "size": 30126
+        },
+        {
+          "path": "subplots_adjust.svg",
+          "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+          "size": 5528
+        },
+        {
+          "path": "subplots_shared.eps",
+          "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+          "size": 38590
+        },
+        {
+          "path": "subplots_shared.pdf",
+          "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+          "size": 25381
+        },
+        {
+          "path": "subplots_shared.png",
+          "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
+          "size": 43211
+        },
+        {
+          "path": "subplots_shared.svg",
+          "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+          "size": 20390
+        },
+        {
+          "path": "surface3d.eps",
+          "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+          "size": 291685
+        },
+        {
+          "path": "surface3d.pdf",
+          "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+          "size": 173038
+        },
+        {
+          "path": "surface3d.png",
+          "sha256": "36c84e5488b7710c407b2d60d99f66befe41dfb9e1fad02f5c65716652c1a32c",
+          "size": 86896
+        },
+        {
+          "path": "surface3d.svg",
+          "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+          "size": 153557
+        },
+        {
+          "path": "surface3d_extra.eps",
+          "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+          "size": 359363
+        },
+        {
+          "path": "surface3d_extra.pdf",
+          "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+          "size": 224681
+        },
+        {
+          "path": "surface3d_extra.png",
+          "sha256": "7fd904babec4b4ce32367a0cd29c3a8808fa240f1d493ce24d09fde5da68dc52",
+          "size": 109161
+        },
+        {
+          "path": "surface3d_extra.svg",
+          "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+          "size": 206292
+        },
+        {
+          "path": "symlog.eps",
+          "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+          "size": 11340
+        },
+        {
+          "path": "symlog.pdf",
+          "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+          "size": 8163
+        },
+        {
+          "path": "symlog.png",
+          "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
+          "size": 22352
+        },
+        {
+          "path": "symlog.svg",
+          "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+          "size": 9070
+        },
+        {
+          "path": "table.eps",
+          "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
+          "size": 6280
+        },
+        {
+          "path": "table.pdf",
+          "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
+          "size": 4165
+        },
+        {
+          "path": "table.png",
+          "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+          "size": 14863
+        },
+        {
+          "path": "table.svg",
+          "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
+          "size": 4641
+        },
+        {
+          "path": "text_annotate.eps",
+          "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+          "size": 12522
+        },
+        {
+          "path": "text_annotate.pdf",
+          "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+          "size": 8311
+        },
+        {
+          "path": "text_annotate.png",
+          "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
+          "size": 34868
+        },
+        {
+          "path": "text_annotate.svg",
+          "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+          "size": 8957
+        },
+        {
+          "path": "text_options.eps",
+          "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+          "size": 9611
+        },
+        {
+          "path": "text_options.pdf",
+          "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+          "size": 6578
+        },
+        {
+          "path": "text_options.png",
+          "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
+          "size": 33984
+        },
+        {
+          "path": "text_options.svg",
+          "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+          "size": 7763
+        },
+        {
+          "path": "tick_locator.eps",
+          "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+          "size": 13359
+        },
+        {
+          "path": "tick_locator.pdf",
+          "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+          "size": 9119
+        },
+        {
+          "path": "tick_locator.png",
+          "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+          "size": 32671
+        },
+        {
+          "path": "tick_locator.svg",
+          "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+          "size": 10692
+        },
+        {
+          "path": "tick_style.eps",
+          "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+          "size": 4743
+        },
+        {
+          "path": "tick_style.pdf",
+          "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+          "size": 3327
+        },
+        {
+          "path": "tick_style.png",
+          "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
+          "size": 27448
+        },
+        {
+          "path": "tick_style.svg",
+          "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+          "size": 3947
+        },
+        {
+          "path": "ticks_legend.eps",
+          "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+          "size": 13957
+        },
+        {
+          "path": "ticks_legend.pdf",
+          "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+          "size": 9476
+        },
+        {
+          "path": "ticks_legend.png",
+          "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+          "size": 35711
+        },
+        {
+          "path": "ticks_legend.svg",
+          "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+          "size": 10721
+        },
+        {
+          "path": "tight_layout.eps",
+          "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+          "size": 9091
+        },
+        {
+          "path": "tight_layout.pdf",
+          "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+          "size": 5147
+        },
+        {
+          "path": "tight_layout.png",
+          "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
+          "size": 40701
+        },
+        {
+          "path": "tight_layout.svg",
+          "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+          "size": 7137
+        },
+        {
+          "path": "title_loc.eps",
+          "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+          "size": 8834
+        },
+        {
+          "path": "title_loc.pdf",
+          "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+          "size": 6008
+        },
+        {
+          "path": "title_loc.png",
+          "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
+          "size": 28887
+        },
+        {
+          "path": "title_loc.svg",
+          "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+          "size": 7093
+        },
+        {
+          "path": "transform_axes.eps",
+          "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+          "size": 8885
+        },
+        {
+          "path": "transform_axes.pdf",
+          "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+          "size": 6124
+        },
+        {
+          "path": "transform_axes.png",
+          "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
+          "size": 33813
+        },
+        {
+          "path": "transform_axes.svg",
+          "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+          "size": 7107
+        },
+        {
+          "path": "tricontour.eps",
+          "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+          "size": 73430
+        },
+        {
+          "path": "tricontour.pdf",
+          "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+          "size": 46453
+        },
+        {
+          "path": "tricontour.png",
+          "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
+          "size": 82284
+        },
+        {
+          "path": "tricontour.svg",
+          "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+          "size": 44665
+        },
+        {
+          "path": "tricontourf.eps",
+          "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+          "size": 196467
+        },
+        {
+          "path": "tricontourf.pdf",
+          "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+          "size": 120784
+        },
+        {
+          "path": "tricontourf.png",
+          "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
+          "size": 100624
+        },
+        {
+          "path": "tricontourf.svg",
+          "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+          "size": 89950
+        },
+        {
+          "path": "tripcolor.eps",
+          "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+          "size": 31920
+        },
+        {
+          "path": "tripcolor.pdf",
+          "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+          "size": 18630
+        },
+        {
+          "path": "tripcolor.png",
+          "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
+          "size": 55772
+        },
+        {
+          "path": "tripcolor.svg",
+          "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+          "size": 16074
+        },
+        {
+          "path": "triplot.eps",
+          "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+          "size": 28434
+        },
+        {
+          "path": "triplot.pdf",
+          "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+          "size": 19818
+        },
+        {
+          "path": "triplot.png",
+          "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
+          "size": 81306
+        },
+        {
+          "path": "triplot.svg",
+          "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+          "size": 13460
+        },
+        {
+          "path": "trisurf.eps",
+          "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+          "size": 42561
+        },
+        {
+          "path": "trisurf.pdf",
+          "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+          "size": 24733
+        },
+        {
+          "path": "trisurf.png",
+          "sha256": "2a5e99c7e4afff663b23dc5ce2176c41b27be090485c64699315d16f8291a087",
+          "size": 78115
+        },
+        {
+          "path": "trisurf.svg",
+          "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+          "size": 23721
+        },
+        {
+          "path": "twinx.eps",
+          "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+          "size": 7293
+        },
+        {
+          "path": "twinx.pdf",
+          "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+          "size": 4337
+        },
+        {
+          "path": "twinx.png",
+          "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
+          "size": 35700
+        },
+        {
+          "path": "twinx.svg",
+          "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+          "size": 5886
+        },
+        {
+          "path": "violin_opts.eps",
+          "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+          "size": 30952
+        },
+        {
+          "path": "violin_opts.pdf",
+          "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+          "size": 23990
+        },
+        {
+          "path": "violin_opts.png",
+          "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
+          "size": 24826
+        },
+        {
+          "path": "violin_opts.svg",
+          "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+          "size": 24473
+        },
+        {
+          "path": "violinplot.eps",
+          "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+          "size": 17583
+        },
+        {
+          "path": "violinplot.pdf",
+          "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+          "size": 13475
+        },
+        {
+          "path": "violinplot.png",
+          "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
+          "size": 20863
+        },
+        {
+          "path": "violinplot.svg",
+          "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+          "size": 13823
+        },
+        {
+          "path": "zorder.eps",
+          "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+          "size": 10414
+        },
+        {
+          "path": "zorder.pdf",
+          "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+          "size": 6442
+        },
+        {
+          "path": "zorder.png",
+          "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
+          "size": 31537
+        },
+        {
+          "path": "zorder.svg",
+          "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+          "size": 6551
+        }
+      ],
+      "generated_from": "tests/out"
+    },
+    "windows-gfortran": {
+      "files": [
+        {
+          "path": "alpha.eps",
+          "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+          "size": 80981
+        },
+        {
+          "path": "alpha.pdf",
+          "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+          "size": 58537
+        },
+        {
+          "path": "alpha.png",
+          "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
+          "size": 60468
+        },
+        {
+          "path": "alpha.svg",
+          "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+          "size": 29813
+        },
+        {
+          "path": "anim_sine.gif",
+          "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
+          "size": 146758
+        },
+        {
+          "path": "annotate_arrow.eps",
+          "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+          "size": 9706
+        },
+        {
+          "path": "annotate_arrow.pdf",
+          "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+          "size": 6618
+        },
+        {
+          "path": "annotate_arrow.png",
+          "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
+          "size": 35121
+        },
+        {
+          "path": "annotate_arrow.svg",
+          "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+          "size": 7557
+        },
+        {
+          "path": "annotate_curve.eps",
+          "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+          "size": 9940
+        },
+        {
+          "path": "annotate_curve.pdf",
+          "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+          "size": 6765
+        },
+        {
+          "path": "annotate_curve.png",
+          "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
+          "size": 35035
+        },
+        {
+          "path": "annotate_curve.svg",
+          "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+          "size": 7615
+        },
+        {
+          "path": "axes_facecolor.eps",
+          "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+          "size": 17496
+        },
+        {
+          "path": "axes_facecolor.pdf",
+          "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+          "size": 11466
+        },
+        {
+          "path": "axes_facecolor.png",
+          "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
+          "size": 40471
+        },
+        {
+          "path": "axes_facecolor.svg",
+          "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+          "size": 13174
+        },
+        {
+          "path": "axes_handles2.eps",
+          "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+          "size": 26227
+        },
+        {
+          "path": "axes_handles2.pdf",
+          "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+          "size": 16957
+        },
+        {
+          "path": "axes_handles2.png",
+          "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
+          "size": 32163
+        },
+        {
+          "path": "axes_handles2.svg",
+          "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+          "size": 19863
+        },
+        {
+          "path": "axis_equal.eps",
+          "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+          "size": 8082
+        },
+        {
+          "path": "axis_equal.pdf",
+          "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+          "size": 5385
+        },
+        {
+          "path": "axis_equal.png",
+          "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
+          "size": 18657
+        },
+        {
+          "path": "axis_equal.svg",
+          "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+          "size": 4733
+        },
+        {
+          "path": "bar.eps",
+          "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+          "size": 7532
+        },
+        {
+          "path": "bar.pdf",
+          "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+          "size": 4363
+        },
+        {
+          "path": "bar.png",
+          "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
+          "size": 17029
+        },
+        {
+          "path": "bar.svg",
+          "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+          "size": 5255
+        },
+        {
+          "path": "bar3d.eps",
+          "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+          "size": 34185
+        },
+        {
+          "path": "bar3d.pdf",
+          "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+          "size": 20605
+        },
+        {
+          "path": "bar3d.png",
+          "sha256": "6cb71a60a5b74a3808f6999efc211284a3b49b290c790d20f4907320785d46c1",
+          "size": 57527
+        },
+        {
+          "path": "bar3d.svg",
+          "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+          "size": 20023
+        },
+        {
+          "path": "bar_colors.eps",
+          "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+          "size": 7530
+        },
+        {
+          "path": "bar_colors.pdf",
+          "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+          "size": 4571
+        },
+        {
+          "path": "bar_colors.png",
+          "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
+          "size": 17074
+        },
+        {
+          "path": "bar_colors.svg",
+          "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+          "size": 5449
+        },
+        {
+          "path": "bar_err.eps",
+          "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+          "size": 10265
+        },
+        {
+          "path": "bar_err.pdf",
+          "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+          "size": 5894
+        },
+        {
+          "path": "bar_err.png",
+          "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
+          "size": 16414
+        },
+        {
+          "path": "bar_err.svg",
+          "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+          "size": 7040
+        },
+        {
+          "path": "bar_stacked.eps",
+          "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+          "size": 10296
+        },
+        {
+          "path": "bar_stacked.pdf",
+          "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+          "size": 5771
+        },
+        {
+          "path": "bar_stacked.png",
+          "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
+          "size": 18411
+        },
+        {
+          "path": "bar_stacked.svg",
+          "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+          "size": 6771
+        },
+        {
+          "path": "barh.eps",
+          "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+          "size": 6714
+        },
+        {
+          "path": "barh.pdf",
+          "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+          "size": 4007
+        },
+        {
+          "path": "barh.png",
+          "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
+          "size": 13399
+        },
+        {
+          "path": "barh.svg",
+          "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+          "size": 4634
+        },
+        {
+          "path": "basic_line.eps",
+          "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+          "size": 10559
+        },
+        {
+          "path": "basic_line.pdf",
+          "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+          "size": 7090
+        },
+        {
+          "path": "basic_line.png",
+          "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
+          "size": 27135
+        },
+        {
+          "path": "basic_line.svg",
+          "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+          "size": 7592
+        },
+        {
+          "path": "box_opts.eps",
+          "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+          "size": 12228
+        },
+        {
+          "path": "box_opts.pdf",
+          "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+          "size": 7789
+        },
+        {
+          "path": "box_opts.png",
+          "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+          "size": 19358
+        },
+        {
+          "path": "box_opts.svg",
+          "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+          "size": 8234
+        },
+        {
+          "path": "boxplot.eps",
+          "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+          "size": 7338
+        },
+        {
+          "path": "boxplot.pdf",
+          "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+          "size": 4561
+        },
+        {
+          "path": "boxplot.png",
+          "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+          "size": 14315
+        },
+        {
+          "path": "boxplot.svg",
+          "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+          "size": 5158
+        },
+        {
+          "path": "broken_barh.eps",
+          "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+          "size": 4871
+        },
+        {
+          "path": "broken_barh.pdf",
+          "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+          "size": 3421
+        },
+        {
+          "path": "broken_barh.png",
+          "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
+          "size": 14714
+        },
+        {
+          "path": "broken_barh.svg",
+          "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+          "size": 3619
+        },
+        {
+          "path": "categorical.eps",
+          "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+          "size": 5691
+        },
+        {
+          "path": "categorical.pdf",
+          "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+          "size": 3529
+        },
+        {
+          "path": "categorical.png",
+          "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
+          "size": 17291
+        },
+        {
+          "path": "categorical.svg",
+          "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+          "size": 4113
+        },
+        {
+          "path": "clabel.eps",
+          "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+          "size": 14848
+        },
+        {
+          "path": "clabel.pdf",
+          "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+          "size": 10428
+        },
+        {
+          "path": "clabel.png",
+          "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
+          "size": 62827
+        },
+        {
+          "path": "clabel.svg",
+          "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+          "size": 11171
+        },
+        {
+          "path": "cmap_discrete.eps",
+          "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+          "size": 165754
+        },
+        {
+          "path": "cmap_discrete.pdf",
+          "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+          "size": 6561
+        },
+        {
+          "path": "cmap_discrete.png",
+          "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
+          "size": 17689
+        },
+        {
+          "path": "cmap_discrete.svg",
+          "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+          "size": 9074
+        },
+        {
+          "path": "cmap_lognorm.eps",
+          "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+          "size": 495916
+        },
+        {
+          "path": "cmap_lognorm.pdf",
+          "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+          "size": 13628
+        },
+        {
+          "path": "cmap_lognorm.png",
+          "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
+          "size": 18530
+        },
+        {
+          "path": "cmap_lognorm.svg",
+          "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+          "size": 15377
+        },
+        {
+          "path": "cmap_reversed.eps",
+          "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+          "size": 496738
+        },
+        {
+          "path": "cmap_reversed.pdf",
+          "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+          "size": 14516
+        },
+        {
+          "path": "cmap_reversed.png",
+          "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
+          "size": 19713
+        },
+        {
+          "path": "cmap_reversed.svg",
+          "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+          "size": 15977
+        },
+        {
+          "path": "cmap_special.eps",
+          "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+          "size": 385887
+        },
+        {
+          "path": "cmap_special.pdf",
+          "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+          "size": 8509
+        },
+        {
+          "path": "cmap_special.png",
+          "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
+          "size": 22036
+        },
+        {
+          "path": "cmap_special.svg",
+          "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+          "size": 10971
+        },
+        {
+          "path": "colorbar_orient.eps",
+          "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+          "size": 481251
+        },
+        {
+          "path": "colorbar_orient.pdf",
+          "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+          "size": 24888
+        },
+        {
+          "path": "colorbar_orient.png",
+          "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
+          "size": 23198
+        },
+        {
+          "path": "colorbar_orient.svg",
+          "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+          "size": 25679
+        },
+        {
+          "path": "colors.eps",
+          "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+          "size": 5537
+        },
+        {
+          "path": "colors.pdf",
+          "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+          "size": 3660
+        },
+        {
+          "path": "colors.png",
+          "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
+          "size": 15230
+        },
+        {
+          "path": "colors.svg",
+          "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+          "size": 4189
+        },
+        {
+          "path": "constrained.eps",
+          "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+          "size": 15645
+        },
+        {
+          "path": "constrained.pdf",
+          "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+          "size": 10197
+        },
+        {
+          "path": "constrained.png",
+          "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
+          "size": 46857
+        },
+        {
+          "path": "constrained.svg",
+          "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+          "size": 12564
+        },
+        {
+          "path": "contour.eps",
+          "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+          "size": 12891
+        },
+        {
+          "path": "contour.pdf",
+          "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+          "size": 8839
+        },
+        {
+          "path": "contour.png",
+          "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
+          "size": 65492
+        },
+        {
+          "path": "contour.svg",
+          "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+          "size": 9576
+        },
+        {
+          "path": "contour3d.eps",
+          "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
+          "size": 36513
+        },
+        {
+          "path": "contour3d.pdf",
+          "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
+          "size": 26115
+        },
+        {
+          "path": "contour3d.png",
+          "sha256": "f0237ea244826fcfcc9ae30e9abf1f63f3157c5a05bfd70c7287ad26a993de4c",
+          "size": 94817
+        },
+        {
+          "path": "contour3d.svg",
+          "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
+          "size": 27643
+        },
+        {
+          "path": "contourf.eps",
+          "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+          "size": 148542
+        },
+        {
+          "path": "contourf.pdf",
+          "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+          "size": 88734
+        },
+        {
+          "path": "contourf.png",
+          "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
+          "size": 65324
+        },
+        {
+          "path": "contourf.svg",
+          "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+          "size": 66386
+        },
+        {
+          "path": "dates.eps",
+          "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+          "size": 16170
+        },
+        {
+          "path": "dates.pdf",
+          "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+          "size": 12158
+        },
+        {
+          "path": "dates.png",
+          "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
+          "size": 33847
+        },
+        {
+          "path": "dates.svg",
+          "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+          "size": 13055
+        },
+        {
+          "path": "errorbar.eps",
+          "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+          "size": 18677
+        },
+        {
+          "path": "errorbar.pdf",
+          "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+          "size": 12254
+        },
+        {
+          "path": "errorbar.png",
+          "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
+          "size": 26603
+        },
+        {
+          "path": "errorbar.svg",
+          "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+          "size": 9685
+        },
+        {
+          "path": "errorbar_xy.eps",
+          "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+          "size": 19492
+        },
+        {
+          "path": "errorbar_xy.pdf",
+          "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+          "size": 12891
+        },
+        {
+          "path": "errorbar_xy.png",
+          "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
+          "size": 18310
+        },
+        {
+          "path": "errorbar_xy.svg",
+          "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+          "size": 9803
+        },
+        {
+          "path": "eventplot.eps",
+          "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+          "size": 14362
+        },
+        {
+          "path": "eventplot.pdf",
+          "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+          "size": 8864
+        },
+        {
+          "path": "eventplot.png",
+          "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
+          "size": 19220
+        },
+        {
+          "path": "eventplot.svg",
+          "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+          "size": 8618
+        },
+        {
+          "path": "facecolor.eps",
+          "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+          "size": 12235
+        },
+        {
+          "path": "facecolor.pdf",
+          "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+          "size": 8108
+        },
+        {
+          "path": "facecolor.png",
+          "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+          "size": 32314
+        },
+        {
+          "path": "facecolor.svg",
+          "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+          "size": 8675
+        },
+        {
+          "path": "figlegend.eps",
+          "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+          "size": 15657
+        },
+        {
+          "path": "figlegend.pdf",
+          "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+          "size": 10220
+        },
+        {
+          "path": "figlegend.png",
+          "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
+          "size": 38060
+        },
+        {
+          "path": "figlegend.svg",
+          "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+          "size": 12445
+        },
+        {
+          "path": "figsize.eps",
+          "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+          "size": 10482
+        },
+        {
+          "path": "figsize.pdf",
+          "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+          "size": 7028
+        },
+        {
+          "path": "figsize.png",
+          "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
+          "size": 24009
+        },
+        {
+          "path": "figsize.svg",
+          "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+          "size": 7577
+        },
+        {
+          "path": "figures.eps",
+          "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+          "size": 4606
+        },
+        {
+          "path": "figures.pdf",
+          "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+          "size": 3048
+        },
+        {
+          "path": "figures.png",
+          "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
+          "size": 25900
+        },
+        {
+          "path": "figures.svg",
+          "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+          "size": 3628
+        },
+        {
+          "path": "fill_between.eps",
+          "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+          "size": 18796
+        },
+        {
+          "path": "fill_between.pdf",
+          "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+          "size": 13247
+        },
+        {
+          "path": "fill_between.png",
+          "sha256": "cf27a182ddb40781a17423b809123e735b38104c094496bea53089f0fe588bc4",
+          "size": 39611
+        },
+        {
+          "path": "fill_between.svg",
+          "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+          "size": 13950
+        },
+        {
+          "path": "fill_where.eps",
+          "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
+          "size": 14886
+        },
+        {
+          "path": "fill_where.pdf",
+          "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
+          "size": 10790
+        },
+        {
+          "path": "fill_where.png",
+          "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
+          "size": 33717
+        },
+        {
+          "path": "fill_where.svg",
+          "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
+          "size": 11789
+        },
+        {
+          "path": "fills.eps",
+          "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+          "size": 17109
+        },
+        {
+          "path": "fills.pdf",
+          "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+          "size": 11768
+        },
+        {
+          "path": "fills.png",
+          "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
+          "size": 37226
+        },
+        {
+          "path": "fills.svg",
+          "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+          "size": 13423
+        },
+        {
+          "path": "font_faces.eps",
+          "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+          "size": 9227
+        },
+        {
+          "path": "font_faces.pdf",
+          "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+          "size": 6271
+        },
+        {
+          "path": "font_faces.png",
+          "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
+          "size": 36737
+        },
+        {
+          "path": "font_faces.svg",
+          "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+          "size": 7508
+        },
+        {
+          "path": "fontsize.eps",
+          "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+          "size": 5477
+        },
+        {
+          "path": "fontsize.pdf",
+          "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+          "size": 3444
+        },
+        {
+          "path": "fontsize.png",
+          "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
+          "size": 32705
+        },
+        {
+          "path": "fontsize.svg",
+          "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+          "size": 4266
+        },
+        {
+          "path": "formatters.eps",
+          "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+          "size": 6509
+        },
+        {
+          "path": "formatters.pdf",
+          "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+          "size": 4947
+        },
+        {
+          "path": "formatters.png",
+          "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
+          "size": 29499
+        },
+        {
+          "path": "formatters.svg",
+          "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+          "size": 5254
+        },
+        {
+          "path": "grid_options.eps",
+          "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+          "size": 36975
+        },
+        {
+          "path": "grid_options.pdf",
+          "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+          "size": 23143
+        },
+        {
+          "path": "grid_options.png",
+          "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
+          "size": 63085
+        },
+        {
+          "path": "grid_options.svg",
+          "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+          "size": 25186
+        },
+        {
+          "path": "grid_ratios.eps",
+          "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+          "size": 24813
+        },
+        {
+          "path": "grid_ratios.pdf",
+          "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+          "size": 16526
+        },
+        {
+          "path": "grid_ratios.png",
+          "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
+          "size": 40356
+        },
+        {
+          "path": "grid_ratios.svg",
+          "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+          "size": 19980
+        },
+        {
+          "path": "gridspec.eps",
+          "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+          "size": 20006
+        },
+        {
+          "path": "gridspec.pdf",
+          "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+          "size": 13384
+        },
+        {
+          "path": "gridspec.png",
+          "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
+          "size": 38342
+        },
+        {
+          "path": "gridspec.svg",
+          "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+          "size": 16082
+        },
+        {
+          "path": "hatch.eps",
+          "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+          "size": 43560
+        },
+        {
+          "path": "hatch.pdf",
+          "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+          "size": 26971
+        },
+        {
+          "path": "hatch.png",
+          "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
+          "size": 42010
+        },
+        {
+          "path": "hatch.svg",
+          "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+          "size": 26350
+        },
+        {
+          "path": "hexbin.eps",
+          "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+          "size": 75718
+        },
+        {
+          "path": "hexbin.pdf",
+          "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+          "size": 54711
+        },
+        {
+          "path": "hexbin.png",
+          "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
+          "size": 87042
+        },
+        {
+          "path": "hexbin.svg",
+          "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+          "size": 44436
+        },
+        {
+          "path": "hist.eps",
+          "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+          "size": 8501
+        },
+        {
+          "path": "hist.pdf",
+          "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+          "size": 4854
+        },
+        {
+          "path": "hist.png",
+          "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
+          "size": 20119
+        },
+        {
+          "path": "hist.svg",
+          "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+          "size": 5634
+        },
+        {
+          "path": "hist2d.eps",
+          "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+          "size": 31502
+        },
+        {
+          "path": "hist2d.pdf",
+          "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+          "size": 17621
+        },
+        {
+          "path": "hist2d.png",
+          "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
+          "size": 20491
+        },
+        {
+          "path": "hist2d.svg",
+          "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+          "size": 14830
+        },
+        {
+          "path": "hist_bins.eps",
+          "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+          "size": 6748
+        },
+        {
+          "path": "hist_bins.pdf",
+          "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+          "size": 4027
+        },
+        {
+          "path": "hist_bins.png",
+          "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
+          "size": 17959
+        },
+        {
+          "path": "hist_bins.svg",
+          "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+          "size": 4773
+        },
+        {
+          "path": "hist_opts.eps",
+          "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+          "size": 9129
+        },
+        {
+          "path": "hist_opts.pdf",
+          "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+          "size": 5639
+        },
+        {
+          "path": "hist_opts.png",
+          "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
+          "size": 19359
+        },
+        {
+          "path": "hist_opts.svg",
+          "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+          "size": 5852
+        },
+        {
+          "path": "hist_orient.eps",
+          "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+          "size": 21335
+        },
+        {
+          "path": "hist_orient.pdf",
+          "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+          "size": 11396
+        },
+        {
+          "path": "hist_orient.png",
+          "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
+          "size": 24932
+        },
+        {
+          "path": "hist_orient.svg",
+          "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+          "size": 13132
+        },
+        {
+          "path": "hist_stacked.eps",
+          "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+          "size": 12928
+        },
+        {
+          "path": "hist_stacked.pdf",
+          "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+          "size": 7090
+        },
+        {
+          "path": "hist_stacked.png",
+          "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
+          "size": 23306
+        },
+        {
+          "path": "hist_stacked.svg",
+          "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+          "size": 8591
+        },
+        {
+          "path": "hv_lines.eps",
+          "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+          "size": 13110
+        },
+        {
+          "path": "hv_lines.pdf",
+          "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+          "size": 8518
+        },
+        {
+          "path": "hv_lines.png",
+          "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
+          "size": 36338
+        },
+        {
+          "path": "hv_lines.svg",
+          "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+          "size": 9248
+        },
+        {
+          "path": "imshow.eps",
+          "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+          "size": 417463
+        },
+        {
+          "path": "imshow.pdf",
+          "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+          "size": 6278
+        },
+        {
+          "path": "imshow.png",
+          "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
+          "size": 15228
+        },
+        {
+          "path": "imshow.svg",
+          "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+          "size": 8275
+        },
+        {
+          "path": "imshow_cbar.eps",
+          "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+          "size": 272389
+        },
+        {
+          "path": "imshow_cbar.pdf",
+          "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+          "size": 13336
+        },
+        {
+          "path": "imshow_cbar.png",
+          "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
+          "size": 24453
+        },
+        {
+          "path": "imshow_cbar.svg",
+          "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+          "size": 14287
+        },
+        {
+          "path": "imshow_log.eps",
+          "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+          "size": 33713
+        },
+        {
+          "path": "imshow_log.pdf",
+          "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+          "size": 18741
+        },
+        {
+          "path": "imshow_log.png",
+          "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
+          "size": 19144
+        },
+        {
+          "path": "imshow_log.svg",
+          "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+          "size": 17077
+        },
+        {
+          "path": "imshow_rgb.eps",
+          "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+          "size": 530576
+        },
+        {
+          "path": "imshow_rgb.pdf",
+          "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+          "size": 6334
+        },
+        {
+          "path": "imshow_rgb.png",
+          "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
+          "size": 16457
+        },
+        {
+          "path": "imshow_rgb.svg",
+          "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+          "size": 7768
+        },
+        {
+          "path": "inset.eps",
+          "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+          "size": 16312
+        },
+        {
+          "path": "inset.pdf",
+          "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+          "size": 10519
+        },
+        {
+          "path": "inset.png",
+          "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
+          "size": 36630
+        },
+        {
+          "path": "inset.svg",
+          "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+          "size": 12927
+        },
+        {
+          "path": "interp.eps",
+          "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+          "size": 394292
+        },
+        {
+          "path": "interp.pdf",
+          "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+          "size": 28040
+        },
+        {
+          "path": "interp.png",
+          "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
+          "size": 62490
+        },
+        {
+          "path": "interp.svg",
+          "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+          "size": 50239
+        },
+        {
+          "path": "invert_axes.eps",
+          "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+          "size": 8720
+        },
+        {
+          "path": "invert_axes.pdf",
+          "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+          "size": 6008
+        },
+        {
+          "path": "invert_axes.png",
+          "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
+          "size": 31964
+        },
+        {
+          "path": "invert_axes.svg",
+          "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+          "size": 6957
+        },
+        {
+          "path": "legend_labels.eps",
+          "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
+          "size": 15431
+        },
+        {
+          "path": "legend_labels.pdf",
+          "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
+          "size": 11163
+        },
+        {
+          "path": "legend_labels.png",
+          "sha256": "e92c4d496445bd933dc3afcbcb7393d0b3ad28d013fc06ee59ecdc512ad60746",
+          "size": 50734
+        },
+        {
+          "path": "legend_labels.svg",
+          "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
+          "size": 12229
+        },
+        {
+          "path": "legend_opts.eps",
+          "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+          "size": 7371
+        },
+        {
+          "path": "legend_opts.pdf",
+          "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+          "size": 4574
+        },
+        {
+          "path": "legend_opts.png",
+          "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
+          "size": 44992
+        },
+        {
+          "path": "legend_opts.svg",
+          "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+          "size": 5558
+        },
+        {
+          "path": "line3d.eps",
+          "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+          "size": 18473
+        },
+        {
+          "path": "line3d.pdf",
+          "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+          "size": 13089
+        },
+        {
+          "path": "line3d.png",
+          "sha256": "10bd8a3f33c90577ddccf73e7b9c833695428e8b4f16357f9a5f91a3072d6e3e",
+          "size": 67870
+        },
+        {
+          "path": "line3d.svg",
+          "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+          "size": 13293
+        },
+        {
+          "path": "log_minor_labels.eps",
+          "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+          "size": 8625
+        },
+        {
+          "path": "log_minor_labels.pdf",
+          "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+          "size": 5528
+        },
+        {
+          "path": "log_minor_labels.png",
+          "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+          "size": 23529
+        },
+        {
+          "path": "log_minor_labels.svg",
+          "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+          "size": 6874
+        },
+        {
+          "path": "loglog.eps",
+          "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+          "size": 14649
+        },
+        {
+          "path": "loglog.pdf",
+          "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+          "size": 8171
+        },
+        {
+          "path": "loglog.png",
+          "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
+          "size": 25190
+        },
+        {
+          "path": "loglog.svg",
+          "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+          "size": 10116
+        },
+        {
+          "path": "many_series.eps",
+          "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+          "size": 126003
+        },
+        {
+          "path": "many_series.pdf",
+          "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+          "size": 100906
+        },
+        {
+          "path": "many_series.png",
+          "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
+          "size": 286478
+        },
+        {
+          "path": "many_series.svg",
+          "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+          "size": 101725
+        },
+        {
+          "path": "margins.eps",
+          "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+          "size": 17663
+        },
+        {
+          "path": "margins.pdf",
+          "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+          "size": 12271
+        },
+        {
+          "path": "margins.png",
+          "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
+          "size": 42437
+        },
+        {
+          "path": "margins.svg",
+          "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+          "size": 14135
+        },
+        {
+          "path": "marker_detail.eps",
+          "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+          "size": 18574
+        },
+        {
+          "path": "marker_detail.pdf",
+          "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+          "size": 13643
+        },
+        {
+          "path": "marker_detail.png",
+          "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
+          "size": 34522
+        },
+        {
+          "path": "marker_detail.svg",
+          "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+          "size": 10883
+        },
+        {
+          "path": "markers_gallery.eps",
+          "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+          "size": 23435
+        },
+        {
+          "path": "markers_gallery.pdf",
+          "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+          "size": 16547
+        },
+        {
+          "path": "markers_gallery.png",
+          "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
+          "size": 22165
+        },
+        {
+          "path": "markers_gallery.svg",
+          "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+          "size": 10058
+        },
+        {
+          "path": "markers_only.eps",
+          "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+          "size": 30048
+        },
+        {
+          "path": "markers_only.pdf",
+          "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+          "size": 21481
+        },
+        {
+          "path": "markers_only.png",
+          "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
+          "size": 30486
+        },
+        {
+          "path": "markers_only.svg",
+          "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+          "size": 11142
+        },
+        {
+          "path": "mathtext.eps",
+          "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+          "size": 10620
+        },
+        {
+          "path": "mathtext.pdf",
+          "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+          "size": 6839
+        },
+        {
+          "path": "mathtext.png",
+          "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
+          "size": 32840
+        },
+        {
+          "path": "mathtext.svg",
+          "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+          "size": 8901
+        },
+        {
+          "path": "mathtext_frac.eps",
+          "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+          "size": 16086
+        },
+        {
+          "path": "mathtext_frac.pdf",
+          "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+          "size": 11400
+        },
+        {
+          "path": "mathtext_frac.png",
+          "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
+          "size": 32506
+        },
+        {
+          "path": "mathtext_frac.svg",
+          "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+          "size": 9515
+        },
+        {
+          "path": "matshow.eps",
+          "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+          "size": 447767
+        },
+        {
+          "path": "matshow.pdf",
+          "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+          "size": 5415
+        },
+        {
+          "path": "matshow.png",
+          "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
+          "size": 12239
+        },
+        {
+          "path": "matshow.svg",
+          "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+          "size": 7206
+        },
+        {
+          "path": "mosaic.eps",
+          "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+          "size": 19753
+        },
+        {
+          "path": "mosaic.pdf",
+          "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+          "size": 13130
+        },
+        {
+          "path": "mosaic.png",
+          "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
+          "size": 37933
+        },
+        {
+          "path": "mosaic.svg",
+          "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+          "size": 15857
+        },
+        {
+          "path": "multi_style.eps",
+          "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+          "size": 107472
+        },
+        {
+          "path": "multi_style.pdf",
+          "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+          "size": 81820
+        },
+        {
+          "path": "multi_style.png",
+          "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
+          "size": 47468
+        },
+        {
+          "path": "multi_style.svg",
+          "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+          "size": 28914
+        },
+        {
+          "path": "nan_gap.eps",
+          "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+          "size": 27755
+        },
+        {
+          "path": "nan_gap.pdf",
+          "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+          "size": 19760
+        },
+        {
+          "path": "nan_gap.png",
+          "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
+          "size": 34425
+        },
+        {
+          "path": "nan_gap.svg",
+          "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+          "size": 11312
+        },
+        {
+          "path": "norms.eps",
+          "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+          "size": 236860
+        },
+        {
+          "path": "norms.pdf",
+          "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+          "size": 9153
+        },
+        {
+          "path": "norms.png",
+          "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
+          "size": 21488
+        },
+        {
+          "path": "norms.svg",
+          "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+          "size": 12345
+        },
+        {
+          "path": "offset_text.eps",
+          "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+          "size": 8853
+        },
+        {
+          "path": "offset_text.pdf",
+          "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+          "size": 6025
+        },
+        {
+          "path": "offset_text.png",
+          "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
+          "size": 31008
+        },
+        {
+          "path": "offset_text.svg",
+          "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+          "size": 7054
+        },
+        {
+          "path": "patches.eps",
+          "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+          "size": 9242
+        },
+        {
+          "path": "patches.pdf",
+          "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+          "size": 6797
+        },
+        {
+          "path": "patches.png",
+          "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
+          "size": 25198
+        },
+        {
+          "path": "patches.svg",
+          "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+          "size": 7157
+        },
+        {
+          "path": "patches_path.eps",
+          "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+          "size": 5626
+        },
+        {
+          "path": "patches_path.pdf",
+          "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+          "size": 3692
+        },
+        {
+          "path": "patches_path.png",
+          "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
+          "size": 30023
+        },
+        {
+          "path": "patches_path.svg",
+          "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+          "size": 4249
+        },
+        {
+          "path": "pcolormesh.eps",
+          "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+          "size": 44989
+        },
+        {
+          "path": "pcolormesh.pdf",
+          "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+          "size": 25245
+        },
+        {
+          "path": "pcolormesh.png",
+          "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
+          "size": 21262
+        },
+        {
+          "path": "pcolormesh.svg",
+          "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+          "size": 21696
+        },
+        {
+          "path": "pie.eps",
+          "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+          "size": 2987
+        },
+        {
+          "path": "pie.pdf",
+          "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+          "size": 2936
+        },
+        {
+          "path": "pie.png",
+          "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+          "size": 23571
+        },
+        {
+          "path": "pie.svg",
+          "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+          "size": 2476
+        },
+        {
+          "path": "pie_opts.eps",
+          "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+          "size": 3945
+        },
+        {
+          "path": "pie_opts.pdf",
+          "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+          "size": 3612
+        },
+        {
+          "path": "pie_opts.png",
+          "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+          "size": 32364
+        },
+        {
+          "path": "pie_opts.svg",
+          "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+          "size": 3469
+        },
+        {
+          "path": "plot_y.eps",
+          "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+          "size": 64767
+        },
+        {
+          "path": "plot_y.pdf",
+          "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+          "size": 47987
+        },
+        {
+          "path": "plot_y.png",
+          "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
+          "size": 40207
+        },
+        {
+          "path": "plot_y.svg",
+          "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+          "size": 19461
+        },
+        {
+          "path": "polar.eps",
+          "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+          "size": 54459
+        },
+        {
+          "path": "polar.pdf",
+          "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+          "size": 43857
+        },
+        {
+          "path": "polar.png",
+          "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+          "size": 72845
+        },
+        {
+          "path": "polar.svg",
+          "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+          "size": 44319
+        },
+        {
+          "path": "quiver.eps",
+          "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+          "size": 24007
+        },
+        {
+          "path": "quiver.pdf",
+          "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+          "size": 17046
+        },
+        {
+          "path": "quiver.png",
+          "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
+          "size": 39122
+        },
+        {
+          "path": "quiver.svg",
+          "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+          "size": 16554
+        },
+        {
+          "path": "quiver3d.eps",
+          "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+          "size": 16864
+        },
+        {
+          "path": "quiver3d.pdf",
+          "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+          "size": 10205
+        },
+        {
+          "path": "quiver3d.png",
+          "sha256": "9a1adedd15b285273be9136f6733412bdc012e860a213e8eb85d65d5c6a7457a",
+          "size": 83816
+        },
+        {
+          "path": "quiver3d.svg",
+          "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+          "size": 11387
+        },
+        {
+          "path": "savefig_tight.eps",
+          "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+          "size": 4931
+        },
+        {
+          "path": "savefig_tight.pdf",
+          "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+          "size": 3211
+        },
+        {
+          "path": "savefig_tight.png",
+          "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+          "size": 68856
+        },
+        {
+          "path": "savefig_tight.svg",
+          "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+          "size": 3941
+        },
+        {
+          "path": "scatter.eps",
+          "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+          "size": 23854
+        },
+        {
+          "path": "scatter.pdf",
+          "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+          "size": 17031
+        },
+        {
+          "path": "scatter.png",
+          "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
+          "size": 24876
+        },
+        {
+          "path": "scatter.svg",
+          "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+          "size": 8371
+        },
+        {
+          "path": "scatter_cmap.eps",
+          "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+          "size": 36048
+        },
+        {
+          "path": "scatter_cmap.pdf",
+          "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+          "size": 23357
+        },
+        {
+          "path": "scatter_cmap.png",
+          "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
+          "size": 34752
+        },
+        {
+          "path": "scatter_cmap.svg",
+          "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+          "size": 21482
+        },
+        {
+          "path": "scatter_edge.eps",
+          "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+          "size": 26390
+        },
+        {
+          "path": "scatter_edge.pdf",
+          "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+          "size": 18737
+        },
+        {
+          "path": "scatter_edge.png",
+          "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
+          "size": 47476
+        },
+        {
+          "path": "scatter_edge.svg",
+          "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+          "size": 16259
+        },
+        {
+          "path": "semilogx.eps",
+          "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+          "size": 10132
+        },
+        {
+          "path": "semilogx.pdf",
+          "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+          "size": 6063
+        },
+        {
+          "path": "semilogx.png",
+          "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
+          "size": 22201
+        },
+        {
+          "path": "semilogx.svg",
+          "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+          "size": 7013
+        },
+        {
+          "path": "semilogy.eps",
+          "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+          "size": 25097
+        },
+        {
+          "path": "semilogy.pdf",
+          "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+          "size": 15725
+        },
+        {
+          "path": "semilogy.png",
+          "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
+          "size": 28573
+        },
+        {
+          "path": "semilogy.svg",
+          "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+          "size": 12650
+        },
+        {
+          "path": "spans.eps",
+          "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+          "size": 9679
+        },
+        {
+          "path": "spans.pdf",
+          "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+          "size": 6618
+        },
+        {
+          "path": "spans.png",
+          "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
+          "size": 32647
+        },
+        {
+          "path": "spans.svg",
+          "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+          "size": 7407
+        },
+        {
+          "path": "stem.eps",
+          "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+          "size": 8915
+        },
+        {
+          "path": "stem.pdf",
+          "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+          "size": 6069
+        },
+        {
+          "path": "stem.png",
+          "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
+          "size": 14320
+        },
+        {
+          "path": "stem.svg",
+          "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+          "size": 5699
+        },
+        {
+          "path": "step.eps",
+          "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+          "size": 4766
+        },
+        {
+          "path": "step.pdf",
+          "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+          "size": 3178
+        },
+        {
+          "path": "step.png",
+          "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
+          "size": 13186
+        },
+        {
+          "path": "step.svg",
+          "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+          "size": 3738
+        },
+        {
+          "path": "streamplot.eps",
+          "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+          "size": 81375
+        },
+        {
+          "path": "streamplot.pdf",
+          "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+          "size": 58212
+        },
+        {
+          "path": "streamplot.png",
+          "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
+          "size": 121548
+        },
+        {
+          "path": "streamplot.svg",
+          "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+          "size": 52950
+        },
+        {
+          "path": "style_ggplot.eps",
+          "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+          "size": 16495
+        },
+        {
+          "path": "style_ggplot.pdf",
+          "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+          "size": 11341
+        },
+        {
+          "path": "style_ggplot.png",
+          "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+          "size": 44679
+        },
+        {
+          "path": "style_ggplot.svg",
+          "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+          "size": 11595
+        },
+        {
+          "path": "subplots_2x1.eps",
+          "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+          "size": 21216
+        },
+        {
+          "path": "subplots_2x1.pdf",
+          "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+          "size": 13468
+        },
+        {
+          "path": "subplots_2x1.png",
+          "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
+          "size": 39291
+        },
+        {
+          "path": "subplots_2x1.svg",
+          "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+          "size": 15344
+        },
+        {
+          "path": "subplots_2x2.eps",
+          "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+          "size": 34200
+        },
+        {
+          "path": "subplots_2x2.pdf",
+          "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+          "size": 21509
+        },
+        {
+          "path": "subplots_2x2.png",
+          "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
+          "size": 51598
+        },
+        {
+          "path": "subplots_2x2.svg",
+          "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+          "size": 24426
+        },
+        {
+          "path": "subplots_adjust.eps",
+          "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+          "size": 7016
+        },
+        {
+          "path": "subplots_adjust.pdf",
+          "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+          "size": 4268
+        },
+        {
+          "path": "subplots_adjust.png",
+          "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+          "size": 30126
+        },
+        {
+          "path": "subplots_adjust.svg",
+          "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+          "size": 5528
+        },
+        {
+          "path": "subplots_shared.eps",
+          "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+          "size": 38590
+        },
+        {
+          "path": "subplots_shared.pdf",
+          "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+          "size": 25381
+        },
+        {
+          "path": "subplots_shared.png",
+          "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
+          "size": 43211
+        },
+        {
+          "path": "subplots_shared.svg",
+          "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+          "size": 20390
+        },
+        {
+          "path": "surface3d.eps",
+          "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+          "size": 291685
+        },
+        {
+          "path": "surface3d.pdf",
+          "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+          "size": 173038
+        },
+        {
+          "path": "surface3d.png",
+          "sha256": "641b388d9280d1eaae87949e9a5973767eb165ee103332c44cc0884ecde729cf",
+          "size": 86896
+        },
+        {
+          "path": "surface3d.svg",
+          "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+          "size": 153557
+        },
+        {
+          "path": "surface3d_extra.eps",
+          "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+          "size": 359363
+        },
+        {
+          "path": "surface3d_extra.pdf",
+          "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+          "size": 224681
+        },
+        {
+          "path": "surface3d_extra.png",
+          "sha256": "e0296bfcc363b006c82cfe98ae573382718734789d06123d3edb1738d3a1dba9",
+          "size": 109161
+        },
+        {
+          "path": "surface3d_extra.svg",
+          "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+          "size": 206292
+        },
+        {
+          "path": "symlog.eps",
+          "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+          "size": 11340
+        },
+        {
+          "path": "symlog.pdf",
+          "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+          "size": 8163
+        },
+        {
+          "path": "symlog.png",
+          "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
+          "size": 22352
+        },
+        {
+          "path": "symlog.svg",
+          "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+          "size": 9070
+        },
+        {
+          "path": "table.eps",
+          "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
+          "size": 6280
+        },
+        {
+          "path": "table.pdf",
+          "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
+          "size": 4165
+        },
+        {
+          "path": "table.png",
+          "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+          "size": 14863
+        },
+        {
+          "path": "table.svg",
+          "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
+          "size": 4641
+        },
+        {
+          "path": "text_annotate.eps",
+          "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+          "size": 12522
+        },
+        {
+          "path": "text_annotate.pdf",
+          "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+          "size": 8311
+        },
+        {
+          "path": "text_annotate.png",
+          "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
+          "size": 34868
+        },
+        {
+          "path": "text_annotate.svg",
+          "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+          "size": 8957
+        },
+        {
+          "path": "text_options.eps",
+          "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+          "size": 9611
+        },
+        {
+          "path": "text_options.pdf",
+          "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+          "size": 6578
+        },
+        {
+          "path": "text_options.png",
+          "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
+          "size": 33984
+        },
+        {
+          "path": "text_options.svg",
+          "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+          "size": 7763
+        },
+        {
+          "path": "tick_locator.eps",
+          "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+          "size": 13359
+        },
+        {
+          "path": "tick_locator.pdf",
+          "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+          "size": 9119
+        },
+        {
+          "path": "tick_locator.png",
+          "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+          "size": 32671
+        },
+        {
+          "path": "tick_locator.svg",
+          "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+          "size": 10692
+        },
+        {
+          "path": "tick_style.eps",
+          "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+          "size": 4743
+        },
+        {
+          "path": "tick_style.pdf",
+          "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+          "size": 3327
+        },
+        {
+          "path": "tick_style.png",
+          "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
+          "size": 27448
+        },
+        {
+          "path": "tick_style.svg",
+          "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+          "size": 3947
+        },
+        {
+          "path": "ticks_legend.eps",
+          "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+          "size": 13957
+        },
+        {
+          "path": "ticks_legend.pdf",
+          "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+          "size": 9476
+        },
+        {
+          "path": "ticks_legend.png",
+          "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+          "size": 35711
+        },
+        {
+          "path": "ticks_legend.svg",
+          "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+          "size": 10721
+        },
+        {
+          "path": "tight_layout.eps",
+          "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+          "size": 9091
+        },
+        {
+          "path": "tight_layout.pdf",
+          "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+          "size": 5147
+        },
+        {
+          "path": "tight_layout.png",
+          "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
+          "size": 40701
+        },
+        {
+          "path": "tight_layout.svg",
+          "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+          "size": 7137
+        },
+        {
+          "path": "title_loc.eps",
+          "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+          "size": 8834
+        },
+        {
+          "path": "title_loc.pdf",
+          "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+          "size": 6008
+        },
+        {
+          "path": "title_loc.png",
+          "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
+          "size": 28887
+        },
+        {
+          "path": "title_loc.svg",
+          "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+          "size": 7093
+        },
+        {
+          "path": "transform_axes.eps",
+          "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+          "size": 8885
+        },
+        {
+          "path": "transform_axes.pdf",
+          "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+          "size": 6124
+        },
+        {
+          "path": "transform_axes.png",
+          "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
+          "size": 33813
+        },
+        {
+          "path": "transform_axes.svg",
+          "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+          "size": 7107
+        },
+        {
+          "path": "tricontour.eps",
+          "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+          "size": 73430
+        },
+        {
+          "path": "tricontour.pdf",
+          "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+          "size": 46453
+        },
+        {
+          "path": "tricontour.png",
+          "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
+          "size": 82284
+        },
+        {
+          "path": "tricontour.svg",
+          "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+          "size": 44665
+        },
+        {
+          "path": "tricontourf.eps",
+          "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+          "size": 196467
+        },
+        {
+          "path": "tricontourf.pdf",
+          "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+          "size": 120784
+        },
+        {
+          "path": "tricontourf.png",
+          "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
+          "size": 100624
+        },
+        {
+          "path": "tricontourf.svg",
+          "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+          "size": 89950
+        },
+        {
+          "path": "tripcolor.eps",
+          "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+          "size": 31920
+        },
+        {
+          "path": "tripcolor.pdf",
+          "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+          "size": 18630
+        },
+        {
+          "path": "tripcolor.png",
+          "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
+          "size": 55772
+        },
+        {
+          "path": "tripcolor.svg",
+          "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+          "size": 16074
+        },
+        {
+          "path": "triplot.eps",
+          "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+          "size": 28434
+        },
+        {
+          "path": "triplot.pdf",
+          "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+          "size": 19818
+        },
+        {
+          "path": "triplot.png",
+          "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
+          "size": 81306
+        },
+        {
+          "path": "triplot.svg",
+          "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+          "size": 13460
+        },
+        {
+          "path": "trisurf.eps",
+          "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+          "size": 42561
+        },
+        {
+          "path": "trisurf.pdf",
+          "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+          "size": 24733
+        },
+        {
+          "path": "trisurf.png",
+          "sha256": "e22fdf4a34bfeb3ee1a8e2982c5996583355eb15d70e9a2e256b4c404bd64615",
+          "size": 78115
+        },
+        {
+          "path": "trisurf.svg",
+          "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+          "size": 23721
+        },
+        {
+          "path": "twinx.eps",
+          "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+          "size": 7293
+        },
+        {
+          "path": "twinx.pdf",
+          "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+          "size": 4337
+        },
+        {
+          "path": "twinx.png",
+          "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
+          "size": 35700
+        },
+        {
+          "path": "twinx.svg",
+          "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+          "size": 5886
+        },
+        {
+          "path": "violin_opts.eps",
+          "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+          "size": 30952
+        },
+        {
+          "path": "violin_opts.pdf",
+          "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+          "size": 23990
+        },
+        {
+          "path": "violin_opts.png",
+          "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
+          "size": 24826
+        },
+        {
+          "path": "violin_opts.svg",
+          "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+          "size": 24473
+        },
+        {
+          "path": "violinplot.eps",
+          "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+          "size": 17583
+        },
+        {
+          "path": "violinplot.pdf",
+          "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+          "size": 13475
+        },
+        {
+          "path": "violinplot.png",
+          "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
+          "size": 20863
+        },
+        {
+          "path": "violinplot.svg",
+          "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+          "size": 13823
+        },
+        {
+          "path": "zorder.eps",
+          "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+          "size": 10414
+        },
+        {
+          "path": "zorder.pdf",
+          "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+          "size": 6442
+        },
+        {
+          "path": "zorder.png",
+          "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
+          "size": 31537
+        },
+        {
+          "path": "zorder.svg",
+          "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+          "size": 6551
+        }
+      ],
+      "generated_from": "tests/out"
     }
-  ],
-  "generated_from": "tests/out",
-  "version": 1
+  },
+  "version": 2
 }

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -1,0 +1,2491 @@
+{
+  "files": [
+    {
+      "path": "alpha.eps",
+      "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+      "size": 80981
+    },
+    {
+      "path": "alpha.pdf",
+      "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+      "size": 58537
+    },
+    {
+      "path": "alpha.png",
+      "sha256": "07ecb1969114f66d77a033eff6bb662e3834e8e149d0dc8bb731708abe95e46e",
+      "size": 60468
+    },
+    {
+      "path": "alpha.svg",
+      "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+      "size": 29813
+    },
+    {
+      "path": "anim_sine.gif",
+      "sha256": "574959a33e3dae5b8d74de2b0e75d083061782f69d65b35f1bd812d4f00201f2",
+      "size": 146758
+    },
+    {
+      "path": "annotate_arrow.eps",
+      "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+      "size": 9706
+    },
+    {
+      "path": "annotate_arrow.pdf",
+      "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+      "size": 6618
+    },
+    {
+      "path": "annotate_arrow.png",
+      "sha256": "4dc7b3e0c5e43c6e85fbcdee488107b10e8dd4f939db38a79597358d90b13005",
+      "size": 35121
+    },
+    {
+      "path": "annotate_arrow.svg",
+      "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+      "size": 7557
+    },
+    {
+      "path": "annotate_curve.eps",
+      "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+      "size": 9940
+    },
+    {
+      "path": "annotate_curve.pdf",
+      "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+      "size": 6765
+    },
+    {
+      "path": "annotate_curve.png",
+      "sha256": "e9476a29341370bf66dd8ad476cc8f3ef592c76d88425b6c47cd51b72842d443",
+      "size": 35035
+    },
+    {
+      "path": "annotate_curve.svg",
+      "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+      "size": 7615
+    },
+    {
+      "path": "axes_facecolor.eps",
+      "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+      "size": 17496
+    },
+    {
+      "path": "axes_facecolor.pdf",
+      "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+      "size": 11466
+    },
+    {
+      "path": "axes_facecolor.png",
+      "sha256": "04d8ae7184e6b50da3cd001bdfa17f4c3ba835a425ddda75373e862375c9288a",
+      "size": 40471
+    },
+    {
+      "path": "axes_facecolor.svg",
+      "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+      "size": 13174
+    },
+    {
+      "path": "axes_handles2.eps",
+      "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+      "size": 26227
+    },
+    {
+      "path": "axes_handles2.pdf",
+      "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+      "size": 16957
+    },
+    {
+      "path": "axes_handles2.png",
+      "sha256": "63e5b5ab0bbcc4fa2dfa098e7bc03edaf8061a493612b0e6db250557519f32c2",
+      "size": 32163
+    },
+    {
+      "path": "axes_handles2.svg",
+      "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+      "size": 19863
+    },
+    {
+      "path": "axis_equal.eps",
+      "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+      "size": 8082
+    },
+    {
+      "path": "axis_equal.pdf",
+      "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+      "size": 5385
+    },
+    {
+      "path": "axis_equal.png",
+      "sha256": "e612d12923be05a5401f3339b1e6f303604ff32af1c56b83af3e58cbe12d081a",
+      "size": 18657
+    },
+    {
+      "path": "axis_equal.svg",
+      "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+      "size": 4733
+    },
+    {
+      "path": "bar.eps",
+      "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+      "size": 7532
+    },
+    {
+      "path": "bar.pdf",
+      "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+      "size": 4363
+    },
+    {
+      "path": "bar.png",
+      "sha256": "37c1c22bcc09e47558837f086bdf91af9d9b5ae0f257ebecc192bced2833e2dc",
+      "size": 17029
+    },
+    {
+      "path": "bar.svg",
+      "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+      "size": 5255
+    },
+    {
+      "path": "bar3d.eps",
+      "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+      "size": 34185
+    },
+    {
+      "path": "bar3d.pdf",
+      "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+      "size": 20605
+    },
+    {
+      "path": "bar3d.png",
+      "sha256": "6cb71a60a5b74a3808f6999efc211284a3b49b290c790d20f4907320785d46c1",
+      "size": 57527
+    },
+    {
+      "path": "bar3d.svg",
+      "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+      "size": 20023
+    },
+    {
+      "path": "bar_colors.eps",
+      "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+      "size": 7530
+    },
+    {
+      "path": "bar_colors.pdf",
+      "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+      "size": 4571
+    },
+    {
+      "path": "bar_colors.png",
+      "sha256": "aa9adc5bd8dd63e93fd40c0d4b7fc92fa7cf757836d5089626f552da243db170",
+      "size": 17074
+    },
+    {
+      "path": "bar_colors.svg",
+      "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+      "size": 5449
+    },
+    {
+      "path": "bar_err.eps",
+      "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+      "size": 10265
+    },
+    {
+      "path": "bar_err.pdf",
+      "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+      "size": 5894
+    },
+    {
+      "path": "bar_err.png",
+      "sha256": "9195f7f1e7d346850fcf22b525af69b64725aeae6428bc68b44b09f7f3d8dccc",
+      "size": 16414
+    },
+    {
+      "path": "bar_err.svg",
+      "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+      "size": 7040
+    },
+    {
+      "path": "bar_stacked.eps",
+      "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+      "size": 10296
+    },
+    {
+      "path": "bar_stacked.pdf",
+      "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+      "size": 5771
+    },
+    {
+      "path": "bar_stacked.png",
+      "sha256": "ea44efcc2371d9042e9c4c44176142219fe81bd984f935a253524fc2fbeedb98",
+      "size": 18411
+    },
+    {
+      "path": "bar_stacked.svg",
+      "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+      "size": 6771
+    },
+    {
+      "path": "barh.eps",
+      "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+      "size": 6714
+    },
+    {
+      "path": "barh.pdf",
+      "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+      "size": 4007
+    },
+    {
+      "path": "barh.png",
+      "sha256": "a0d33b8bed3c2b316167c88d6299bce8310ea721453e0ba6678546439535a768",
+      "size": 13399
+    },
+    {
+      "path": "barh.svg",
+      "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+      "size": 4634
+    },
+    {
+      "path": "basic_line.eps",
+      "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+      "size": 10559
+    },
+    {
+      "path": "basic_line.pdf",
+      "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+      "size": 7090
+    },
+    {
+      "path": "basic_line.png",
+      "sha256": "1d87234424f4b47477a34c0bd6885775ffca8eb0ef47fa16280fda11ae3e6bb3",
+      "size": 27135
+    },
+    {
+      "path": "basic_line.svg",
+      "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+      "size": 7592
+    },
+    {
+      "path": "box_opts.eps",
+      "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+      "size": 12228
+    },
+    {
+      "path": "box_opts.pdf",
+      "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+      "size": 7789
+    },
+    {
+      "path": "box_opts.png",
+      "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+      "size": 19358
+    },
+    {
+      "path": "box_opts.svg",
+      "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+      "size": 8234
+    },
+    {
+      "path": "boxplot.eps",
+      "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+      "size": 7338
+    },
+    {
+      "path": "boxplot.pdf",
+      "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+      "size": 4561
+    },
+    {
+      "path": "boxplot.png",
+      "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+      "size": 14315
+    },
+    {
+      "path": "boxplot.svg",
+      "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+      "size": 5158
+    },
+    {
+      "path": "broken_barh.eps",
+      "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+      "size": 4871
+    },
+    {
+      "path": "broken_barh.pdf",
+      "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+      "size": 3421
+    },
+    {
+      "path": "broken_barh.png",
+      "sha256": "d83a057438b77216a20ef99ac9ce7c8827dedaf59ec84c7fab2f9b2e0f4d6308",
+      "size": 14714
+    },
+    {
+      "path": "broken_barh.svg",
+      "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+      "size": 3619
+    },
+    {
+      "path": "categorical.eps",
+      "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+      "size": 5691
+    },
+    {
+      "path": "categorical.pdf",
+      "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+      "size": 3529
+    },
+    {
+      "path": "categorical.png",
+      "sha256": "ffe1645b2ffe1e0fda9f849167988f493007b2b91cac41f2eb912cad3da2bcc2",
+      "size": 17291
+    },
+    {
+      "path": "categorical.svg",
+      "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+      "size": 4113
+    },
+    {
+      "path": "clabel.eps",
+      "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+      "size": 14848
+    },
+    {
+      "path": "clabel.pdf",
+      "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+      "size": 10428
+    },
+    {
+      "path": "clabel.png",
+      "sha256": "c6bab040b98b9ab97fcc81766631f8658bb533f5ae739ea29bd2342bf847f8db",
+      "size": 62827
+    },
+    {
+      "path": "clabel.svg",
+      "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+      "size": 11171
+    },
+    {
+      "path": "cmap_discrete.eps",
+      "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+      "size": 165754
+    },
+    {
+      "path": "cmap_discrete.pdf",
+      "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+      "size": 6561
+    },
+    {
+      "path": "cmap_discrete.png",
+      "sha256": "c7af5f0c36bca972c3dbbc2caa88588662d41ebf2694cdb911825d99b4219826",
+      "size": 17689
+    },
+    {
+      "path": "cmap_discrete.svg",
+      "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+      "size": 9074
+    },
+    {
+      "path": "cmap_lognorm.eps",
+      "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+      "size": 495916
+    },
+    {
+      "path": "cmap_lognorm.pdf",
+      "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+      "size": 13628
+    },
+    {
+      "path": "cmap_lognorm.png",
+      "sha256": "b7d12c7f97a55e0de7cc6c2b82c0ff77a534de922fc0eb3e5058fe183179896e",
+      "size": 18530
+    },
+    {
+      "path": "cmap_lognorm.svg",
+      "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+      "size": 15377
+    },
+    {
+      "path": "cmap_reversed.eps",
+      "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+      "size": 496738
+    },
+    {
+      "path": "cmap_reversed.pdf",
+      "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+      "size": 14516
+    },
+    {
+      "path": "cmap_reversed.png",
+      "sha256": "e24a0ae1da012109ec0dd627e6f3e47c2a7e59e3985b216fd8b744f174c748de",
+      "size": 19713
+    },
+    {
+      "path": "cmap_reversed.svg",
+      "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+      "size": 15977
+    },
+    {
+      "path": "cmap_special.eps",
+      "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+      "size": 385887
+    },
+    {
+      "path": "cmap_special.pdf",
+      "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+      "size": 8509
+    },
+    {
+      "path": "cmap_special.png",
+      "sha256": "1465e72fd667c2d73e0a1dab5310f19ea8c6e30fc72fbb3e94a730523d22faab",
+      "size": 22036
+    },
+    {
+      "path": "cmap_special.svg",
+      "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+      "size": 10971
+    },
+    {
+      "path": "colorbar_orient.eps",
+      "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+      "size": 481251
+    },
+    {
+      "path": "colorbar_orient.pdf",
+      "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+      "size": 24888
+    },
+    {
+      "path": "colorbar_orient.png",
+      "sha256": "31d6664d98e5af86ad074753f871770c5648a314b3915f8d5089c7140c42b403",
+      "size": 23198
+    },
+    {
+      "path": "colorbar_orient.svg",
+      "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+      "size": 25679
+    },
+    {
+      "path": "colors.eps",
+      "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+      "size": 5537
+    },
+    {
+      "path": "colors.pdf",
+      "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+      "size": 3660
+    },
+    {
+      "path": "colors.png",
+      "sha256": "4dbbe1847abc5837b4745470500adb1260063f84b7c21c7b2d7e76abbc3458f5",
+      "size": 15230
+    },
+    {
+      "path": "colors.svg",
+      "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+      "size": 4189
+    },
+    {
+      "path": "constrained.eps",
+      "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+      "size": 15645
+    },
+    {
+      "path": "constrained.pdf",
+      "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+      "size": 10197
+    },
+    {
+      "path": "constrained.png",
+      "sha256": "cd2b56719eeaa707af8ce0e48cb426c96d303ce76a1cadfc879b724f5b1d253b",
+      "size": 46857
+    },
+    {
+      "path": "constrained.svg",
+      "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+      "size": 12564
+    },
+    {
+      "path": "contour.eps",
+      "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+      "size": 12891
+    },
+    {
+      "path": "contour.pdf",
+      "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+      "size": 8839
+    },
+    {
+      "path": "contour.png",
+      "sha256": "906d3395fc1c56c27b91fa4817770e55a85e475f3fba8ff250f0a634b89a07b6",
+      "size": 65492
+    },
+    {
+      "path": "contour.svg",
+      "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+      "size": 9576
+    },
+    {
+      "path": "contour3d.eps",
+      "sha256": "0357adf629cd735bd9189a54fd355cd38f0c5c63ed6f763c9f12c9fbf60a02e0",
+      "size": 36513
+    },
+    {
+      "path": "contour3d.pdf",
+      "sha256": "6b040a3b0d957cdfe74a1a167d4dd200a019f723f9df21670df01158a3f9d309",
+      "size": 26115
+    },
+    {
+      "path": "contour3d.png",
+      "sha256": "f0237ea244826fcfcc9ae30e9abf1f63f3157c5a05bfd70c7287ad26a993de4c",
+      "size": 94817
+    },
+    {
+      "path": "contour3d.svg",
+      "sha256": "c506f10d7db99b709193aa8633940cdd1c81e0f4fc0f191330f9f716d009b055",
+      "size": 27643
+    },
+    {
+      "path": "contourf.eps",
+      "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+      "size": 148542
+    },
+    {
+      "path": "contourf.pdf",
+      "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+      "size": 88734
+    },
+    {
+      "path": "contourf.png",
+      "sha256": "e6277e753895172d7b0250933437c2307c208ef60503f28c19b75841f79874ac",
+      "size": 65324
+    },
+    {
+      "path": "contourf.svg",
+      "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+      "size": 66386
+    },
+    {
+      "path": "dates.eps",
+      "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+      "size": 16170
+    },
+    {
+      "path": "dates.pdf",
+      "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+      "size": 12158
+    },
+    {
+      "path": "dates.png",
+      "sha256": "931e0df5017d917d93c34f02b5fa1bfe8820ab9ce776c089468bf7ac8bfc21e3",
+      "size": 33847
+    },
+    {
+      "path": "dates.svg",
+      "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+      "size": 13055
+    },
+    {
+      "path": "errorbar.eps",
+      "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+      "size": 18677
+    },
+    {
+      "path": "errorbar.pdf",
+      "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+      "size": 12254
+    },
+    {
+      "path": "errorbar.png",
+      "sha256": "d4cda608c712b4b476f6e1e2a0c6c1b037458ccfcdcfa2527141e3730741a97c",
+      "size": 26603
+    },
+    {
+      "path": "errorbar.svg",
+      "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+      "size": 9685
+    },
+    {
+      "path": "errorbar_xy.eps",
+      "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+      "size": 19492
+    },
+    {
+      "path": "errorbar_xy.pdf",
+      "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+      "size": 12891
+    },
+    {
+      "path": "errorbar_xy.png",
+      "sha256": "aafb1cc4cec8a007ece0f664dbfcf6520a8182ed0c5fa5e2409f4c89cbc8ffee",
+      "size": 18310
+    },
+    {
+      "path": "errorbar_xy.svg",
+      "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+      "size": 9803
+    },
+    {
+      "path": "eventplot.eps",
+      "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+      "size": 14362
+    },
+    {
+      "path": "eventplot.pdf",
+      "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+      "size": 8864
+    },
+    {
+      "path": "eventplot.png",
+      "sha256": "2c07b27119f11d7758e5acf1eb3094b6bb4c9ec1cdbb4470ec1eb1c2342ee9d8",
+      "size": 19220
+    },
+    {
+      "path": "eventplot.svg",
+      "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+      "size": 8618
+    },
+    {
+      "path": "facecolor.eps",
+      "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+      "size": 12235
+    },
+    {
+      "path": "facecolor.pdf",
+      "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+      "size": 8108
+    },
+    {
+      "path": "facecolor.png",
+      "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+      "size": 32314
+    },
+    {
+      "path": "facecolor.svg",
+      "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+      "size": 8675
+    },
+    {
+      "path": "figlegend.eps",
+      "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+      "size": 15657
+    },
+    {
+      "path": "figlegend.pdf",
+      "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+      "size": 10220
+    },
+    {
+      "path": "figlegend.png",
+      "sha256": "4c268124a7756617b26a8f5b72d76fe5ddcc6a4f814cc46d95ed4b62faf6529a",
+      "size": 38060
+    },
+    {
+      "path": "figlegend.svg",
+      "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+      "size": 12445
+    },
+    {
+      "path": "figsize.eps",
+      "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+      "size": 10482
+    },
+    {
+      "path": "figsize.pdf",
+      "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+      "size": 7028
+    },
+    {
+      "path": "figsize.png",
+      "sha256": "6255d60791fb1111d5d60ed70effebf76a65325139041c5ac1c5c4ce7cc34b1c",
+      "size": 24009
+    },
+    {
+      "path": "figsize.svg",
+      "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+      "size": 7577
+    },
+    {
+      "path": "figures.eps",
+      "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+      "size": 4606
+    },
+    {
+      "path": "figures.pdf",
+      "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+      "size": 3048
+    },
+    {
+      "path": "figures.png",
+      "sha256": "fe06a728430bab0eddfa0cb1a698549fd68c331ac8b68595da685d22c3be7dbb",
+      "size": 25900
+    },
+    {
+      "path": "figures.svg",
+      "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+      "size": 3628
+    },
+    {
+      "path": "fill_between.eps",
+      "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+      "size": 18796
+    },
+    {
+      "path": "fill_between.pdf",
+      "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+      "size": 13247
+    },
+    {
+      "path": "fill_between.png",
+      "sha256": "cf27a182ddb40781a17423b809123e735b38104c094496bea53089f0fe588bc4",
+      "size": 39611
+    },
+    {
+      "path": "fill_between.svg",
+      "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+      "size": 13950
+    },
+    {
+      "path": "fill_where.eps",
+      "sha256": "0bbcde00b548d606ea59a21bf4702eda2215c5001677b99068728dadd3e7d027",
+      "size": 14886
+    },
+    {
+      "path": "fill_where.pdf",
+      "sha256": "60e67aee069327e3b44a91d24b30f1963f6918fc7331a150c9e0710691b1aa97",
+      "size": 10790
+    },
+    {
+      "path": "fill_where.png",
+      "sha256": "142c62aa5a3d729c8e469ad4d302c3f4eb8f442434350e71e5a94625b8a61dd0",
+      "size": 33717
+    },
+    {
+      "path": "fill_where.svg",
+      "sha256": "0963ffd7d058d35ef142d7e8c4302b8f50c25d51bafc605dc1695516bc2ddfb5",
+      "size": 11789
+    },
+    {
+      "path": "fills.eps",
+      "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+      "size": 17109
+    },
+    {
+      "path": "fills.pdf",
+      "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+      "size": 11768
+    },
+    {
+      "path": "fills.png",
+      "sha256": "e0fb7542631bacde9b4784ce9212e2992a28773fa43a1590fa28ba1b71c6cf94",
+      "size": 37226
+    },
+    {
+      "path": "fills.svg",
+      "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+      "size": 13423
+    },
+    {
+      "path": "font_faces.eps",
+      "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+      "size": 9227
+    },
+    {
+      "path": "font_faces.pdf",
+      "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+      "size": 6271
+    },
+    {
+      "path": "font_faces.png",
+      "sha256": "101b41c7244c721a962d75d50fa4891e870c1616c32b368a81d064ac884c12e9",
+      "size": 36737
+    },
+    {
+      "path": "font_faces.svg",
+      "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+      "size": 7508
+    },
+    {
+      "path": "fontsize.eps",
+      "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+      "size": 5477
+    },
+    {
+      "path": "fontsize.pdf",
+      "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+      "size": 3444
+    },
+    {
+      "path": "fontsize.png",
+      "sha256": "d3503f23cefe9696929e3b2d91e99dfdc7e24d83b06b262cc9a9d81485c8e72e",
+      "size": 32705
+    },
+    {
+      "path": "fontsize.svg",
+      "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+      "size": 4266
+    },
+    {
+      "path": "formatters.eps",
+      "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+      "size": 6509
+    },
+    {
+      "path": "formatters.pdf",
+      "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+      "size": 4947
+    },
+    {
+      "path": "formatters.png",
+      "sha256": "687fa980c0436ae9ea88eb17919d7d2adc1f68bc27816a750b1f9c9499d35517",
+      "size": 29499
+    },
+    {
+      "path": "formatters.svg",
+      "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+      "size": 5254
+    },
+    {
+      "path": "grid_options.eps",
+      "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+      "size": 36975
+    },
+    {
+      "path": "grid_options.pdf",
+      "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+      "size": 23143
+    },
+    {
+      "path": "grid_options.png",
+      "sha256": "56c7e6314055c365297aa7e54f294d938b400f8c316fd67a0a36ed25ad286595",
+      "size": 63085
+    },
+    {
+      "path": "grid_options.svg",
+      "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+      "size": 25186
+    },
+    {
+      "path": "grid_ratios.eps",
+      "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+      "size": 24813
+    },
+    {
+      "path": "grid_ratios.pdf",
+      "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+      "size": 16526
+    },
+    {
+      "path": "grid_ratios.png",
+      "sha256": "624604c21f01bd7254784a01afdd5dd93ab725a1230319dbf411eea15ebb0912",
+      "size": 40356
+    },
+    {
+      "path": "grid_ratios.svg",
+      "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+      "size": 19980
+    },
+    {
+      "path": "gridspec.eps",
+      "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+      "size": 20006
+    },
+    {
+      "path": "gridspec.pdf",
+      "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+      "size": 13384
+    },
+    {
+      "path": "gridspec.png",
+      "sha256": "a00cef8235ac1db7eb09e16bf11bb9eacc33c5f4e18f25ca20299698c35be5ab",
+      "size": 38342
+    },
+    {
+      "path": "gridspec.svg",
+      "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+      "size": 16082
+    },
+    {
+      "path": "hatch.eps",
+      "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+      "size": 43560
+    },
+    {
+      "path": "hatch.pdf",
+      "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+      "size": 26971
+    },
+    {
+      "path": "hatch.png",
+      "sha256": "5ede6f051a217bd08187243c20d95c015651f8493ddc5863ac655c7517324c67",
+      "size": 42010
+    },
+    {
+      "path": "hatch.svg",
+      "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+      "size": 26350
+    },
+    {
+      "path": "hexbin.eps",
+      "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+      "size": 75718
+    },
+    {
+      "path": "hexbin.pdf",
+      "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+      "size": 54711
+    },
+    {
+      "path": "hexbin.png",
+      "sha256": "11295914e8baf1395c5435c6a678a52ba67c38a861f517b46047c9e7809a12b8",
+      "size": 87042
+    },
+    {
+      "path": "hexbin.svg",
+      "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+      "size": 44436
+    },
+    {
+      "path": "hist.eps",
+      "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+      "size": 8501
+    },
+    {
+      "path": "hist.pdf",
+      "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+      "size": 4854
+    },
+    {
+      "path": "hist.png",
+      "sha256": "bc62c2da2aac0881453016ca9c91167c33829a3d08eef75a1593a025c82b12a0",
+      "size": 20119
+    },
+    {
+      "path": "hist.svg",
+      "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+      "size": 5634
+    },
+    {
+      "path": "hist2d.eps",
+      "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+      "size": 31502
+    },
+    {
+      "path": "hist2d.pdf",
+      "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+      "size": 17621
+    },
+    {
+      "path": "hist2d.png",
+      "sha256": "3dd82e4b2c66ecefb916da271c79083689fa50af7cbecd100837f39a1085994e",
+      "size": 20491
+    },
+    {
+      "path": "hist2d.svg",
+      "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+      "size": 14830
+    },
+    {
+      "path": "hist_bins.eps",
+      "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+      "size": 6748
+    },
+    {
+      "path": "hist_bins.pdf",
+      "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+      "size": 4027
+    },
+    {
+      "path": "hist_bins.png",
+      "sha256": "774d5737073c7050e48922624bed90fe0f254ffa4801cd533577277d30e9e76d",
+      "size": 17959
+    },
+    {
+      "path": "hist_bins.svg",
+      "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+      "size": 4773
+    },
+    {
+      "path": "hist_opts.eps",
+      "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+      "size": 9129
+    },
+    {
+      "path": "hist_opts.pdf",
+      "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+      "size": 5639
+    },
+    {
+      "path": "hist_opts.png",
+      "sha256": "e192286f37bc722166e018f8d887b85c3cf5448ebbb653f5e414f0e83b70d559",
+      "size": 19359
+    },
+    {
+      "path": "hist_opts.svg",
+      "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+      "size": 5852
+    },
+    {
+      "path": "hist_orient.eps",
+      "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+      "size": 21335
+    },
+    {
+      "path": "hist_orient.pdf",
+      "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+      "size": 11396
+    },
+    {
+      "path": "hist_orient.png",
+      "sha256": "4eb535a9d4c41acc7191f7a6da222947005f957cd7dc3cf837b347a718e08da1",
+      "size": 24932
+    },
+    {
+      "path": "hist_orient.svg",
+      "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+      "size": 13132
+    },
+    {
+      "path": "hist_stacked.eps",
+      "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+      "size": 12928
+    },
+    {
+      "path": "hist_stacked.pdf",
+      "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+      "size": 7090
+    },
+    {
+      "path": "hist_stacked.png",
+      "sha256": "402346081ce11d88c9c05e08ee20d6ef2a7d6afdc25f584ba04a3e745f36812f",
+      "size": 23306
+    },
+    {
+      "path": "hist_stacked.svg",
+      "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+      "size": 8591
+    },
+    {
+      "path": "hv_lines.eps",
+      "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+      "size": 13110
+    },
+    {
+      "path": "hv_lines.pdf",
+      "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+      "size": 8518
+    },
+    {
+      "path": "hv_lines.png",
+      "sha256": "bdc81a3e630afbfe8fb072cf2cbed290becf1495b070c1e1ee0cf8e18bf01b84",
+      "size": 36338
+    },
+    {
+      "path": "hv_lines.svg",
+      "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+      "size": 9248
+    },
+    {
+      "path": "imshow.eps",
+      "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+      "size": 417463
+    },
+    {
+      "path": "imshow.pdf",
+      "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+      "size": 6278
+    },
+    {
+      "path": "imshow.png",
+      "sha256": "aa533df49959beedc50037b95ff4e7a7a1cd7bf069936b016b6d126846e282d4",
+      "size": 15228
+    },
+    {
+      "path": "imshow.svg",
+      "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+      "size": 8275
+    },
+    {
+      "path": "imshow_cbar.eps",
+      "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+      "size": 272389
+    },
+    {
+      "path": "imshow_cbar.pdf",
+      "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+      "size": 13336
+    },
+    {
+      "path": "imshow_cbar.png",
+      "sha256": "df90f4156add3bbf7aeac24298b6b48594af044013a7149955717c794f49d77a",
+      "size": 24453
+    },
+    {
+      "path": "imshow_cbar.svg",
+      "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+      "size": 14287
+    },
+    {
+      "path": "imshow_log.eps",
+      "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+      "size": 33713
+    },
+    {
+      "path": "imshow_log.pdf",
+      "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+      "size": 18741
+    },
+    {
+      "path": "imshow_log.png",
+      "sha256": "cde527bdc1ff587d89daed262089064236e83480de968ed6f2c7fcdb31a4bf69",
+      "size": 19144
+    },
+    {
+      "path": "imshow_log.svg",
+      "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+      "size": 17077
+    },
+    {
+      "path": "imshow_rgb.eps",
+      "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+      "size": 530576
+    },
+    {
+      "path": "imshow_rgb.pdf",
+      "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+      "size": 6334
+    },
+    {
+      "path": "imshow_rgb.png",
+      "sha256": "37fea8add9ae269887a784cbfccb4ff6e3ac6c8a8ed6fe055a7ae818791183c5",
+      "size": 16457
+    },
+    {
+      "path": "imshow_rgb.svg",
+      "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+      "size": 7768
+    },
+    {
+      "path": "inset.eps",
+      "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+      "size": 16312
+    },
+    {
+      "path": "inset.pdf",
+      "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+      "size": 10519
+    },
+    {
+      "path": "inset.png",
+      "sha256": "d2d67dd777640a9c00b62753365123cdb64afe7ee6201b836c39a836322accff",
+      "size": 36630
+    },
+    {
+      "path": "inset.svg",
+      "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+      "size": 12927
+    },
+    {
+      "path": "interp.eps",
+      "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+      "size": 394292
+    },
+    {
+      "path": "interp.pdf",
+      "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+      "size": 28040
+    },
+    {
+      "path": "interp.png",
+      "sha256": "5a60a8d5dd2e641496e2bfbf79a96a92c14e1e905021112d51cca1b4cf25135d",
+      "size": 62490
+    },
+    {
+      "path": "interp.svg",
+      "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+      "size": 50239
+    },
+    {
+      "path": "invert_axes.eps",
+      "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+      "size": 8720
+    },
+    {
+      "path": "invert_axes.pdf",
+      "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+      "size": 6008
+    },
+    {
+      "path": "invert_axes.png",
+      "sha256": "c9f076b06a855ac3a71ad96a8660016a86e84ba07517335462edb848deb6ba3e",
+      "size": 31964
+    },
+    {
+      "path": "invert_axes.svg",
+      "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+      "size": 6957
+    },
+    {
+      "path": "legend_labels.eps",
+      "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
+      "size": 15431
+    },
+    {
+      "path": "legend_labels.pdf",
+      "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
+      "size": 11163
+    },
+    {
+      "path": "legend_labels.png",
+      "sha256": "e92c4d496445bd933dc3afcbcb7393d0b3ad28d013fc06ee59ecdc512ad60746",
+      "size": 50734
+    },
+    {
+      "path": "legend_labels.svg",
+      "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
+      "size": 12229
+    },
+    {
+      "path": "legend_opts.eps",
+      "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+      "size": 7371
+    },
+    {
+      "path": "legend_opts.pdf",
+      "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+      "size": 4574
+    },
+    {
+      "path": "legend_opts.png",
+      "sha256": "63dd0d118fe090d9ef8b3c8fbba48a09e37f7bd72b93ab594a427f77de848ccb",
+      "size": 44992
+    },
+    {
+      "path": "legend_opts.svg",
+      "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+      "size": 5558
+    },
+    {
+      "path": "line3d.eps",
+      "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+      "size": 18473
+    },
+    {
+      "path": "line3d.pdf",
+      "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+      "size": 13089
+    },
+    {
+      "path": "line3d.png",
+      "sha256": "10bd8a3f33c90577ddccf73e7b9c833695428e8b4f16357f9a5f91a3072d6e3e",
+      "size": 67870
+    },
+    {
+      "path": "line3d.svg",
+      "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+      "size": 13293
+    },
+    {
+      "path": "log_minor_labels.eps",
+      "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+      "size": 8625
+    },
+    {
+      "path": "log_minor_labels.pdf",
+      "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+      "size": 5528
+    },
+    {
+      "path": "log_minor_labels.png",
+      "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+      "size": 23529
+    },
+    {
+      "path": "log_minor_labels.svg",
+      "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+      "size": 6874
+    },
+    {
+      "path": "loglog.eps",
+      "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+      "size": 14649
+    },
+    {
+      "path": "loglog.pdf",
+      "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+      "size": 8171
+    },
+    {
+      "path": "loglog.png",
+      "sha256": "fef7a90d4b972486ad9c9a7934daf856b89c87d9460092692eaa2a3aec9b37b1",
+      "size": 25190
+    },
+    {
+      "path": "loglog.svg",
+      "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+      "size": 10116
+    },
+    {
+      "path": "many_series.eps",
+      "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+      "size": 126003
+    },
+    {
+      "path": "many_series.pdf",
+      "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+      "size": 100906
+    },
+    {
+      "path": "many_series.png",
+      "sha256": "98a4004ad7492f9c280059daaf7da19e8d4e77c31dc7a04e881340f400f7ca50",
+      "size": 286478
+    },
+    {
+      "path": "many_series.svg",
+      "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+      "size": 101725
+    },
+    {
+      "path": "margins.eps",
+      "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+      "size": 17663
+    },
+    {
+      "path": "margins.pdf",
+      "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+      "size": 12271
+    },
+    {
+      "path": "margins.png",
+      "sha256": "b0661342bb6077aca33c9f65568e6ae95aaffe253e1ee5d64cb265af69af1d07",
+      "size": 42437
+    },
+    {
+      "path": "margins.svg",
+      "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+      "size": 14135
+    },
+    {
+      "path": "marker_detail.eps",
+      "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+      "size": 18574
+    },
+    {
+      "path": "marker_detail.pdf",
+      "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+      "size": 13643
+    },
+    {
+      "path": "marker_detail.png",
+      "sha256": "1292b46bc440f106b35d14e095587029090d13bb4ef1c332486411ee10516c07",
+      "size": 34522
+    },
+    {
+      "path": "marker_detail.svg",
+      "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+      "size": 10883
+    },
+    {
+      "path": "markers_gallery.eps",
+      "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+      "size": 23435
+    },
+    {
+      "path": "markers_gallery.pdf",
+      "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+      "size": 16547
+    },
+    {
+      "path": "markers_gallery.png",
+      "sha256": "b979260cf01f1865484dc2609b8e04fc2fb09b98b58343b69c58ae01c5ecab62",
+      "size": 22165
+    },
+    {
+      "path": "markers_gallery.svg",
+      "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+      "size": 10058
+    },
+    {
+      "path": "markers_only.eps",
+      "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+      "size": 30048
+    },
+    {
+      "path": "markers_only.pdf",
+      "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+      "size": 21481
+    },
+    {
+      "path": "markers_only.png",
+      "sha256": "c21e080bc9c1e04a12c516825e672c6e56ab6b6654609e5cc9ada536441d64c3",
+      "size": 30486
+    },
+    {
+      "path": "markers_only.svg",
+      "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+      "size": 11142
+    },
+    {
+      "path": "mathtext.eps",
+      "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+      "size": 10620
+    },
+    {
+      "path": "mathtext.pdf",
+      "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+      "size": 6839
+    },
+    {
+      "path": "mathtext.png",
+      "sha256": "a3ff1b2f20ae15069b0cc8eb6a386b22def7a65769164e76ef92530432016f2f",
+      "size": 32840
+    },
+    {
+      "path": "mathtext.svg",
+      "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+      "size": 8901
+    },
+    {
+      "path": "mathtext_frac.eps",
+      "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+      "size": 16086
+    },
+    {
+      "path": "mathtext_frac.pdf",
+      "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+      "size": 11400
+    },
+    {
+      "path": "mathtext_frac.png",
+      "sha256": "5d94d5342da7837ae0336ea56947c907831af45e777e36ac2bb49ec8dfb650e2",
+      "size": 32506
+    },
+    {
+      "path": "mathtext_frac.svg",
+      "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+      "size": 9515
+    },
+    {
+      "path": "matshow.eps",
+      "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+      "size": 447767
+    },
+    {
+      "path": "matshow.pdf",
+      "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+      "size": 5415
+    },
+    {
+      "path": "matshow.png",
+      "sha256": "4869c42f81cbe68afeba0ff0148a483e9fb0b967348b86a885b3943d403f62c1",
+      "size": 12239
+    },
+    {
+      "path": "matshow.svg",
+      "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+      "size": 7206
+    },
+    {
+      "path": "mosaic.eps",
+      "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+      "size": 19753
+    },
+    {
+      "path": "mosaic.pdf",
+      "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+      "size": 13130
+    },
+    {
+      "path": "mosaic.png",
+      "sha256": "deabc595d4a68f32bf2d032804b0dee063cb7d66709d608945a815928d4586a2",
+      "size": 37933
+    },
+    {
+      "path": "mosaic.svg",
+      "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+      "size": 15857
+    },
+    {
+      "path": "multi_style.eps",
+      "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+      "size": 107472
+    },
+    {
+      "path": "multi_style.pdf",
+      "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+      "size": 81820
+    },
+    {
+      "path": "multi_style.png",
+      "sha256": "140ac4c6b6f205d6f950205712d0286cf40de9cf80bce795e2b4234555344699",
+      "size": 47468
+    },
+    {
+      "path": "multi_style.svg",
+      "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+      "size": 28914
+    },
+    {
+      "path": "nan_gap.eps",
+      "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+      "size": 27755
+    },
+    {
+      "path": "nan_gap.pdf",
+      "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+      "size": 19760
+    },
+    {
+      "path": "nan_gap.png",
+      "sha256": "7f8490aef805a727e05dd1788566553db80ad81681b6925c5bd627a1a61c2ba4",
+      "size": 34425
+    },
+    {
+      "path": "nan_gap.svg",
+      "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+      "size": 11312
+    },
+    {
+      "path": "norms.eps",
+      "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+      "size": 236860
+    },
+    {
+      "path": "norms.pdf",
+      "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+      "size": 9153
+    },
+    {
+      "path": "norms.png",
+      "sha256": "a90d4fb0876d87a46494404b6e009b487a1ea15ea53c821c9c6382efa4b4c9e5",
+      "size": 21488
+    },
+    {
+      "path": "norms.svg",
+      "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+      "size": 12345
+    },
+    {
+      "path": "offset_text.eps",
+      "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+      "size": 8853
+    },
+    {
+      "path": "offset_text.pdf",
+      "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+      "size": 6025
+    },
+    {
+      "path": "offset_text.png",
+      "sha256": "f3dbc417dbab5dd03b341d81076cdae9f9744ada7b0fc1845404b96ed9a16959",
+      "size": 31008
+    },
+    {
+      "path": "offset_text.svg",
+      "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+      "size": 7054
+    },
+    {
+      "path": "patches.eps",
+      "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+      "size": 9242
+    },
+    {
+      "path": "patches.pdf",
+      "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+      "size": 6797
+    },
+    {
+      "path": "patches.png",
+      "sha256": "b42ae5a2c728e83da65ff97cb5e66470a5a38b31fb5cd1ca97da0923dbd9bc75",
+      "size": 25198
+    },
+    {
+      "path": "patches.svg",
+      "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+      "size": 7157
+    },
+    {
+      "path": "patches_path.eps",
+      "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+      "size": 5626
+    },
+    {
+      "path": "patches_path.pdf",
+      "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+      "size": 3692
+    },
+    {
+      "path": "patches_path.png",
+      "sha256": "86894eab7db36c886e9ee6344af33781c195c1ed98dcc1d9afd4a13e152d0efa",
+      "size": 30023
+    },
+    {
+      "path": "patches_path.svg",
+      "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+      "size": 4249
+    },
+    {
+      "path": "pcolormesh.eps",
+      "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+      "size": 44989
+    },
+    {
+      "path": "pcolormesh.pdf",
+      "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+      "size": 25245
+    },
+    {
+      "path": "pcolormesh.png",
+      "sha256": "76bc69cea800afea8840fcd0ef9e7ec55401b701d5a01701bca1548bd74ab395",
+      "size": 21262
+    },
+    {
+      "path": "pcolormesh.svg",
+      "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+      "size": 21696
+    },
+    {
+      "path": "pie.eps",
+      "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+      "size": 2987
+    },
+    {
+      "path": "pie.pdf",
+      "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+      "size": 2936
+    },
+    {
+      "path": "pie.png",
+      "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+      "size": 23571
+    },
+    {
+      "path": "pie.svg",
+      "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+      "size": 2476
+    },
+    {
+      "path": "pie_opts.eps",
+      "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+      "size": 3945
+    },
+    {
+      "path": "pie_opts.pdf",
+      "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+      "size": 3612
+    },
+    {
+      "path": "pie_opts.png",
+      "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+      "size": 32364
+    },
+    {
+      "path": "pie_opts.svg",
+      "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+      "size": 3469
+    },
+    {
+      "path": "plot_y.eps",
+      "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+      "size": 64767
+    },
+    {
+      "path": "plot_y.pdf",
+      "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+      "size": 47987
+    },
+    {
+      "path": "plot_y.png",
+      "sha256": "2b17a32318c7dfdff3ae6a0830a0c8fd1305d627307e32487bfcf3e613e73e76",
+      "size": 40207
+    },
+    {
+      "path": "plot_y.svg",
+      "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+      "size": 19461
+    },
+    {
+      "path": "polar.eps",
+      "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+      "size": 54459
+    },
+    {
+      "path": "polar.pdf",
+      "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+      "size": 43857
+    },
+    {
+      "path": "polar.png",
+      "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+      "size": 72845
+    },
+    {
+      "path": "polar.svg",
+      "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+      "size": 44319
+    },
+    {
+      "path": "quiver.eps",
+      "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+      "size": 24007
+    },
+    {
+      "path": "quiver.pdf",
+      "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+      "size": 17046
+    },
+    {
+      "path": "quiver.png",
+      "sha256": "6e37afdeeeaf9f9be00bd8c9ae06361d36a6dc7f79114315f382b159039165f6",
+      "size": 39122
+    },
+    {
+      "path": "quiver.svg",
+      "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+      "size": 16554
+    },
+    {
+      "path": "quiver3d.eps",
+      "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+      "size": 16864
+    },
+    {
+      "path": "quiver3d.pdf",
+      "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+      "size": 10205
+    },
+    {
+      "path": "quiver3d.png",
+      "sha256": "9a1adedd15b285273be9136f6733412bdc012e860a213e8eb85d65d5c6a7457a",
+      "size": 83816
+    },
+    {
+      "path": "quiver3d.svg",
+      "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+      "size": 11387
+    },
+    {
+      "path": "savefig_tight.eps",
+      "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+      "size": 4931
+    },
+    {
+      "path": "savefig_tight.pdf",
+      "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+      "size": 3211
+    },
+    {
+      "path": "savefig_tight.png",
+      "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+      "size": 68856
+    },
+    {
+      "path": "savefig_tight.svg",
+      "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+      "size": 3941
+    },
+    {
+      "path": "scatter.eps",
+      "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+      "size": 23854
+    },
+    {
+      "path": "scatter.pdf",
+      "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+      "size": 17031
+    },
+    {
+      "path": "scatter.png",
+      "sha256": "1d91a95646765bad6940c7f41c7c8cacef0ac4622c9a825db716be81b56bdca9",
+      "size": 24876
+    },
+    {
+      "path": "scatter.svg",
+      "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+      "size": 8371
+    },
+    {
+      "path": "scatter_cmap.eps",
+      "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+      "size": 36048
+    },
+    {
+      "path": "scatter_cmap.pdf",
+      "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+      "size": 23357
+    },
+    {
+      "path": "scatter_cmap.png",
+      "sha256": "d3ab154940167d087253d112a920fbfe77d00cd8a1e0ef0ede6def982c4f621d",
+      "size": 34752
+    },
+    {
+      "path": "scatter_cmap.svg",
+      "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+      "size": 21482
+    },
+    {
+      "path": "scatter_edge.eps",
+      "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+      "size": 26390
+    },
+    {
+      "path": "scatter_edge.pdf",
+      "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+      "size": 18737
+    },
+    {
+      "path": "scatter_edge.png",
+      "sha256": "f347f0bb0db4b56299e01566ead5a15e5a523a2cc15f86c5d71e5ab1b6c5fd5d",
+      "size": 47476
+    },
+    {
+      "path": "scatter_edge.svg",
+      "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+      "size": 16259
+    },
+    {
+      "path": "semilogx.eps",
+      "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+      "size": 10132
+    },
+    {
+      "path": "semilogx.pdf",
+      "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+      "size": 6063
+    },
+    {
+      "path": "semilogx.png",
+      "sha256": "bc2250de662f864b2ceb86d826beda483cc9e8b9810fd284a1c5c5bb4ea32456",
+      "size": 22201
+    },
+    {
+      "path": "semilogx.svg",
+      "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+      "size": 7013
+    },
+    {
+      "path": "semilogy.eps",
+      "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+      "size": 25097
+    },
+    {
+      "path": "semilogy.pdf",
+      "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+      "size": 15725
+    },
+    {
+      "path": "semilogy.png",
+      "sha256": "b252eadffd6046f39227914c7e4bc9c36ac3e816a0e86b0b1f13e1a1e56063fd",
+      "size": 28573
+    },
+    {
+      "path": "semilogy.svg",
+      "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+      "size": 12650
+    },
+    {
+      "path": "spans.eps",
+      "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+      "size": 9679
+    },
+    {
+      "path": "spans.pdf",
+      "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+      "size": 6618
+    },
+    {
+      "path": "spans.png",
+      "sha256": "6a439e0f52bb77709a5f43a45fe69043bc0b7f166f586130f113b84179476799",
+      "size": 32647
+    },
+    {
+      "path": "spans.svg",
+      "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+      "size": 7407
+    },
+    {
+      "path": "stem.eps",
+      "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+      "size": 8915
+    },
+    {
+      "path": "stem.pdf",
+      "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+      "size": 6069
+    },
+    {
+      "path": "stem.png",
+      "sha256": "8c94ef4af8934b85c48690c8ebd51431bf611d193fbcc48265222de6df8d93f2",
+      "size": 14320
+    },
+    {
+      "path": "stem.svg",
+      "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+      "size": 5699
+    },
+    {
+      "path": "step.eps",
+      "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+      "size": 4766
+    },
+    {
+      "path": "step.pdf",
+      "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+      "size": 3178
+    },
+    {
+      "path": "step.png",
+      "sha256": "8aa50ff152a0c81cd6a33788ee9449a3ceb3a29c7c4dbd71324afb87be323d84",
+      "size": 13186
+    },
+    {
+      "path": "step.svg",
+      "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+      "size": 3738
+    },
+    {
+      "path": "streamplot.eps",
+      "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+      "size": 81375
+    },
+    {
+      "path": "streamplot.pdf",
+      "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+      "size": 58212
+    },
+    {
+      "path": "streamplot.png",
+      "sha256": "58687e4d073c1ed8d55fea773229a2c31f2a3ffe75d713dda6435b8e1654228c",
+      "size": 121548
+    },
+    {
+      "path": "streamplot.svg",
+      "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+      "size": 52950
+    },
+    {
+      "path": "style_ggplot.eps",
+      "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+      "size": 16495
+    },
+    {
+      "path": "style_ggplot.pdf",
+      "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+      "size": 11341
+    },
+    {
+      "path": "style_ggplot.png",
+      "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+      "size": 44679
+    },
+    {
+      "path": "style_ggplot.svg",
+      "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+      "size": 11595
+    },
+    {
+      "path": "subplots_2x1.eps",
+      "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+      "size": 21216
+    },
+    {
+      "path": "subplots_2x1.pdf",
+      "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+      "size": 13468
+    },
+    {
+      "path": "subplots_2x1.png",
+      "sha256": "e7496dcc67d39e6f2a10b50e5d7035481adcc4785b3969e26906ee122e8d62f9",
+      "size": 39291
+    },
+    {
+      "path": "subplots_2x1.svg",
+      "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+      "size": 15344
+    },
+    {
+      "path": "subplots_2x2.eps",
+      "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+      "size": 34200
+    },
+    {
+      "path": "subplots_2x2.pdf",
+      "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+      "size": 21509
+    },
+    {
+      "path": "subplots_2x2.png",
+      "sha256": "025757ef9c6f787a4bc69fda73d3284b77283f4cd0d6e5325f171ec2d7207945",
+      "size": 51598
+    },
+    {
+      "path": "subplots_2x2.svg",
+      "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+      "size": 24426
+    },
+    {
+      "path": "subplots_adjust.eps",
+      "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+      "size": 7016
+    },
+    {
+      "path": "subplots_adjust.pdf",
+      "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+      "size": 4268
+    },
+    {
+      "path": "subplots_adjust.png",
+      "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+      "size": 30126
+    },
+    {
+      "path": "subplots_adjust.svg",
+      "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+      "size": 5528
+    },
+    {
+      "path": "subplots_shared.eps",
+      "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+      "size": 38590
+    },
+    {
+      "path": "subplots_shared.pdf",
+      "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+      "size": 25381
+    },
+    {
+      "path": "subplots_shared.png",
+      "sha256": "4cdad7d4eda853a674817ae43ff07a398a5fd81519a8fc64a4c2816e8f73d14e",
+      "size": 43211
+    },
+    {
+      "path": "subplots_shared.svg",
+      "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+      "size": 20390
+    },
+    {
+      "path": "surface3d.eps",
+      "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+      "size": 291685
+    },
+    {
+      "path": "surface3d.pdf",
+      "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+      "size": 173038
+    },
+    {
+      "path": "surface3d.png",
+      "sha256": "641b388d9280d1eaae87949e9a5973767eb165ee103332c44cc0884ecde729cf",
+      "size": 86896
+    },
+    {
+      "path": "surface3d.svg",
+      "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+      "size": 153557
+    },
+    {
+      "path": "surface3d_extra.eps",
+      "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+      "size": 359363
+    },
+    {
+      "path": "surface3d_extra.pdf",
+      "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+      "size": 224681
+    },
+    {
+      "path": "surface3d_extra.png",
+      "sha256": "e0296bfcc363b006c82cfe98ae573382718734789d06123d3edb1738d3a1dba9",
+      "size": 109161
+    },
+    {
+      "path": "surface3d_extra.svg",
+      "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+      "size": 206292
+    },
+    {
+      "path": "symlog.eps",
+      "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+      "size": 11340
+    },
+    {
+      "path": "symlog.pdf",
+      "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+      "size": 8163
+    },
+    {
+      "path": "symlog.png",
+      "sha256": "127724ebbd1bff2fa42d240b23c0665cdcf10ad3c2ee7785dd46230140ac1396",
+      "size": 22352
+    },
+    {
+      "path": "symlog.svg",
+      "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+      "size": 9070
+    },
+    {
+      "path": "table.eps",
+      "sha256": "1620128b244020e525144dc4b848a7a5e9235dd6a5bd3725befcb412b79eb654",
+      "size": 6280
+    },
+    {
+      "path": "table.pdf",
+      "sha256": "202d1f76227d699d4d905bbb3b24531c883e73583ddad86cdef584f92d98b9d9",
+      "size": 4165
+    },
+    {
+      "path": "table.png",
+      "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+      "size": 14863
+    },
+    {
+      "path": "table.svg",
+      "sha256": "529fa6bbf531f1511df22df431e4954166cb2a34e00252188b6df40e5a4b1c71",
+      "size": 4641
+    },
+    {
+      "path": "text_annotate.eps",
+      "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+      "size": 12522
+    },
+    {
+      "path": "text_annotate.pdf",
+      "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+      "size": 8311
+    },
+    {
+      "path": "text_annotate.png",
+      "sha256": "0cfa5b3ad61b3306a3f7557cc2dd7ec3edafdf4f52d8893f91e0788bd2efddd9",
+      "size": 34868
+    },
+    {
+      "path": "text_annotate.svg",
+      "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+      "size": 8957
+    },
+    {
+      "path": "text_options.eps",
+      "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+      "size": 9611
+    },
+    {
+      "path": "text_options.pdf",
+      "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+      "size": 6578
+    },
+    {
+      "path": "text_options.png",
+      "sha256": "46a4ffdb1d9c6c237a05bc5055d5753738a23aa035d1e43008f14156474485c6",
+      "size": 33984
+    },
+    {
+      "path": "text_options.svg",
+      "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+      "size": 7763
+    },
+    {
+      "path": "tick_locator.eps",
+      "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+      "size": 13359
+    },
+    {
+      "path": "tick_locator.pdf",
+      "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+      "size": 9119
+    },
+    {
+      "path": "tick_locator.png",
+      "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+      "size": 32671
+    },
+    {
+      "path": "tick_locator.svg",
+      "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+      "size": 10692
+    },
+    {
+      "path": "tick_style.eps",
+      "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+      "size": 4743
+    },
+    {
+      "path": "tick_style.pdf",
+      "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+      "size": 3327
+    },
+    {
+      "path": "tick_style.png",
+      "sha256": "23dde15bd0917eccce35ccda7f06917eb1a3967b1eb4edfc1fc0ebbfc371a714",
+      "size": 27448
+    },
+    {
+      "path": "tick_style.svg",
+      "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+      "size": 3947
+    },
+    {
+      "path": "ticks_legend.eps",
+      "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+      "size": 13957
+    },
+    {
+      "path": "ticks_legend.pdf",
+      "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+      "size": 9476
+    },
+    {
+      "path": "ticks_legend.png",
+      "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+      "size": 35711
+    },
+    {
+      "path": "ticks_legend.svg",
+      "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+      "size": 10721
+    },
+    {
+      "path": "tight_layout.eps",
+      "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+      "size": 9091
+    },
+    {
+      "path": "tight_layout.pdf",
+      "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+      "size": 5147
+    },
+    {
+      "path": "tight_layout.png",
+      "sha256": "d0960c855d06804c842c3977e44b520602044d5fa82de45d7e7252dcd9d8e127",
+      "size": 40701
+    },
+    {
+      "path": "tight_layout.svg",
+      "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+      "size": 7137
+    },
+    {
+      "path": "title_loc.eps",
+      "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+      "size": 8834
+    },
+    {
+      "path": "title_loc.pdf",
+      "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+      "size": 6008
+    },
+    {
+      "path": "title_loc.png",
+      "sha256": "1d0982262999ed9789f0544fc2d9e6f603973adb2e175f7557b398de11984199",
+      "size": 28887
+    },
+    {
+      "path": "title_loc.svg",
+      "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+      "size": 7093
+    },
+    {
+      "path": "transform_axes.eps",
+      "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+      "size": 8885
+    },
+    {
+      "path": "transform_axes.pdf",
+      "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+      "size": 6124
+    },
+    {
+      "path": "transform_axes.png",
+      "sha256": "e4ba4c8fb003db59e4485157e4e0347ccec80ee13b11ef728789211809b8512e",
+      "size": 33813
+    },
+    {
+      "path": "transform_axes.svg",
+      "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+      "size": 7107
+    },
+    {
+      "path": "tricontour.eps",
+      "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+      "size": 73430
+    },
+    {
+      "path": "tricontour.pdf",
+      "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+      "size": 46453
+    },
+    {
+      "path": "tricontour.png",
+      "sha256": "66184831276fb68649f25e239544bba17f94a5650c111a8c92a9628cb0f9a894",
+      "size": 82284
+    },
+    {
+      "path": "tricontour.svg",
+      "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+      "size": 44665
+    },
+    {
+      "path": "tricontourf.eps",
+      "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+      "size": 196467
+    },
+    {
+      "path": "tricontourf.pdf",
+      "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+      "size": 120784
+    },
+    {
+      "path": "tricontourf.png",
+      "sha256": "2005cdffa1f8308a774f3758173f3468081674bdcbd7b307f41fbab6c2b57de5",
+      "size": 100624
+    },
+    {
+      "path": "tricontourf.svg",
+      "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+      "size": 89950
+    },
+    {
+      "path": "tripcolor.eps",
+      "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+      "size": 31920
+    },
+    {
+      "path": "tripcolor.pdf",
+      "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+      "size": 18630
+    },
+    {
+      "path": "tripcolor.png",
+      "sha256": "382a3054a48df5c1a10c9b4b2be74ff1f44b0677a7ce02bcddc8ba9ae4fc1305",
+      "size": 55772
+    },
+    {
+      "path": "tripcolor.svg",
+      "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+      "size": 16074
+    },
+    {
+      "path": "triplot.eps",
+      "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+      "size": 28434
+    },
+    {
+      "path": "triplot.pdf",
+      "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+      "size": 19818
+    },
+    {
+      "path": "triplot.png",
+      "sha256": "0eba4989bb16f1865c256113c5c0fb4409b67b1fd3ab1cec0e43144cb3dab83d",
+      "size": 81306
+    },
+    {
+      "path": "triplot.svg",
+      "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+      "size": 13460
+    },
+    {
+      "path": "trisurf.eps",
+      "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+      "size": 42561
+    },
+    {
+      "path": "trisurf.pdf",
+      "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+      "size": 24733
+    },
+    {
+      "path": "trisurf.png",
+      "sha256": "e22fdf4a34bfeb3ee1a8e2982c5996583355eb15d70e9a2e256b4c404bd64615",
+      "size": 78115
+    },
+    {
+      "path": "trisurf.svg",
+      "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+      "size": 23721
+    },
+    {
+      "path": "twinx.eps",
+      "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+      "size": 7293
+    },
+    {
+      "path": "twinx.pdf",
+      "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+      "size": 4337
+    },
+    {
+      "path": "twinx.png",
+      "sha256": "3de35574f0d57e8dd4bd6520c911dabfa49fd8a5749aa2611613069d9f6cefe6",
+      "size": 35700
+    },
+    {
+      "path": "twinx.svg",
+      "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+      "size": 5886
+    },
+    {
+      "path": "violin_opts.eps",
+      "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+      "size": 30952
+    },
+    {
+      "path": "violin_opts.pdf",
+      "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+      "size": 23990
+    },
+    {
+      "path": "violin_opts.png",
+      "sha256": "6fe0776406dbbe44d2fc345324909228575eac3a0628fb0248676960ee8301b2",
+      "size": 24826
+    },
+    {
+      "path": "violin_opts.svg",
+      "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+      "size": 24473
+    },
+    {
+      "path": "violinplot.eps",
+      "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+      "size": 17583
+    },
+    {
+      "path": "violinplot.pdf",
+      "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+      "size": 13475
+    },
+    {
+      "path": "violinplot.png",
+      "sha256": "c4601f393ecf3f684a51440a4a58c7480ef2679e95d897f5c43f664d23670613",
+      "size": 20863
+    },
+    {
+      "path": "violinplot.svg",
+      "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+      "size": 13823
+    },
+    {
+      "path": "zorder.eps",
+      "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+      "size": 10414
+    },
+    {
+      "path": "zorder.pdf",
+      "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+      "size": 6442
+    },
+    {
+      "path": "zorder.png",
+      "sha256": "85784640e74355ed17cb81718802a327878d6dba31be4a52886817e4ea8cdded",
+      "size": 31537
+    },
+    {
+      "path": "zorder.svg",
+      "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+      "size": 6551
+    }
+  ],
+  "generated_from": "tests/out",
+  "version": 1
+}

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -4980,6 +4980,2496 @@
       ],
       "generated_from": "tests/out"
     },
+    "linux-ifx": {
+      "files": [
+        {
+          "path": "alpha.eps",
+          "sha256": "dfb43560d7a755166288ddfea40c28bc2d670da0d04a6ac97e3983c8f5541f49",
+          "size": 80981
+        },
+        {
+          "path": "alpha.pdf",
+          "sha256": "ef623f2c337cd9e07c114ef9befd10ba11588ab80a290730d0cbfd608f23785e",
+          "size": 58537
+        },
+        {
+          "path": "alpha.png",
+          "sha256": "3cf482d5d99e652460b76daadaede6d50af702a74098d0c832748ac7117f04ae",
+          "size": 60415
+        },
+        {
+          "path": "alpha.svg",
+          "sha256": "53103758d0a1889b4a04c8255cb3a3695fc70775557555a6321ebdc8cc939cd9",
+          "size": 29813
+        },
+        {
+          "path": "anim_sine.gif",
+          "sha256": "a6321c3b3bf9351ef513e852fcfe6474d1579c9b81424785573acba9422ac37a",
+          "size": 146764
+        },
+        {
+          "path": "annotate_arrow.eps",
+          "sha256": "cde02f4ba28156ddafc0ed4f94c3a46f5ae08ccc4ed5c3c1d47be39289dba696",
+          "size": 9706
+        },
+        {
+          "path": "annotate_arrow.pdf",
+          "sha256": "fa12511a695606b6e45da9b5b5ca70bdecda4337e2dabffc25a0488759469c5b",
+          "size": 6618
+        },
+        {
+          "path": "annotate_arrow.png",
+          "sha256": "b03c660e459a5fb91511112ea8357543296bf04e4a462d3db4fae5346700cd0e",
+          "size": 35125
+        },
+        {
+          "path": "annotate_arrow.svg",
+          "sha256": "21a7efc370cb9b89684dbd7dd4b55d1ba7c80e456550ead6630bc4a94e003062",
+          "size": 7557
+        },
+        {
+          "path": "annotate_curve.eps",
+          "sha256": "f556bb0d6a1bd4fa2f1c32dcf8b6d5e0a641ce6498a4060c424529885d85274c",
+          "size": 9940
+        },
+        {
+          "path": "annotate_curve.pdf",
+          "sha256": "02b0be2f825a42e8625055ef25362dc858f75fe7a06c184658c701277a2362f1",
+          "size": 6765
+        },
+        {
+          "path": "annotate_curve.png",
+          "sha256": "5a95acd576e02e528d8695060d2d9bc54c58171cc727a8468d83ae35fdb5f851",
+          "size": 35039
+        },
+        {
+          "path": "annotate_curve.svg",
+          "sha256": "948b23294ac6359832636e0a3f065651991f2180e6a1851ef3d6fe6a1e614009",
+          "size": 7615
+        },
+        {
+          "path": "axes_facecolor.eps",
+          "sha256": "365cd1e6a71fb4cb1e1ade6be2612d1f705017600e0c779025af9326f44ce6e8",
+          "size": 17496
+        },
+        {
+          "path": "axes_facecolor.pdf",
+          "sha256": "6647005d4ab905fb230e52cacc2ef74fd736edb68eaebbb64cf7363e027b511a",
+          "size": 11466
+        },
+        {
+          "path": "axes_facecolor.png",
+          "sha256": "1159004aa54ec65142f496b762666a9ebb486585de017268b263a65a02d5b1db",
+          "size": 40443
+        },
+        {
+          "path": "axes_facecolor.svg",
+          "sha256": "56ed8194e36e03083b9fcdc214a94f793b5a50d5943b150867fa2aeb8eb1e317",
+          "size": 13174
+        },
+        {
+          "path": "axes_handles2.eps",
+          "sha256": "b8be1532345fe359f62b62512603c68dace834d35b6bac83c78a107ea214cfd8",
+          "size": 26227
+        },
+        {
+          "path": "axes_handles2.pdf",
+          "sha256": "df43ddecef4eb53cd724ed818ee4fafad2506cb06dd09690bd94481635cfa6b0",
+          "size": 16957
+        },
+        {
+          "path": "axes_handles2.png",
+          "sha256": "f4c409680c2eacb1fb145c9fc55e414e704d01f625a4e32cbea08d101de76085",
+          "size": 32356
+        },
+        {
+          "path": "axes_handles2.svg",
+          "sha256": "f04a3c75251844ea648e8b441add59167aa9ba6218ff68d345745b627dc53515",
+          "size": 19863
+        },
+        {
+          "path": "axis_equal.eps",
+          "sha256": "e3d49cef7dd6b0e9f075083c8449cb0992703a3225f7d32c249a86b8a3f406b2",
+          "size": 8082
+        },
+        {
+          "path": "axis_equal.pdf",
+          "sha256": "a590731f4342ec8f7178e1a333b9f8711fbce86f478a81a95324c26e91a238ad",
+          "size": 5385
+        },
+        {
+          "path": "axis_equal.png",
+          "sha256": "ac78a8ecee7ebce232dcb4f73c5a2512d984c64acae838e306e3a03ddb3d8e31",
+          "size": 18658
+        },
+        {
+          "path": "axis_equal.svg",
+          "sha256": "863152668a36655336d58805cfbca17e0495fbe67deb96ad9b998ee5b1f8ccbc",
+          "size": 4733
+        },
+        {
+          "path": "bar.eps",
+          "sha256": "ceda290373cce40773b35e0339db59576f53424a730f037a661f111d72b9f441",
+          "size": 7532
+        },
+        {
+          "path": "bar.pdf",
+          "sha256": "4503e2974093c7878162cdb561f63c4ae6e18d556943fc5e80ac64e60907488f",
+          "size": 4363
+        },
+        {
+          "path": "bar.png",
+          "sha256": "2643967688fc5060151575662615e73e29d7bc0dba08b077976e7d094f935ed7",
+          "size": 17033
+        },
+        {
+          "path": "bar.svg",
+          "sha256": "069711ba635699f8637bc56074b2c5ae2ef558cd8b9f38cbb61ce16ed0c0183d",
+          "size": 5255
+        },
+        {
+          "path": "bar3d.eps",
+          "sha256": "27ad15d60bf751cb1f7ffdd942b563a834d3504b2ff08bbd92196e6109e2b033",
+          "size": 34185
+        },
+        {
+          "path": "bar3d.pdf",
+          "sha256": "da1f53ad0b038e350ed377b25450a5f0ea34ba5f1f802f3d4115855386413589",
+          "size": 20605
+        },
+        {
+          "path": "bar3d.png",
+          "sha256": "27f476bb7d0ce0e41ddd80f1088315be9594bbd1837c410ccfa14e1ef1d4e3aa",
+          "size": 57563
+        },
+        {
+          "path": "bar3d.svg",
+          "sha256": "c98fe8b1c822ab262112daebbe01112ed2ffb0a6b317f31f20baf906a038445d",
+          "size": 20023
+        },
+        {
+          "path": "bar_colors.eps",
+          "sha256": "85767c3c4368125c4ca463e09bceffe34e7cf145326455516f71bbe16875851a",
+          "size": 7530
+        },
+        {
+          "path": "bar_colors.pdf",
+          "sha256": "30ed8e6691309d0a001cbdd13ead80de32866f0dc97a17af7504e10de045f345",
+          "size": 4571
+        },
+        {
+          "path": "bar_colors.png",
+          "sha256": "013d041d4dd75796ef79aacd9a8c32f15751c391cadb101230727ad648db7aa8",
+          "size": 17074
+        },
+        {
+          "path": "bar_colors.svg",
+          "sha256": "c481902a6766999c9f21b8bb7a3aec0688f7bd6d935068075947b51f7777c11e",
+          "size": 5449
+        },
+        {
+          "path": "bar_err.eps",
+          "sha256": "8237d86e298df6dc9dfe90aae790e2f8c6fcb07296f9338443978063f1c5d05a",
+          "size": 10265
+        },
+        {
+          "path": "bar_err.pdf",
+          "sha256": "89acb432e77193fd05c834297fdc92d52ae3a12a998666ca6a84a55e269bf392",
+          "size": 5894
+        },
+        {
+          "path": "bar_err.png",
+          "sha256": "c2e8dcbc597b58b38f68c413a817ddb833f9bf849dfaffdb113f9c5a1f34ff64",
+          "size": 16414
+        },
+        {
+          "path": "bar_err.svg",
+          "sha256": "321590c4095c7ed7ecd43061c1e8716a4dc700e28608c00932ba06cb8254a4d0",
+          "size": 7040
+        },
+        {
+          "path": "bar_stacked.eps",
+          "sha256": "4b6bc01c985e8db458a7a5428b9628f4e5894b96c5936b24d92f597ce77c53bf",
+          "size": 10296
+        },
+        {
+          "path": "bar_stacked.pdf",
+          "sha256": "81e1807a71306d6a28b66cf92213ce5ab0b7b7f9d3f56c0dc61e39bf48483bc9",
+          "size": 5771
+        },
+        {
+          "path": "bar_stacked.png",
+          "sha256": "96b1fa3803adc29bdc25560000e1f2e399492dc22c1673b7ae88169880197791",
+          "size": 18410
+        },
+        {
+          "path": "bar_stacked.svg",
+          "sha256": "70adcd57e5d079d77d75bfa6473f9894ed37186aef7ca170d7bf1387803a4d88",
+          "size": 6771
+        },
+        {
+          "path": "barh.eps",
+          "sha256": "cbb32025dfa5e4456f387b6de9c2467f827bc9adb3e2ff27df510eb3db6b8061",
+          "size": 6714
+        },
+        {
+          "path": "barh.pdf",
+          "sha256": "cd8159b71ab582049acf7893b43a8b23a0ac7d40a33e75666cad0bfae8dc602f",
+          "size": 4007
+        },
+        {
+          "path": "barh.png",
+          "sha256": "0f851c3d4e08582a4cb29652e76c11f14bc251de4c5bbe570bf7b9f7d4fda2b9",
+          "size": 13399
+        },
+        {
+          "path": "barh.svg",
+          "sha256": "ab4076bb8eb85b2b17c66e6a268f21c89ea4e701e2613b578bbcc205292cac35",
+          "size": 4634
+        },
+        {
+          "path": "basic_line.eps",
+          "sha256": "89558623e086e107f2af8d07ec20c3c60f84d047ecb4d27a9569883f44f9e8ee",
+          "size": 10559
+        },
+        {
+          "path": "basic_line.pdf",
+          "sha256": "c6fdb80981e5ddf98a719004ee8f6c6f9aa919e873b490855c8f7cd8f8cd2247",
+          "size": 7090
+        },
+        {
+          "path": "basic_line.png",
+          "sha256": "b8b01f64eb33607fac894d21eae9d1f752cc1b4d833ec1f974ae180d51163182",
+          "size": 27132
+        },
+        {
+          "path": "basic_line.svg",
+          "sha256": "7e2259fd7f7e03f83c9439eee66b5f4e725e9a74d595f965ec47adb2b0dfa945",
+          "size": 7592
+        },
+        {
+          "path": "box_opts.eps",
+          "sha256": "446869eea9bd2cbf05a1350146e7048f0b4f1fe94f198a1ed55ec94f8304c051",
+          "size": 12228
+        },
+        {
+          "path": "box_opts.pdf",
+          "sha256": "445e065745faeb1d158a204ff842210d9434c4102784d89d6c14630d1305e91e",
+          "size": 7789
+        },
+        {
+          "path": "box_opts.png",
+          "sha256": "96e3a37714076932da524fdf49573c447e0147a7d0834b771eef45f1061e58fa",
+          "size": 19358
+        },
+        {
+          "path": "box_opts.svg",
+          "sha256": "25b2f984e42c968f06e4cb29a124e342dddf5ead44b73500f2c016320a660779",
+          "size": 8234
+        },
+        {
+          "path": "boxplot.eps",
+          "sha256": "112bb79681b92d389c813a3e60cb314eb657a80dfe4e3a6508221a2961e16735",
+          "size": 7338
+        },
+        {
+          "path": "boxplot.pdf",
+          "sha256": "2bb969ecbc82a30905906c97e0ff4177b0a1a60d16944d722e86fc8382a9e0ee",
+          "size": 4561
+        },
+        {
+          "path": "boxplot.png",
+          "sha256": "14a5d51505a960f0fc55f80a2393d34571908ff30ee51a2c89381e2a6ca9825f",
+          "size": 14315
+        },
+        {
+          "path": "boxplot.svg",
+          "sha256": "8d383c17eac4ca63a639dd26c2a9239353e59f65a5285798cd407ba8d76b409f",
+          "size": 5158
+        },
+        {
+          "path": "broken_barh.eps",
+          "sha256": "03da0ee15669479210e5cb589ab78115296716c4f46658680715406104db92e0",
+          "size": 4871
+        },
+        {
+          "path": "broken_barh.pdf",
+          "sha256": "96f570fcfe2f38f9afcde90074376e3c65e14340671ba2005a69046df898daeb",
+          "size": 3421
+        },
+        {
+          "path": "broken_barh.png",
+          "sha256": "aae7f16cf8d46156211cab87d5d128a4529c2180afe126b0ce02a67747018455",
+          "size": 14714
+        },
+        {
+          "path": "broken_barh.svg",
+          "sha256": "15ce25afad201fb752c10acdd78e4ccf407c7fac9cde78f1f268f11d1729f65b",
+          "size": 3619
+        },
+        {
+          "path": "categorical.eps",
+          "sha256": "35b11328de57887216d22bcc4314ec7b119ed919bc06a9d68a47ce6c9eb2b9b0",
+          "size": 5691
+        },
+        {
+          "path": "categorical.pdf",
+          "sha256": "de25c3eb2277bd24e77e0e345ddeb3229dd0ea4d7f35566b82b488a725cea19d",
+          "size": 3529
+        },
+        {
+          "path": "categorical.png",
+          "sha256": "7304deb0e7e7c6345771eb116fb7d106858363d2b3e63d30e22c27ea3347a66c",
+          "size": 17292
+        },
+        {
+          "path": "categorical.svg",
+          "sha256": "dd0734ff244930b89ceb53585cf69aa0831a3f6fa845f6f3d80abe2fca1e4857",
+          "size": 4113
+        },
+        {
+          "path": "clabel.eps",
+          "sha256": "8a284d9293af5cb2cefcfe1bbb56fecfa52076fb9f46049db067adff51630348",
+          "size": 14848
+        },
+        {
+          "path": "clabel.pdf",
+          "sha256": "2142735ff756426a6786daebaf8e98617a1fca98c4c1d8eb50dd0d0a41c74186",
+          "size": 10428
+        },
+        {
+          "path": "clabel.png",
+          "sha256": "e1fe51477979f49f9468fc84d11830e9e94e0a4253ad22903b1fb3b9d718264a",
+          "size": 62828
+        },
+        {
+          "path": "clabel.svg",
+          "sha256": "7b160043435bf973821c46315e18e09e3a6d30e1089cb19094dbcfcb787dbb81",
+          "size": 11171
+        },
+        {
+          "path": "cmap_discrete.eps",
+          "sha256": "3db1095816ae843e64a2880c803f3aed4bd16c564af69cf67fe76b9153e03ccf",
+          "size": 165754
+        },
+        {
+          "path": "cmap_discrete.pdf",
+          "sha256": "e3def140c47e15b524fbc32ac9946096312d22164762aae049413fe9d091143e",
+          "size": 6561
+        },
+        {
+          "path": "cmap_discrete.png",
+          "sha256": "fc10a1c41d31c805eaf152601dab1c5a878c2bd6b68c5fff600dbaa9914e705c",
+          "size": 17689
+        },
+        {
+          "path": "cmap_discrete.svg",
+          "sha256": "522daaf4d01cd5784eb32bb1b325fc2511f2115e61d33eb869c608d8b690ad65",
+          "size": 9074
+        },
+        {
+          "path": "cmap_lognorm.eps",
+          "sha256": "5f74e9bdac08d5433bd1b610937a257038d0b4ac1b640d3887b77eb3a528363f",
+          "size": 495916
+        },
+        {
+          "path": "cmap_lognorm.pdf",
+          "sha256": "a4c8552c2d1a0145b669326edf7689219c6dd1bc85c8ce0a98fbbc949437b42b",
+          "size": 13628
+        },
+        {
+          "path": "cmap_lognorm.png",
+          "sha256": "d36aa7d8115725e78809e9e0109caec6a9aa445e0f12289607ffcaf5261bf029",
+          "size": 18530
+        },
+        {
+          "path": "cmap_lognorm.svg",
+          "sha256": "09f54c0f0f975cb7a5de43b9b6d3a7aa1d66450f5fad9e1b7bf2ffb48eeb5014",
+          "size": 15377
+        },
+        {
+          "path": "cmap_reversed.eps",
+          "sha256": "15e660ba0062918b374a4864d8c1315f0980fdac428914c033f2c80f0fc3d1c2",
+          "size": 496738
+        },
+        {
+          "path": "cmap_reversed.pdf",
+          "sha256": "a0d78ab1a611fbdf45744f3dfea3fd9aea97a64483585438c2276cf80ecd13f1",
+          "size": 14516
+        },
+        {
+          "path": "cmap_reversed.png",
+          "sha256": "4eb91258d43e4afefe70ac25d4faf774bad24884062320a9a322f31e27652821",
+          "size": 19713
+        },
+        {
+          "path": "cmap_reversed.svg",
+          "sha256": "ed27b7218eb548e7cb221ecb3f3e0233174e8a7cf16383e51f54eec375d9eb9f",
+          "size": 15977
+        },
+        {
+          "path": "cmap_special.eps",
+          "sha256": "36e4e8fadf2e530c945f2adb990c85c506782a7cfa491dcb7539c623d98ffdea",
+          "size": 385887
+        },
+        {
+          "path": "cmap_special.pdf",
+          "sha256": "679117dd05816b98259432901de9672267e77523a8c55667a2c00cfd27ca84b7",
+          "size": 8509
+        },
+        {
+          "path": "cmap_special.png",
+          "sha256": "6bd6c82591164fcd66621a3e7126e600ce1b9be41a8e8b8420c6b875f00903b9",
+          "size": 22045
+        },
+        {
+          "path": "cmap_special.svg",
+          "sha256": "e498eb02bbc87ecef36fc019d4e3b58c34c33f5ad4944e82544efa228defac52",
+          "size": 10971
+        },
+        {
+          "path": "colorbar_orient.eps",
+          "sha256": "24d42707d47adf8323eebfe5b69d12df91614946469f2908016f7ceee876bb84",
+          "size": 481251
+        },
+        {
+          "path": "colorbar_orient.pdf",
+          "sha256": "f1469b0bce42db041af8e4a28b461a450ebae47054692664428c2b9f2946ed43",
+          "size": 24888
+        },
+        {
+          "path": "colorbar_orient.png",
+          "sha256": "0ee5593f4cbb12db04bdad90011abf6581d51c2dc860ec42ac9d2b9a9a55a207",
+          "size": 23193
+        },
+        {
+          "path": "colorbar_orient.svg",
+          "sha256": "29fc286750f845774a50c248a5cee98a79f2259bb2d9e5bbbc42fb5d855da8a0",
+          "size": 25679
+        },
+        {
+          "path": "colors.eps",
+          "sha256": "7b5cb22b98f61ccc6207813839f125886c8235fbf5c62c1ce09128ca5b3a58b0",
+          "size": 5537
+        },
+        {
+          "path": "colors.pdf",
+          "sha256": "f1c75f09f193bbf20aab58c730705c670687570d723e53c021569bce41871777",
+          "size": 3660
+        },
+        {
+          "path": "colors.png",
+          "sha256": "2ded4adbf05da3c8c56920d71a432ed7bc7cb7a69928d06c1e32f657ffeb448b",
+          "size": 15230
+        },
+        {
+          "path": "colors.svg",
+          "sha256": "20b5641ed098df2a03f89c6bebcc53788462cbf11262c9578395cff0608f06da",
+          "size": 4189
+        },
+        {
+          "path": "constrained.eps",
+          "sha256": "12ede373a702b67d546c08dc73d63f42b92dece8c96f827371dc40b747c81b07",
+          "size": 15645
+        },
+        {
+          "path": "constrained.pdf",
+          "sha256": "d970a75ee01f1b779c1239a3f1aafc50d30c38acd190adf6ad65aaa855183a18",
+          "size": 10197
+        },
+        {
+          "path": "constrained.png",
+          "sha256": "c88b8ae9d9545e3fb1903c37c161b92d88bc7b0c6c38a2c2317d6d63cd117d48",
+          "size": 46877
+        },
+        {
+          "path": "constrained.svg",
+          "sha256": "01d2e22e5177badb1623682737a6e262740af7dcf30994572c6e9bb0cdd2069f",
+          "size": 12564
+        },
+        {
+          "path": "contour.eps",
+          "sha256": "d80fe52539ab961cc1b549cdc81ce7020f0f591ee2867f68d0651ec2144876f2",
+          "size": 12891
+        },
+        {
+          "path": "contour.pdf",
+          "sha256": "46775a124bb7a42527a937982dd87eb7445d6b1617e9df07a6cde1c01e1f6997",
+          "size": 8839
+        },
+        {
+          "path": "contour.png",
+          "sha256": "ec5b51428c9779f989da85bc6fd4babc37346c7edb1dcb8e349cc309b6f4cb34",
+          "size": 65490
+        },
+        {
+          "path": "contour.svg",
+          "sha256": "0314478ba636a6360d9168025321d357a92ff144a1415214202b321c1e4df83d",
+          "size": 9576
+        },
+        {
+          "path": "contour3d.eps",
+          "sha256": "310d7a9d0a565b2208f23bca4f76fe98764285555ddaf838667e2489505b3f1b",
+          "size": 36571
+        },
+        {
+          "path": "contour3d.pdf",
+          "sha256": "f2aae65ddcf81715d38cd63a1b584fbc51d9623d6870149ae8473a10d3b3f05b",
+          "size": 26163
+        },
+        {
+          "path": "contour3d.png",
+          "sha256": "64f4627c5fbd9672bd2a472f6e5d275e8695795a0e29b95306e1320f8e7f7069",
+          "size": 94842
+        },
+        {
+          "path": "contour3d.svg",
+          "sha256": "0c6e536facb1145aed88aec97e02c299430592516961ed8a590628c8001771d3",
+          "size": 27691
+        },
+        {
+          "path": "contourf.eps",
+          "sha256": "d6828c8b962232298a52ae4480273366b706fa990fe6defe8a4d6459e5241300",
+          "size": 148542
+        },
+        {
+          "path": "contourf.pdf",
+          "sha256": "8059d3d6423339bb81004d6f31a4ce1abff6d6489b87059f66b2477bd6306e1f",
+          "size": 88734
+        },
+        {
+          "path": "contourf.png",
+          "sha256": "c2d51c10aa56f0ac98a2b05b75e13584c4b004ffb324ac9f29e9cad0d6044777",
+          "size": 65324
+        },
+        {
+          "path": "contourf.svg",
+          "sha256": "aea83563e434ccd8480d8c6592f9267564a44a4d110e77182bebc85934824e25",
+          "size": 66386
+        },
+        {
+          "path": "dates.eps",
+          "sha256": "defdff6956c54cd9700556b94c56fa96adb8ae386246d0a28105f15415e35f66",
+          "size": 16170
+        },
+        {
+          "path": "dates.pdf",
+          "sha256": "e7d8f5a8d1074a5108b65af068db05b6b2fdfcbcac2aeb2f807179907a272305",
+          "size": 12158
+        },
+        {
+          "path": "dates.png",
+          "sha256": "663d886634f825d3deb59a7d48111b3aa26c6d7d843436d730e1b03f6b96ed9e",
+          "size": 33847
+        },
+        {
+          "path": "dates.svg",
+          "sha256": "9b3c9041e4fadd33867b2abb9278b3cd48e65ce73c68e9993222b3b4ae1cf673",
+          "size": 13055
+        },
+        {
+          "path": "errorbar.eps",
+          "sha256": "988c430b9eb6c89c28d2e06a0f4e046652d726a9a8571d2a0755af6c16dd062b",
+          "size": 18677
+        },
+        {
+          "path": "errorbar.pdf",
+          "sha256": "45a70586ef3868e50fde65e1823149a9ca51a83a01c2eb4d5d89e2b67ceadd5d",
+          "size": 12254
+        },
+        {
+          "path": "errorbar.png",
+          "sha256": "fe4905327257ef67295301f18464d39b2a5d761f349cb6fd6199809c1abd46a4",
+          "size": 26603
+        },
+        {
+          "path": "errorbar.svg",
+          "sha256": "b7da032b42a2766743e92146ce77de949380a7172bddee4c758d9ca79291b570",
+          "size": 9685
+        },
+        {
+          "path": "errorbar_xy.eps",
+          "sha256": "edd7829d787da0a2e585f41075ac693a55d6c40a6e6ab245e88ee719ed6459b0",
+          "size": 19492
+        },
+        {
+          "path": "errorbar_xy.pdf",
+          "sha256": "91c939f0aec47d96c7f5d883d90b80bd443bd19a659c5eeb57d6f19a9bc2e6a4",
+          "size": 12891
+        },
+        {
+          "path": "errorbar_xy.png",
+          "sha256": "974fd0d49e82542ae2a1f0fa35647d6227c9bca3093a29bbb291c889d46f5d48",
+          "size": 18310
+        },
+        {
+          "path": "errorbar_xy.svg",
+          "sha256": "a43e7a02ebf7ffa0bb1e43f1c2a52cb7af58ef3070d29619a14b9239dc13e601",
+          "size": 9803
+        },
+        {
+          "path": "eventplot.eps",
+          "sha256": "1d2ef9a9f4cb52a74be3e1773d2307fe874a07f121f2696a941e42128454747c",
+          "size": 14362
+        },
+        {
+          "path": "eventplot.pdf",
+          "sha256": "2bb9810c065cfb4619b9bf8d36964b2092eb5e61c7f266b8c32fc33799b65b4f",
+          "size": 8864
+        },
+        {
+          "path": "eventplot.png",
+          "sha256": "25a2940920c3a173118a4f2bc65c6cc3cf581635a7eb8ab640a3fb5fb670f092",
+          "size": 19220
+        },
+        {
+          "path": "eventplot.svg",
+          "sha256": "52ee05a15181da91b0d032697970c66ae6134287956ff301dca76feb16b47a4f",
+          "size": 8618
+        },
+        {
+          "path": "facecolor.eps",
+          "sha256": "0fe4d6654b3318dd9d628a64b69959645fafce98e470154fbf615f6d1e6ca878",
+          "size": 12235
+        },
+        {
+          "path": "facecolor.pdf",
+          "sha256": "4936708f2bd10755e07c68b893073ee64a0ea2c89979b1ed57111f7eda8a36c8",
+          "size": 8108
+        },
+        {
+          "path": "facecolor.png",
+          "sha256": "0cafd945ccc7bfb09f7b6400ae8048f1f8d182b1524fea81d8e41e179c493152",
+          "size": 32314
+        },
+        {
+          "path": "facecolor.svg",
+          "sha256": "a97a93a2bdff441ebf62c17201235798a0a4ea5b837e2e1f7a39626b4363e28b",
+          "size": 8675
+        },
+        {
+          "path": "figlegend.eps",
+          "sha256": "93135505737440dc5fa9fd82cbb2cc761c2d1a1f529040aa763bdbfd70270c17",
+          "size": 15657
+        },
+        {
+          "path": "figlegend.pdf",
+          "sha256": "2c0774879e44ceb689d357bd344a39080fa8f624ac4c1bbf09fae994dc9ce818",
+          "size": 10220
+        },
+        {
+          "path": "figlegend.png",
+          "sha256": "47e647d1dde2b530a8a0cd265b924de982bb404c6ce32842ce18a9b54159321a",
+          "size": 38044
+        },
+        {
+          "path": "figlegend.svg",
+          "sha256": "85d8e4881efc49e877596a5cb2ca610f76a24e4c75db826783aeb7542e6b152c",
+          "size": 12445
+        },
+        {
+          "path": "figsize.eps",
+          "sha256": "4d8d265251df379d53146b8419ca97af3e0db83fb53dea93627b3263471e46a2",
+          "size": 10482
+        },
+        {
+          "path": "figsize.pdf",
+          "sha256": "6f6d4a9870138c19192fc5717ea81897c2d5f2099d3a1dd1f914155af9f63f99",
+          "size": 7028
+        },
+        {
+          "path": "figsize.png",
+          "sha256": "f46273631b451662de04a2c97a5700a1602bbe2d9e447170383e7fe7a03f5674",
+          "size": 24010
+        },
+        {
+          "path": "figsize.svg",
+          "sha256": "3f3a1791abdcc4f578cfd11430123a0fa515c526ef39f36959c9f9d072565b4d",
+          "size": 7577
+        },
+        {
+          "path": "figures.eps",
+          "sha256": "c98fabc0f2c29309765064b141144c4dd469499846ef492bb324065b8c4fecfd",
+          "size": 4606
+        },
+        {
+          "path": "figures.pdf",
+          "sha256": "9135ca2bc614c27de6611506fa8b6f8f4677292618ecc321a0b01a07354aa5f5",
+          "size": 3048
+        },
+        {
+          "path": "figures.png",
+          "sha256": "988b0c19ba6af3b41233b84ebc6faa4d9169fb0d1e7981f435802b71ca392d4f",
+          "size": 25901
+        },
+        {
+          "path": "figures.svg",
+          "sha256": "7a6ed2e37a9de55464aba038732e62f74336f2bb97f333f06ad887b3d3d4e116",
+          "size": 3628
+        },
+        {
+          "path": "fill_between.eps",
+          "sha256": "1f025ae088998cc36b04f4c72713f278f82b3cb1ba9058808f1a73088f29d0d1",
+          "size": 18796
+        },
+        {
+          "path": "fill_between.pdf",
+          "sha256": "bd44122738572865b50cb1c9e9afd86cb575d0b5282f10cb38ea68458f6e0462",
+          "size": 13247
+        },
+        {
+          "path": "fill_between.png",
+          "sha256": "f71ae929c64dcb5c7caf1223e9e6d30e963038289f4569b319418365e9870b6b",
+          "size": 39936
+        },
+        {
+          "path": "fill_between.svg",
+          "sha256": "38438f321c208b4b493b5d4600d1f0a1b5b940d6a7ee0d58cecbe55487176d66",
+          "size": 13950
+        },
+        {
+          "path": "fill_where.eps",
+          "sha256": "bcfd76b001965342b9898d6a01dcb972a3318a5e0b72ae2aa2cce14b99f16cc7",
+          "size": 14938
+        },
+        {
+          "path": "fill_where.pdf",
+          "sha256": "ece20b5cd5e85611b9e5961ccb228ad14363b4f5ca3babbc2f279fffd6acbfc3",
+          "size": 10832
+        },
+        {
+          "path": "fill_where.png",
+          "sha256": "f114247367ba8b2ef831fbca9d68d68eab879d80562b84ed280143e14866d851",
+          "size": 33695
+        },
+        {
+          "path": "fill_where.svg",
+          "sha256": "c6617abadec56f34f8aa79bf7e1b2686c10068c1b4d24e26614d6e3edd1f3142",
+          "size": 11831
+        },
+        {
+          "path": "fills.eps",
+          "sha256": "98792c95ce45201683f1636f41d57e9f85ee847228a1c0ed5416b3c396cfd1d0",
+          "size": 17109
+        },
+        {
+          "path": "fills.pdf",
+          "sha256": "795a7f4ce52abfa8fbbe03fbb64a786c7554ad88fd651c41bb309ed2ba2066f1",
+          "size": 11768
+        },
+        {
+          "path": "fills.png",
+          "sha256": "95200e5bf6948bad05c9af611d1dded56beae549f720d10ee92cd053d43ec535",
+          "size": 37273
+        },
+        {
+          "path": "fills.svg",
+          "sha256": "18163917b635e997e81f72e8d8cbda21f2a816a3f25c24564e55644deeb99d25",
+          "size": 13423
+        },
+        {
+          "path": "font_faces.eps",
+          "sha256": "ec5c8d7622d447390db6ecd27e31ab05cca194d10b90aca8feccdbf8a2d2e4be",
+          "size": 9227
+        },
+        {
+          "path": "font_faces.pdf",
+          "sha256": "651e35f8715315115d45ad52911061d31f222e9ea48a7035e765cd259e93e623",
+          "size": 6271
+        },
+        {
+          "path": "font_faces.png",
+          "sha256": "100163d9114b26893398dcda94b5530b261fb7c4e6115d9f2d73dac45c4b395c",
+          "size": 36742
+        },
+        {
+          "path": "font_faces.svg",
+          "sha256": "83b141b324cef65a95d877df81868c755f2cdfb234475dd193b4a458fd7c5c7c",
+          "size": 7508
+        },
+        {
+          "path": "fontsize.eps",
+          "sha256": "10c1e3a6c4b6efe7f7e1b3d21e5634cbac94e3fca47164ba2abb36ea1ce5b42e",
+          "size": 5477
+        },
+        {
+          "path": "fontsize.pdf",
+          "sha256": "30a81526fb99613d20762338c0ffc9f54f79f0b128e58d443b84510475f48533",
+          "size": 3444
+        },
+        {
+          "path": "fontsize.png",
+          "sha256": "6f4a75e6828e52e84192796dd7e792b250772158c718f78007b04a8923441161",
+          "size": 32705
+        },
+        {
+          "path": "fontsize.svg",
+          "sha256": "9a22de7bd0274516980831600a9f44f29e622dfb37209598547b68cdd13b205b",
+          "size": 4266
+        },
+        {
+          "path": "formatters.eps",
+          "sha256": "95246dd0717dead0f0d36f16e41217397c8b38773a858978285d04561408a024",
+          "size": 6509
+        },
+        {
+          "path": "formatters.pdf",
+          "sha256": "aa2a7f005ac69cf5b53fb3ed82f467ca8dd8123758626d356b2cb68591cffaa3",
+          "size": 4947
+        },
+        {
+          "path": "formatters.png",
+          "sha256": "c4df322adf565975dc56811dbbdb3cdf67c6acf0323c78fd918f7b2c2f5068ff",
+          "size": 29499
+        },
+        {
+          "path": "formatters.svg",
+          "sha256": "cdf485522f2a161420637f1d2f73779c87104b9e5dcb94f28acb9cf79c3d9aa1",
+          "size": 5254
+        },
+        {
+          "path": "grid_options.eps",
+          "sha256": "27cec72913943e19ff0238e23e1078ea5a3cf7e190f4f5dbf75d5702ae0da00e",
+          "size": 36975
+        },
+        {
+          "path": "grid_options.pdf",
+          "sha256": "790d4c5b3a8afc9d250c6d6bf3b8a77c63274872ccb574379281fc63242c6c57",
+          "size": 23143
+        },
+        {
+          "path": "grid_options.png",
+          "sha256": "35966cfb1487348800e50b3d9a99946772a7c4e740d1279de4a3481f65e9c83d",
+          "size": 63079
+        },
+        {
+          "path": "grid_options.svg",
+          "sha256": "7a360df7e21c2d56d271afb3238c36e133dae8447c59918c950d4f00477e6c04",
+          "size": 25186
+        },
+        {
+          "path": "grid_ratios.eps",
+          "sha256": "edf1ca15f084604679abd9b630dc57884d34618a58873c1e6394e6c534ef8f87",
+          "size": 24813
+        },
+        {
+          "path": "grid_ratios.pdf",
+          "sha256": "31ebf9e756fe52683c22205bc9de2244537afba3a293edc2fe0eaba47f3b283f",
+          "size": 16526
+        },
+        {
+          "path": "grid_ratios.png",
+          "sha256": "bc2b7b048113d28c2a26b7950d6a018e2bd2a69f8cef41ce3b3678d9495e7c3d",
+          "size": 40356
+        },
+        {
+          "path": "grid_ratios.svg",
+          "sha256": "b077bebca027c86320a4ed2241b69ea97d5ec18abb91b82566456d50a6f65334",
+          "size": 19980
+        },
+        {
+          "path": "gridspec.eps",
+          "sha256": "1cdc3a48f4eff0cf4ea25e8790b2341b164c251c677987170a5c2767c1993196",
+          "size": 20006
+        },
+        {
+          "path": "gridspec.pdf",
+          "sha256": "eff81bb4a179a11a178a73c404a0e4a63096e16ffb62c319cfa15c9b94aea0ed",
+          "size": 13384
+        },
+        {
+          "path": "gridspec.png",
+          "sha256": "59dbbddc01a085c1eef5c01c7de753524726a76a071effcce8dba528197eeeb9",
+          "size": 38362
+        },
+        {
+          "path": "gridspec.svg",
+          "sha256": "715e438121ff8108e70b861191672c2b6292405d3b802f59138a4bbb23e9f209",
+          "size": 16082
+        },
+        {
+          "path": "hatch.eps",
+          "sha256": "cd4865511070b03d064cec1e3371eba4f6e606f3307e9d3f8c3bbf4b834e3be4",
+          "size": 43560
+        },
+        {
+          "path": "hatch.pdf",
+          "sha256": "314bc045ef3bedb87f35a0068380642179ba0095fc311d473900a2dc73f4ab60",
+          "size": 26971
+        },
+        {
+          "path": "hatch.png",
+          "sha256": "86e83514217e6f7ebf42f98cdc83dbf1fda1b7a7825b48bbaf1b691fc64b1427",
+          "size": 42022
+        },
+        {
+          "path": "hatch.svg",
+          "sha256": "4db590595956c4a2faa8bd526a67f968ace588386379b4e129e417a9e6bcfcd6",
+          "size": 26350
+        },
+        {
+          "path": "hexbin.eps",
+          "sha256": "f9ab22cddd11dfdd5b2b3ceb343d91411b7cd223dac32c983f3da1dc143e83e4",
+          "size": 75718
+        },
+        {
+          "path": "hexbin.pdf",
+          "sha256": "6ec18f7389edfc0a2b7742ba1fe618a6507e780283da90a6c3a10c5702712c5b",
+          "size": 54711
+        },
+        {
+          "path": "hexbin.png",
+          "sha256": "74ec59a4b099b6e5ef73447a7bcc02872a66170e6f6d8f07ae7df6412740c945",
+          "size": 87050
+        },
+        {
+          "path": "hexbin.svg",
+          "sha256": "bbdb093b21f5891dcaae0b8187e4bb0d919d543eaeb216804ccdbea57d821cca",
+          "size": 44436
+        },
+        {
+          "path": "hist.eps",
+          "sha256": "14988108b08ac36ff80e77201fd541f9c66d055d19a86cc038e78fea7c870922",
+          "size": 8501
+        },
+        {
+          "path": "hist.pdf",
+          "sha256": "dffa330fbb1fd1657a6470707f42df9b1895d7e545d8914a2d332fb11312ea60",
+          "size": 4854
+        },
+        {
+          "path": "hist.png",
+          "sha256": "052b20d33aa2f13b4ea257b4951d2652bf0e6e57bf55c624d981c7f69b7782c6",
+          "size": 20110
+        },
+        {
+          "path": "hist.svg",
+          "sha256": "8642d996f3c7b91579f060d6a784a76fac3c5fd5fbe0f6074021f8ee306b0f02",
+          "size": 5634
+        },
+        {
+          "path": "hist2d.eps",
+          "sha256": "e2d49017ae7fddd401c7a16140af9f7657e8fd4b3608d1cfa06c77e33029c445",
+          "size": 31502
+        },
+        {
+          "path": "hist2d.pdf",
+          "sha256": "eabc568caaf5b5dce7718d802455310146c023f95c67cb40f75044895ba0b338",
+          "size": 17621
+        },
+        {
+          "path": "hist2d.png",
+          "sha256": "908cedfea40fd9f34330bbdd2d7ddc5f33ca702820e534db4875a7d680ab392d",
+          "size": 20486
+        },
+        {
+          "path": "hist2d.svg",
+          "sha256": "ded4895f75b2fe01f9d489b1741d47deaeb4fd773802f7cb1ea19e8ff48892c4",
+          "size": 14830
+        },
+        {
+          "path": "hist_bins.eps",
+          "sha256": "8aebfe079fbb41f97086661a0f5e221f9d67fe37cafc063dfd02a653e48f82a1",
+          "size": 6748
+        },
+        {
+          "path": "hist_bins.pdf",
+          "sha256": "0d291e9e66fa2790d448e14f9f6a0e6181f7d0e491bf1252e446951ccde850f6",
+          "size": 4027
+        },
+        {
+          "path": "hist_bins.png",
+          "sha256": "c02d6b5f8465c4ecfcd884aa32255188a755d23121b2a1ec892708284cefddc6",
+          "size": 17955
+        },
+        {
+          "path": "hist_bins.svg",
+          "sha256": "dc14529ca04976ae1168f18605650ce5bdf03af94da7b6bd59fe5e540236c740",
+          "size": 4773
+        },
+        {
+          "path": "hist_opts.eps",
+          "sha256": "6c180375e2860084e9ee1a766e2d420d9d68bcddb28778fa4d68c23f62e5ed88",
+          "size": 9129
+        },
+        {
+          "path": "hist_opts.pdf",
+          "sha256": "9c764920a02739b702c2926b0010de95ee52c291e8f6e42e86a18f3f366066b0",
+          "size": 5639
+        },
+        {
+          "path": "hist_opts.png",
+          "sha256": "dc7f46f00895bb4504682d1d421b93113712c16dec26a1bc8a78e752772f3e7d",
+          "size": 19359
+        },
+        {
+          "path": "hist_opts.svg",
+          "sha256": "a0e9bf92b2ad36f3e5c45555d2f06e660c32c1008f56ff7d41892e3c688ee8eb",
+          "size": 5852
+        },
+        {
+          "path": "hist_orient.eps",
+          "sha256": "63252f546ffc9a363231630749f10a7755b9534610f7cc8888f2c64764ab5db9",
+          "size": 21335
+        },
+        {
+          "path": "hist_orient.pdf",
+          "sha256": "1a26c994aee7e3b9f5896783a2a26aa2e3195027265bd99af9045f101e1dadc3",
+          "size": 11396
+        },
+        {
+          "path": "hist_orient.png",
+          "sha256": "4c6abb29e998e4c70b6e6e1fc119733f79dbf99af8e0afab879fa32cdeb1c665",
+          "size": 24924
+        },
+        {
+          "path": "hist_orient.svg",
+          "sha256": "8e51f56267bc85f8c6a577682c4462d8fdb305dba2afc96ab7e619608ec30974",
+          "size": 13132
+        },
+        {
+          "path": "hist_stacked.eps",
+          "sha256": "04083c2f983d3a7fe21234424bbdcaa2af6926c562611b3b7b5f7d1185d66439",
+          "size": 12928
+        },
+        {
+          "path": "hist_stacked.pdf",
+          "sha256": "548d659f8d121944fcca908b4ea4383e21c8f46f7be501b443d5f5224843cf98",
+          "size": 7090
+        },
+        {
+          "path": "hist_stacked.png",
+          "sha256": "02a2021552c77b269d506302e32604e0950fb01cad91dc8682a072c523a184ad",
+          "size": 23317
+        },
+        {
+          "path": "hist_stacked.svg",
+          "sha256": "3e81be483115fb4f43bba3bc07177a4eea2dfc9e8f10305fcdde4501566fdc9c",
+          "size": 8591
+        },
+        {
+          "path": "hv_lines.eps",
+          "sha256": "8c3a5f33194eeb23fb67d4bcbc1e0ffac77ec7d80d40057d19baa893e0dadf4b",
+          "size": 13110
+        },
+        {
+          "path": "hv_lines.pdf",
+          "sha256": "98179b3a1d139144222de7e3b141f098987eb259f8f287d41cf7f88f1ff51d8d",
+          "size": 8518
+        },
+        {
+          "path": "hv_lines.png",
+          "sha256": "4f21cdc36a2ac6dd5de46802da44c0afdfebb39180c99c3d311d4b7da126af92",
+          "size": 36342
+        },
+        {
+          "path": "hv_lines.svg",
+          "sha256": "d6f4e7fd0d3257012206c21e8e7e685b1dcf26598f4b0b4a5cdb63ecaa718f2b",
+          "size": 9248
+        },
+        {
+          "path": "imshow.eps",
+          "sha256": "04655a6e0eac7518046b5c0c8f9378b22ec6adc610e9c63ada9c9bacea5d32eb",
+          "size": 417463
+        },
+        {
+          "path": "imshow.pdf",
+          "sha256": "2830876ef58f6b6415847c6ecce51e3d751736f3e88fa35305ec73745b094e0e",
+          "size": 6278
+        },
+        {
+          "path": "imshow.png",
+          "sha256": "63e42de7afee0f0aaaaf0cc166b3a4db4bdb8d4fb1e731e7698f7cf378ac4607",
+          "size": 15231
+        },
+        {
+          "path": "imshow.svg",
+          "sha256": "9d45c1cbf5eb711e4e5608f5a44bcf548162c818176b588760aa9d5e51262284",
+          "size": 8275
+        },
+        {
+          "path": "imshow_cbar.eps",
+          "sha256": "187084f2bee0d624b83bfcd74b3f33aabef5eaf8e1168ad7c9e1ac6960a1285a",
+          "size": 272389
+        },
+        {
+          "path": "imshow_cbar.pdf",
+          "sha256": "2e50c3f1d03e8d98e8916de7e7cb17fd08a18bc6624781adadf5e95641983cdc",
+          "size": 13336
+        },
+        {
+          "path": "imshow_cbar.png",
+          "sha256": "b4359505baf2481027e7ef7d718eefc75c8e2b3cdc84750e46de50bd56ccf301",
+          "size": 24457
+        },
+        {
+          "path": "imshow_cbar.svg",
+          "sha256": "3af1cf6f169bc6bb03ad509158d80c0ff7c76ec19ad3f1ce192ef18b10aec5a4",
+          "size": 14287
+        },
+        {
+          "path": "imshow_log.eps",
+          "sha256": "50a089c1043b8e95bacf54a07f2a1d95d408cf34e30ed094da341aefb1666409",
+          "size": 33713
+        },
+        {
+          "path": "imshow_log.pdf",
+          "sha256": "b6150dd32253dfb81bcbfda727a4a821cf32b23171a3e70aa0518643ebe9b94c",
+          "size": 18741
+        },
+        {
+          "path": "imshow_log.png",
+          "sha256": "49e7b3d4178a6932ef8370dee4f147901a51134845f4b0216f80b12d53654f6b",
+          "size": 19142
+        },
+        {
+          "path": "imshow_log.svg",
+          "sha256": "f85bcf03d803284b43879e5c67c7584927d49332289ea1cbbc3a351f365b15bd",
+          "size": 17077
+        },
+        {
+          "path": "imshow_rgb.eps",
+          "sha256": "5d8de73a49bb4b481f11b329c59441bae055a261961be9226fab44f35c9e1821",
+          "size": 530576
+        },
+        {
+          "path": "imshow_rgb.pdf",
+          "sha256": "b40abbbe170f2ef2072899222588f2097e9c3baab7027556db6ad613ac5ba09b",
+          "size": 6334
+        },
+        {
+          "path": "imshow_rgb.png",
+          "sha256": "906bee75742241fabcb2314352bcced600546825065b693500646949a52ff876",
+          "size": 16457
+        },
+        {
+          "path": "imshow_rgb.svg",
+          "sha256": "78b9b667541e93c41402a148832bce1353327f8ed2550c30adf31f3a1fcebe43",
+          "size": 7768
+        },
+        {
+          "path": "inset.eps",
+          "sha256": "aa8dae81f3f72523cc616812a3ed5c817de1c7d1bbcde3c94516d9545dd186e4",
+          "size": 16312
+        },
+        {
+          "path": "inset.pdf",
+          "sha256": "6df801e11984526b7210d616a59ef12681049229c03394b753019c9d57233c41",
+          "size": 10519
+        },
+        {
+          "path": "inset.png",
+          "sha256": "411c7c3453bd1f6cb3a3a4bb5be425426d2691304a96baa12819c66d7d78fdc3",
+          "size": 36635
+        },
+        {
+          "path": "inset.svg",
+          "sha256": "f947338779708d728f2ea3e93d04f6dfa8bf47c0602ebb874cfe6e96bd6860f3",
+          "size": 12927
+        },
+        {
+          "path": "interp.eps",
+          "sha256": "40be6042df10ff905d0cc73d166d3e1d504b26478cf8e9787c844305c0356548",
+          "size": 394292
+        },
+        {
+          "path": "interp.pdf",
+          "sha256": "f1685962f65fe65c67abe3f5b70b5afd6ad9693a10cbe3293c808715599edba6",
+          "size": 28040
+        },
+        {
+          "path": "interp.png",
+          "sha256": "d8adedb9a01d2a020e8425cf4fd98e45369f49bb52e7e49f96a7d8906cfcbc83",
+          "size": 62496
+        },
+        {
+          "path": "interp.svg",
+          "sha256": "1a9908434d5b546cf10d6c3d32a95219f4133042a06df50e55829de5d807a790",
+          "size": 50239
+        },
+        {
+          "path": "invert_axes.eps",
+          "sha256": "00a37470b08bcc52c24b819ed9294a8cafb8e7d39bf6c72305cce1e08b166a51",
+          "size": 8720
+        },
+        {
+          "path": "invert_axes.pdf",
+          "sha256": "653b7313e17968950a32bb2e86615be39ba06ec11df207af1aa43a6a0581a5e2",
+          "size": 6008
+        },
+        {
+          "path": "invert_axes.png",
+          "sha256": "80572b96b4c4b3128ef45372ed666fa2348978e71b930f006a09f5c2e9e331b7",
+          "size": 31964
+        },
+        {
+          "path": "invert_axes.svg",
+          "sha256": "3016202e5f33963e702b3d3da13c4137eb226b4efd59fa30513f22617b725b3a",
+          "size": 6957
+        },
+        {
+          "path": "legend_labels.eps",
+          "sha256": "89d405ec22c85fa7d1ab342944927785f3098385f98774e14b4c760ca3447294",
+          "size": 15431
+        },
+        {
+          "path": "legend_labels.pdf",
+          "sha256": "d1b40a451d8a60f4d705fd5f01257fea4d7de0f692b67bc40457cdffc27bee4c",
+          "size": 11163
+        },
+        {
+          "path": "legend_labels.png",
+          "sha256": "34394d1f06c9de3c6e2da4b30248e4e8fc46f473b32d0c16debbee4f13831eff",
+          "size": 50734
+        },
+        {
+          "path": "legend_labels.svg",
+          "sha256": "4d7ac187dfb8bb0e31929f3202f2bf671cc16d5e9731b190017f575ed5a1517a",
+          "size": 12229
+        },
+        {
+          "path": "legend_opts.eps",
+          "sha256": "20ef010adacf21bd5c6d2fa07494342592e1d56f1ecc9a57d3bb11000d585fa8",
+          "size": 7371
+        },
+        {
+          "path": "legend_opts.pdf",
+          "sha256": "de21a2e0befd4d1e782e413aa6e2cd1c2412a86533527d43aee2a82982cf1a63",
+          "size": 4574
+        },
+        {
+          "path": "legend_opts.png",
+          "sha256": "5234cc9120c02ea6c78284c44bbff8fe6cdf30298822d2cd32f3651d2844e84b",
+          "size": 44992
+        },
+        {
+          "path": "legend_opts.svg",
+          "sha256": "71cb29118d63aea05aa240780664aeb6c21a191b768e24c723f8a604b13e638e",
+          "size": 5558
+        },
+        {
+          "path": "line3d.eps",
+          "sha256": "f88bd51be539bdccc7f89bddbd4fa80981b9a950efdfd8a45a1a43fc6a482ea7",
+          "size": 18473
+        },
+        {
+          "path": "line3d.pdf",
+          "sha256": "866f16f06aa86e3d76a87751544532191ad92060d0ae05032ec4797048d0371c",
+          "size": 13089
+        },
+        {
+          "path": "line3d.png",
+          "sha256": "1b58b7ec61891f1c41c881b78356f641e5cae72493b3242f4dcc6cbb289db7bb",
+          "size": 68094
+        },
+        {
+          "path": "line3d.svg",
+          "sha256": "f28b6529f859f438c1b6306efb03e29b05953c4b0013b41f432a03f5a062948e",
+          "size": 13293
+        },
+        {
+          "path": "log_minor_labels.eps",
+          "sha256": "f13b25bd0422085747861e116049c8b838e81c944fe8ea11e310f9a55e9d9845",
+          "size": 8625
+        },
+        {
+          "path": "log_minor_labels.pdf",
+          "sha256": "01988cd6316ec28bc186af8afcda4e54db58165e702310d44b9c544cbf07ece4",
+          "size": 5528
+        },
+        {
+          "path": "log_minor_labels.png",
+          "sha256": "99637a3b05e626feb2fdc6312be4ad6fcdb6a6671bf93b395e6b20d1e60f80c0",
+          "size": 23529
+        },
+        {
+          "path": "log_minor_labels.svg",
+          "sha256": "33c5a88d13fffaf7e457db804842ab9a35dd6c7d1a8832197f697ac3a6f8779a",
+          "size": 6874
+        },
+        {
+          "path": "loglog.eps",
+          "sha256": "6fb80133114b01cd372529d59967f58ddf6126384b6921ee339e32756ce02485",
+          "size": 14649
+        },
+        {
+          "path": "loglog.pdf",
+          "sha256": "abdeb04c452302df486111ab6145db37fee3c9992d35301f78ddbc48def2d0cb",
+          "size": 8171
+        },
+        {
+          "path": "loglog.png",
+          "sha256": "9bc7c1993951bb931426538123e61105220e0542e9bc5838e3afc8e59ace5f7a",
+          "size": 25185
+        },
+        {
+          "path": "loglog.svg",
+          "sha256": "8bbafca6f3c0361b7f69473528be409de57834754d38ad878542170075de4331",
+          "size": 10116
+        },
+        {
+          "path": "many_series.eps",
+          "sha256": "5f04e17ed429ba2a05811e37671a0d805dd79484b6d2c472402cc408cf6e24af",
+          "size": 126003
+        },
+        {
+          "path": "many_series.pdf",
+          "sha256": "1c661e821e8114208bc50f31f15bac7c03d1bf313a9963f2113ddc788da9d2ef",
+          "size": 100906
+        },
+        {
+          "path": "many_series.png",
+          "sha256": "e965dcefa4fdf5622ce8be8018869f73ed8ce12af96638051b859a0801996a5c",
+          "size": 286478
+        },
+        {
+          "path": "many_series.svg",
+          "sha256": "9770c9a96ed7c08ff7038fb57a53ed36a16a58737556ebffd6c25a168d987fec",
+          "size": 101725
+        },
+        {
+          "path": "margins.eps",
+          "sha256": "12b905600e0fcecd2a460a3c7b010acefb9d6c38a29f31d3cb705101bfe1ef17",
+          "size": 17663
+        },
+        {
+          "path": "margins.pdf",
+          "sha256": "5dc48c03bf38e1abc267b8d291afa42999ca366803256c91006770ab18d53c08",
+          "size": 12271
+        },
+        {
+          "path": "margins.png",
+          "sha256": "223029c6b4af40622ed519d183d01de86f0c56af351769edbcc74abf393177f2",
+          "size": 42445
+        },
+        {
+          "path": "margins.svg",
+          "sha256": "df843277d6e765c07b970b0096e7d18d3f4a0875905da7bae7528b4b891f27f4",
+          "size": 14135
+        },
+        {
+          "path": "marker_detail.eps",
+          "sha256": "cde0d396d59cc64677396b7b22610532aaa73b8ea42f2270ad3b1f58b8c7f804",
+          "size": 18574
+        },
+        {
+          "path": "marker_detail.pdf",
+          "sha256": "7dbb6c6a614de7715da5f8b7c969bf638b38c11ea81930958ea9e1a516cd5777",
+          "size": 13643
+        },
+        {
+          "path": "marker_detail.png",
+          "sha256": "b749294f635b7ec76c008f42add21cec295e3862c61c90ff7e2dd117dcb0a7a7",
+          "size": 34523
+        },
+        {
+          "path": "marker_detail.svg",
+          "sha256": "b95b4831fb5ad6a1f56fcc69fe8c42b5d9d70b5c02e365a6d065e3876fe53672",
+          "size": 10883
+        },
+        {
+          "path": "markers_gallery.eps",
+          "sha256": "cc9f1a7d4a1ab717ceb9e6c75ca7f5a81b13d8cd4f9fbffdf2b3a6ab3ff5d7d4",
+          "size": 23435
+        },
+        {
+          "path": "markers_gallery.pdf",
+          "sha256": "a1239b1e9a1fc5901ee18e0c55224e8306be2b016dabe67cb92f2e7dbaee0c4f",
+          "size": 16547
+        },
+        {
+          "path": "markers_gallery.png",
+          "sha256": "836351821d0f831685c6170f545d038cae92ec0d4aff045860342c7ad1d2ae3d",
+          "size": 22167
+        },
+        {
+          "path": "markers_gallery.svg",
+          "sha256": "10f8ecb7eac16799a2504e19ab48702f52d295ef0208a28a81ed87fdb9a9062a",
+          "size": 10058
+        },
+        {
+          "path": "markers_only.eps",
+          "sha256": "accb6107def1afe84eb6d7f088614d118001003f550a4ecf32c675752111e7c4",
+          "size": 30048
+        },
+        {
+          "path": "markers_only.pdf",
+          "sha256": "0b9c002151f2a2f0454d396be5410a3de13a2bafb8140e2a8a04afa12fc9ebc4",
+          "size": 21481
+        },
+        {
+          "path": "markers_only.png",
+          "sha256": "186e645388d32b09c28730a087e7e32b0461c0882faf59c697117207d211b620",
+          "size": 30488
+        },
+        {
+          "path": "markers_only.svg",
+          "sha256": "1eb278b0b0d93016dd346e50b1220997fb9079c2b7086b78ef3279e3f5ba9c25",
+          "size": 11142
+        },
+        {
+          "path": "mathtext.eps",
+          "sha256": "3cd6b2369f1227f1a02681b8c517b30503b81fae967ff0ddc688590df67b1f70",
+          "size": 10620
+        },
+        {
+          "path": "mathtext.pdf",
+          "sha256": "45fe8c7989dd0d45615be72722ec153dfc130c56bb210ce490129cec39f1804c",
+          "size": 6839
+        },
+        {
+          "path": "mathtext.png",
+          "sha256": "124fc14df1645fbf23ff666056e2c8e5f72ff51fd138162499916dff42d6753e",
+          "size": 32844
+        },
+        {
+          "path": "mathtext.svg",
+          "sha256": "27a3a317e78f15f472f6867943c91d3d15e02d6417d4975e917fc30c6d822098",
+          "size": 8901
+        },
+        {
+          "path": "mathtext_frac.eps",
+          "sha256": "952b7d406f3cf20072e88832603ba8b366b04f20349c6cf633bfbdfff6496ee3",
+          "size": 16086
+        },
+        {
+          "path": "mathtext_frac.pdf",
+          "sha256": "dd732e986b1a68ba54302109d8eacab2c8fab6b932291b102a116688b849a7de",
+          "size": 11400
+        },
+        {
+          "path": "mathtext_frac.png",
+          "sha256": "5d3397ff33a3c83f8e0b28909a90deab1ad91f57f45e792d72e0344138f0166c",
+          "size": 32510
+        },
+        {
+          "path": "mathtext_frac.svg",
+          "sha256": "cac3b1662cc59d6562cda56bf8d184bdc7a64935fd8ab6dc1f244fa37bfb6e31",
+          "size": 9515
+        },
+        {
+          "path": "matshow.eps",
+          "sha256": "2ee1f8dc2330a341ce8909572b2a73d5c7f88b20bff262b49e24263f316c7d2a",
+          "size": 447767
+        },
+        {
+          "path": "matshow.pdf",
+          "sha256": "3ed8defc77b4fe3903ee5d52fb21c8624c4a893631afe0d6673f45ee85fc2f29",
+          "size": 5415
+        },
+        {
+          "path": "matshow.png",
+          "sha256": "30ba63f2f99f799f69ab27c64dcbf1f1688fcadfcd17d6288d93696e380bf85c",
+          "size": 12239
+        },
+        {
+          "path": "matshow.svg",
+          "sha256": "feceb8b858ce726ff4abe76247eecfd9cd313c2bb1ab673436c0460077942ea2",
+          "size": 7206
+        },
+        {
+          "path": "mosaic.eps",
+          "sha256": "f3edd16217c11aa84a57c9cf36c859ab68f9e5eff912bfc25984acc1d3908a08",
+          "size": 19753
+        },
+        {
+          "path": "mosaic.pdf",
+          "sha256": "acb67ddcc476b9f13d2dde6809cb1fbbefcfcffa7e2891dd90a27656fb913ebb",
+          "size": 13130
+        },
+        {
+          "path": "mosaic.png",
+          "sha256": "0c512cbafb8ca98a638ea44760d8eeecd8eef2d4aa22906af0e1b03c3ecd8a1a",
+          "size": 37941
+        },
+        {
+          "path": "mosaic.svg",
+          "sha256": "61dde78c1158fbddee243e7b786040da38688280c81c710851acfb6dac10dd6f",
+          "size": 15857
+        },
+        {
+          "path": "multi_style.eps",
+          "sha256": "bd6feb07cd20c3ec9df7e9d7855c7c7dfe4d31c1336878913a55ba0e618a204f",
+          "size": 107472
+        },
+        {
+          "path": "multi_style.pdf",
+          "sha256": "65cb37b79e1a449d8a7cbf4f418082304a1d2c33b725bd9a6b1c23780222822b",
+          "size": 81820
+        },
+        {
+          "path": "multi_style.png",
+          "sha256": "cfb8e12d5228870fe8e688f5196084651f477f24928e7cf1317a688613f3e459",
+          "size": 47465
+        },
+        {
+          "path": "multi_style.svg",
+          "sha256": "a4cd92aa96555ff5772be6660fc9e3c9474e59f60279d21c59ce2b844715d487",
+          "size": 28914
+        },
+        {
+          "path": "nan_gap.eps",
+          "sha256": "8fc9624b76770d58db1e3ab9f48c1b3c6354bf464fbede3f1235740b2972eaf5",
+          "size": 27755
+        },
+        {
+          "path": "nan_gap.pdf",
+          "sha256": "f04dbc2aa82bacb4547ac12c51cd9bf60313f3f920e42b7029e01da1d8c19453",
+          "size": 19760
+        },
+        {
+          "path": "nan_gap.png",
+          "sha256": "1b52df9c93b9f8cdfd3b5f43054c5d0075610daf082529fe76bf6aa3d9143158",
+          "size": 34373
+        },
+        {
+          "path": "nan_gap.svg",
+          "sha256": "fde246454c25e4893178b300760694c1c880df73bcd9ffca22337ad2a9aecdb2",
+          "size": 11312
+        },
+        {
+          "path": "norms.eps",
+          "sha256": "91e17a317e4eba439582b5fdd995f3410a379eaef52c4979bbf25d29855b63ae",
+          "size": 236860
+        },
+        {
+          "path": "norms.pdf",
+          "sha256": "ec4995b0435d667048ba391a12036be5f855349670f1ad1ddbfbe0941f4c57ca",
+          "size": 9153
+        },
+        {
+          "path": "norms.png",
+          "sha256": "3061fb1980f891701ddeb50c6db740c500ae332a75fecb7afc06eaca70b57493",
+          "size": 21498
+        },
+        {
+          "path": "norms.svg",
+          "sha256": "48fa42ba0f8749beb73ffa7eba568e17c10d048b69d0bc0abf451da21cd5e264",
+          "size": 12345
+        },
+        {
+          "path": "offset_text.eps",
+          "sha256": "206489e839dd6e75f1c1f4bf566de77e024f4343b3f68d7ab755934e85bed164",
+          "size": 8853
+        },
+        {
+          "path": "offset_text.pdf",
+          "sha256": "dfe02dc11c571b67b29dbddf95dfd7fd00a4dc114d52f4e133345cafe65a08e6",
+          "size": 6025
+        },
+        {
+          "path": "offset_text.png",
+          "sha256": "75c2e36287aab44bd01ad659cdfce9e87db52b312e1e4bef6838f4619f8c196f",
+          "size": 31008
+        },
+        {
+          "path": "offset_text.svg",
+          "sha256": "5d917d986c9008c57be1524b10c500757ef2cea161773a3f9e540037c08a9efe",
+          "size": 7054
+        },
+        {
+          "path": "patches.eps",
+          "sha256": "4273597b00778c315680fb5cce64529adf575578a1f8180573923ba66f614b58",
+          "size": 9242
+        },
+        {
+          "path": "patches.pdf",
+          "sha256": "0e3121d1b8bd856868250ce96c7fb89b65ce10df111848658f3c3ce0e7d6d390",
+          "size": 6797
+        },
+        {
+          "path": "patches.png",
+          "sha256": "f9844574e51ea20468d88043e655cf52a9200510975b82615fb91f15cbf7c74a",
+          "size": 25221
+        },
+        {
+          "path": "patches.svg",
+          "sha256": "ef77aae1314e84a2a9888505a18ea3ed2a6902bbeabc5b03584ce07149c59a9f",
+          "size": 7157
+        },
+        {
+          "path": "patches_path.eps",
+          "sha256": "2293b25464c145d1bafc089f7de114dcb1efaed34fbd280c150598fdd60c8dfc",
+          "size": 5626
+        },
+        {
+          "path": "patches_path.pdf",
+          "sha256": "d6c8e2ef2879270190ed69dc41c8bd727bde6c1d32114ff1af9fc48a53c75863",
+          "size": 3692
+        },
+        {
+          "path": "patches_path.png",
+          "sha256": "08b81d15849d2fa6bf30a9b3b66be8b833ee2f75eb6245276b602d64f9bb7f7a",
+          "size": 30023
+        },
+        {
+          "path": "patches_path.svg",
+          "sha256": "d16238e2115b45b469423b1bf9a10f8767a2c53827fa3f36aaed3b15760cbebf",
+          "size": 4249
+        },
+        {
+          "path": "pcolormesh.eps",
+          "sha256": "d8d1ff0f6f09a7133d4b6404339a12cb225cb33ca2d89cbcece0f6de9ab5d500",
+          "size": 44989
+        },
+        {
+          "path": "pcolormesh.pdf",
+          "sha256": "5fe46331a0385f4d39f8e58d7d6384a70d6bcd93b5a95bc587e391c59532707a",
+          "size": 25245
+        },
+        {
+          "path": "pcolormesh.png",
+          "sha256": "fcd838ff0c401e018cf7b40c7e190246feb2731b7c6752b054a9410778713384",
+          "size": 21261
+        },
+        {
+          "path": "pcolormesh.svg",
+          "sha256": "01a8f09bac107e113d1575575ec649c14297be96aebfae5b39bea4f8a8c6f113",
+          "size": 21696
+        },
+        {
+          "path": "pie.eps",
+          "sha256": "3481967c00ff6a6b31916b33fb1925de832a533e5b40e1c1f0b2c9c51e63639a",
+          "size": 2987
+        },
+        {
+          "path": "pie.pdf",
+          "sha256": "7dd543cba11b50a9b700be22a4ebcb5b661a62f0bc9680c37ad0edd603356ee8",
+          "size": 2936
+        },
+        {
+          "path": "pie.png",
+          "sha256": "23137ddf2de975a8ea59644e5ebc045e21884bfbd8ae571db07fbd2899f22759",
+          "size": 23571
+        },
+        {
+          "path": "pie.svg",
+          "sha256": "7815a879f898e14608d60c4a646f862adc8f924e8db99881b8e75ee518ae5583",
+          "size": 2476
+        },
+        {
+          "path": "pie_opts.eps",
+          "sha256": "2351ce716d72702bd7308224fb49445cfdc8d98bfadf305bb35e57243e72ef72",
+          "size": 3945
+        },
+        {
+          "path": "pie_opts.pdf",
+          "sha256": "96775648d3b498a8ed8feec8d25171fd328a966b254dab348f289002b095a260",
+          "size": 3612
+        },
+        {
+          "path": "pie_opts.png",
+          "sha256": "262bc9d65bc8939331ca275a5e7d37cc0493ec538ac2dd242063c46bfc608588",
+          "size": 32364
+        },
+        {
+          "path": "pie_opts.svg",
+          "sha256": "10643643446f2bdf4eb670dad4dc39c297e6461c91e6268b3647e1837f6a8a9f",
+          "size": 3469
+        },
+        {
+          "path": "plot_y.eps",
+          "sha256": "b51b3f6533ac44ece3945d1e30a13dc8dc35471ad5a3c3de4244830c1d87f7aa",
+          "size": 64767
+        },
+        {
+          "path": "plot_y.pdf",
+          "sha256": "55f58bb6d18e137f160c193669ba34211882295221479ff125c3a3e652dbaf52",
+          "size": 47987
+        },
+        {
+          "path": "plot_y.png",
+          "sha256": "12d1dc996f1741e44cb4f0a74d4f04f082a2ccee54bdec23af23b7462106ff6e",
+          "size": 40210
+        },
+        {
+          "path": "plot_y.svg",
+          "sha256": "c534bbb016629262018351fef98c9fa6007853fa4a6bf5cca9fe0b931125d03f",
+          "size": 19461
+        },
+        {
+          "path": "polar.eps",
+          "sha256": "f37c48688c1452a225a0f6329ce4c0f5f048f0c6902b7b7dbbac55d4b2d4d5c3",
+          "size": 54459
+        },
+        {
+          "path": "polar.pdf",
+          "sha256": "0d848006824e901ee8b50e1187a5899440eb901ebdb669aa5dc9924950cf7224",
+          "size": 43857
+        },
+        {
+          "path": "polar.png",
+          "sha256": "b1f036f6a93fc9c7604aa1349d6912c36c25110178e1f3c41f9f421bf0b20ac7",
+          "size": 72845
+        },
+        {
+          "path": "polar.svg",
+          "sha256": "293d2c4dca562cff67f6be3f02315f9329bbab4e45a7b232b712b16d53990957",
+          "size": 44319
+        },
+        {
+          "path": "quiver.eps",
+          "sha256": "996af9d349f1d83c192610c84138de54c34c3552b24d0a6024f76a276aac29ba",
+          "size": 24007
+        },
+        {
+          "path": "quiver.pdf",
+          "sha256": "4dac8340a0b4b9397ebf669d26a424cca4688d35438226c706aac11020d4a583",
+          "size": 17046
+        },
+        {
+          "path": "quiver.png",
+          "sha256": "0b156a10c780d0e147c4f0927381416bb775f66ec0a60270e17792bf00a473d5",
+          "size": 39119
+        },
+        {
+          "path": "quiver.svg",
+          "sha256": "c93234d088a1d137f2d915f496047b39bb0f50b90f79ac5478682458ad34ddf1",
+          "size": 16554
+        },
+        {
+          "path": "quiver3d.eps",
+          "sha256": "22b7123d16e0512eec024bd1245f5da0804fcf2ec06875ade65fb1f1ce342a89",
+          "size": 16864
+        },
+        {
+          "path": "quiver3d.pdf",
+          "sha256": "1bcd41a91ebf96642765f09e68c15213f32d73426cb53cc7de59867e652c1c4f",
+          "size": 10205
+        },
+        {
+          "path": "quiver3d.png",
+          "sha256": "b1e14ff9e57723135ff2d83e239434026470ef14fab4837040cd99d4a57df46f",
+          "size": 84221
+        },
+        {
+          "path": "quiver3d.svg",
+          "sha256": "85cd14c6d9482eb3321c06c02bde6d5858abef5f5e10de93b756b315c3a3ec6f",
+          "size": 11387
+        },
+        {
+          "path": "savefig_tight.eps",
+          "sha256": "cefa235f59b193569578b1ab8bf2cd3df33c59d5b0c31d6283fa5d60153bae4f",
+          "size": 4931
+        },
+        {
+          "path": "savefig_tight.pdf",
+          "sha256": "b193398fbd8569b57158c08686149b3354a61442bdd9efd90bde2ee448d23c54",
+          "size": 3211
+        },
+        {
+          "path": "savefig_tight.png",
+          "sha256": "5057fce26518e33dfa43fcba217562463d28b1baba6c581a0efa1207ad376ffd",
+          "size": 68856
+        },
+        {
+          "path": "savefig_tight.svg",
+          "sha256": "28f9166fc8299042a14b4d747f8524debbafccade5fe85c063b707f304fd3041",
+          "size": 3941
+        },
+        {
+          "path": "scatter.eps",
+          "sha256": "49e93429adb0fb9fb02fe45d20bc5b076b3cc627884945d277b121bbb9f6adaf",
+          "size": 23854
+        },
+        {
+          "path": "scatter.pdf",
+          "sha256": "99b91a41d1f73cf2785ff304c8f18397e981f3e0b9e3845816979726d1db5943",
+          "size": 17031
+        },
+        {
+          "path": "scatter.png",
+          "sha256": "a17b5e216dfe93dc6d490c630ca51d268112e86640f504a8441614d0bec2c818",
+          "size": 24876
+        },
+        {
+          "path": "scatter.svg",
+          "sha256": "c046e4cdfeb01c6655c343dd907830547b45e8fc86d212fc5a421aa1cd79bfaf",
+          "size": 8371
+        },
+        {
+          "path": "scatter_cmap.eps",
+          "sha256": "4ed666b82d9c94cc766c8fa3114c2d3af197e185384dc13a54c9ae202daace6c",
+          "size": 36048
+        },
+        {
+          "path": "scatter_cmap.pdf",
+          "sha256": "727999043f0bcebb7420e5ee7ffb46f50542bfe59a0c99c05e5a9be66137e474",
+          "size": 23357
+        },
+        {
+          "path": "scatter_cmap.png",
+          "sha256": "b29cff1fbc40f1678791d9c2aa5dc992268fe62a6e227767b8be014a9aac0755",
+          "size": 34752
+        },
+        {
+          "path": "scatter_cmap.svg",
+          "sha256": "4d62acf34690695616a7b3e3a000efd7f90d44b6f4d4f039609cc5cf183f82e8",
+          "size": 21482
+        },
+        {
+          "path": "scatter_edge.eps",
+          "sha256": "77889a20630d643e8acb11e926e9936c5f5ca4c8b7243aaae61f7fa74915d9c8",
+          "size": 26390
+        },
+        {
+          "path": "scatter_edge.pdf",
+          "sha256": "24b92e271fc3651a105367f86744df0adbcded2d7ecc2aca5e08a3bcbddcdd34",
+          "size": 18737
+        },
+        {
+          "path": "scatter_edge.png",
+          "sha256": "d3c5f6df04f8ff192711ef82c3cfb20c4569fba9af88a85095a071730f0c3975",
+          "size": 47476
+        },
+        {
+          "path": "scatter_edge.svg",
+          "sha256": "f22880cbf90cc3bb8117f8131a58e2f6462e2421965f72ee522877d630b2d8af",
+          "size": 16259
+        },
+        {
+          "path": "semilogx.eps",
+          "sha256": "44c880bb3d22953113b2d9961b5e220dcda6518bf684471a4557530fec2feb13",
+          "size": 10132
+        },
+        {
+          "path": "semilogx.pdf",
+          "sha256": "2bda83069dc9c644c7ab80e3e171097c039dbd0b56a8f9cd02cf30b5b45e1eb0",
+          "size": 6063
+        },
+        {
+          "path": "semilogx.png",
+          "sha256": "0520569f0441e97274d7f11160339d9e2856fe312480a2635f33d41a9b3edf54",
+          "size": 22204
+        },
+        {
+          "path": "semilogx.svg",
+          "sha256": "012941d447e0cd9e2457783eb6e3d679ce841bcd072df3236c86c5b0fdcfa14d",
+          "size": 7013
+        },
+        {
+          "path": "semilogy.eps",
+          "sha256": "06a52225883a27767279a0fdd4a9b2799a062c432a14a68eefa6dc5acb28f7b8",
+          "size": 25097
+        },
+        {
+          "path": "semilogy.pdf",
+          "sha256": "4007bc91e64278f8888cc97ff7acb1dfaea8a4d33a7d9b0131b2081c12c43ecd",
+          "size": 15725
+        },
+        {
+          "path": "semilogy.png",
+          "sha256": "501c4cabb6694fec2c9664756cdf4646634c3572ff3887409ac4cd7faf01a712",
+          "size": 28549
+        },
+        {
+          "path": "semilogy.svg",
+          "sha256": "9c9786fbbbca6e90fa4dd9b24abe928b64eaf69c90b199b5b85d3bd645adfbbd",
+          "size": 12650
+        },
+        {
+          "path": "spans.eps",
+          "sha256": "d463580f0ee9b75cfb79b3ae290c11c853aac0abf69d1b961598c5b5daca7e89",
+          "size": 9679
+        },
+        {
+          "path": "spans.pdf",
+          "sha256": "c0ded2389bfe0ef0e080d25f6b67ca6c2b2c8463af26ec63b587332aea30e947",
+          "size": 6618
+        },
+        {
+          "path": "spans.png",
+          "sha256": "4860b80cf8794f6677fa45830c6f496e1e3c79bef27716f5ad37386bddbded0a",
+          "size": 32690
+        },
+        {
+          "path": "spans.svg",
+          "sha256": "0dc9bf6dfadacafce679dc509db05da3828973dfa0e9c4baaca7a9abdc1719ad",
+          "size": 7407
+        },
+        {
+          "path": "stem.eps",
+          "sha256": "434a2ecc88b56f2302cf395c984a98705201608e3404635536ccf1b7f8969f1d",
+          "size": 8915
+        },
+        {
+          "path": "stem.pdf",
+          "sha256": "870286f411d3b06b518985033a25bc061444fbd8416348beb20d9391e786bf0f",
+          "size": 6069
+        },
+        {
+          "path": "stem.png",
+          "sha256": "f32c24cd20184c53984b03a10713de67594cfbfa4ac88e144eae89c4ecabb55c",
+          "size": 14321
+        },
+        {
+          "path": "stem.svg",
+          "sha256": "dea488aab660e44a061b42f5a10513dc64481cae2720c167958365f185363f85",
+          "size": 5699
+        },
+        {
+          "path": "step.eps",
+          "sha256": "a6fcf2d72604fcbda4bf7093c5b3d59379ca717c6c4184a96fda96fa9ff34f60",
+          "size": 4766
+        },
+        {
+          "path": "step.pdf",
+          "sha256": "3153fa33f4f2adbcdf13319950afcd77b910ec6c82149b879e79aaab7143e61a",
+          "size": 3178
+        },
+        {
+          "path": "step.png",
+          "sha256": "762f4889b197cafb3859f4d2731437e2589ad80456d7b0bfd99e1a300ae9c657",
+          "size": 13186
+        },
+        {
+          "path": "step.svg",
+          "sha256": "aba632c372e2837831b3b1c2706e42c9e484b540ab74c0bb6ac8882400162702",
+          "size": 3738
+        },
+        {
+          "path": "streamplot.eps",
+          "sha256": "eeb23c12407a689c3007de81122436e122b2fb0371ecbde645fce194aeb8df12",
+          "size": 81375
+        },
+        {
+          "path": "streamplot.pdf",
+          "sha256": "8109b3366f219647e769adcbafe96cb4ec6c519ab5207f0592cf98c6ebec73b8",
+          "size": 58212
+        },
+        {
+          "path": "streamplot.png",
+          "sha256": "734c85540ab103c0ea1981782ffc5f89f98dde39b3a6367c669155e7782fdc2c",
+          "size": 121548
+        },
+        {
+          "path": "streamplot.svg",
+          "sha256": "04101c00246aa4a99d37e391b1972cf62d53e63ac9c4b5d6214ca31d15192d18",
+          "size": 52950
+        },
+        {
+          "path": "style_ggplot.eps",
+          "sha256": "61ec61f5885b3b462d39f1c3699c4141fcc31215c148a7c985637c412abb2d59",
+          "size": 16495
+        },
+        {
+          "path": "style_ggplot.pdf",
+          "sha256": "7044d1dfc7dd884f6ef9e56e18f3f732602158f15dffdbd0626c796912c8673f",
+          "size": 11341
+        },
+        {
+          "path": "style_ggplot.png",
+          "sha256": "713b84bd57fd9522051aeffe9f8906ac39683d12645805d0d7f84934502f7859",
+          "size": 44679
+        },
+        {
+          "path": "style_ggplot.svg",
+          "sha256": "075bd5b27893bdff929d41e39e0ce71da223918e27045218d81878052a932bf4",
+          "size": 11595
+        },
+        {
+          "path": "subplots_2x1.eps",
+          "sha256": "0187af4d73819eae67e75b9a2a275e1c59fea231d0a696f3c18065d5625f7b33",
+          "size": 21216
+        },
+        {
+          "path": "subplots_2x1.pdf",
+          "sha256": "c130338b20077c65229217c563871ff806825903d6992e878f846fe40b366712",
+          "size": 13468
+        },
+        {
+          "path": "subplots_2x1.png",
+          "sha256": "e36b22eabbf82c098f61b5bd5ccbafa3003431797bfebba943e2875b682794ca",
+          "size": 39295
+        },
+        {
+          "path": "subplots_2x1.svg",
+          "sha256": "7f08c8ad7bc1085b4638520eb83ac8694d66155f54369c1bd297ea6f647b43cc",
+          "size": 15344
+        },
+        {
+          "path": "subplots_2x2.eps",
+          "sha256": "78273931335a234eba725c265d2be8b927598fc21fee08bcce1b3233c22324eb",
+          "size": 34200
+        },
+        {
+          "path": "subplots_2x2.pdf",
+          "sha256": "bc9cf7043d922cca54410f0f178ec5a31d16bf6637320abd624ebaac7e4e5a74",
+          "size": 21509
+        },
+        {
+          "path": "subplots_2x2.png",
+          "sha256": "3937bd8c79184851736605c291fccd1e4a77590a717828f88a5c196df636341a",
+          "size": 51616
+        },
+        {
+          "path": "subplots_2x2.svg",
+          "sha256": "12f719e160022bc24d5a77ca01911451556d80b43b5f3b4dde835fef3a46e254",
+          "size": 24426
+        },
+        {
+          "path": "subplots_adjust.eps",
+          "sha256": "03acdd1706ea23e3bb0b12ac6d6d500f0c364a1b57368830ed30619cdc8827d8",
+          "size": 7016
+        },
+        {
+          "path": "subplots_adjust.pdf",
+          "sha256": "9631f8c3b0e42b30dac394e9fd4c271d940407e5530516e6aab262b4607f11c1",
+          "size": 4268
+        },
+        {
+          "path": "subplots_adjust.png",
+          "sha256": "b778c40d216d8d8214ac1bf688184e79b32e848c9a6d958ef7a7535236153b44",
+          "size": 30126
+        },
+        {
+          "path": "subplots_adjust.svg",
+          "sha256": "02ab984b075d843a845f7fe84e817b12e8d209e3bfe3bd960d2c3f9de33519b5",
+          "size": 5528
+        },
+        {
+          "path": "subplots_shared.eps",
+          "sha256": "ea99a79f3f0d7a65501db1135fd38371927feba14653714562ab9ca6831159db",
+          "size": 38590
+        },
+        {
+          "path": "subplots_shared.pdf",
+          "sha256": "5e651161429baad7b7e74177042e169dd4431efbc0c778afdc996b6bb7444f5a",
+          "size": 25381
+        },
+        {
+          "path": "subplots_shared.png",
+          "sha256": "b3730c38040010c8392a6a6d22d7aef34246fbe856ccd9554baeb82dc9dc555f",
+          "size": 43236
+        },
+        {
+          "path": "subplots_shared.svg",
+          "sha256": "f32dac349af91f3f67f162b29d4690d4f7ecf916b7e90a7b8dfb9588ecb28382",
+          "size": 20390
+        },
+        {
+          "path": "surface3d.eps",
+          "sha256": "cc6abed70367e3e0f974ccc64bd518b111167a94e944770dc129e2ec5f0daa6f",
+          "size": 291685
+        },
+        {
+          "path": "surface3d.pdf",
+          "sha256": "9c93e1b0e23531a091bec6c58d1e6f56baf982408b2eefe4c9a15b0ab72b3526",
+          "size": 173038
+        },
+        {
+          "path": "surface3d.png",
+          "sha256": "b0081192f62a373511dada6d9f33b3c5c03d9aaad63c7405587b2890aea658f1",
+          "size": 86877
+        },
+        {
+          "path": "surface3d.svg",
+          "sha256": "f7c312282979a64e3eefc95144fe326565fe54e06a78204bab49e691479c0bb8",
+          "size": 153557
+        },
+        {
+          "path": "surface3d_extra.eps",
+          "sha256": "1a6c15f738088003f796663095352d62943d375f5956936e0df3ac81eb13d82d",
+          "size": 359363
+        },
+        {
+          "path": "surface3d_extra.pdf",
+          "sha256": "50f79067fc4886bc7422ed6145db4e7ba21a6dce2161486e3dc47cd539d3f510",
+          "size": 224681
+        },
+        {
+          "path": "surface3d_extra.png",
+          "sha256": "0d7081d1172e3e2fcd10611d086bfffa50685946941d73f1ab8fd2520f80ac03",
+          "size": 108931
+        },
+        {
+          "path": "surface3d_extra.svg",
+          "sha256": "b1a79910f06a157eb34331d2e417371ad08481d9733772ee62c11473fec1bc99",
+          "size": 206292
+        },
+        {
+          "path": "symlog.eps",
+          "sha256": "12b2b65d230c4d423fdaf638333d24eb05acc17f5afe4535e9d7e9b0dc2c6f15",
+          "size": 11340
+        },
+        {
+          "path": "symlog.pdf",
+          "sha256": "8baead0c5f2a67c0f912a442592ee3d56fe6446f854171973cb1237901008f61",
+          "size": 8163
+        },
+        {
+          "path": "symlog.png",
+          "sha256": "27cc138006726c587f30c17814383f065bdca8a98f8192cacec300744d91feed",
+          "size": 22353
+        },
+        {
+          "path": "symlog.svg",
+          "sha256": "37581a641ed6dd2ce394ebe72720efd22e9f1c385cf727963988b2c4618013cf",
+          "size": 9070
+        },
+        {
+          "path": "table.eps",
+          "sha256": "daa49d40065f722280810e3d08fb7e35bd29e256502815453970b206fed57420",
+          "size": 6280
+        },
+        {
+          "path": "table.pdf",
+          "sha256": "25c83ea9c4b44cff469b7ea79434ccca631aefa1801f08d37fc2fbcd7e47aa08",
+          "size": 4165
+        },
+        {
+          "path": "table.png",
+          "sha256": "243ed169e5d68603c4cca3e7d3928a29bf55af040900c74106a6814e2bfb0745",
+          "size": 14863
+        },
+        {
+          "path": "table.svg",
+          "sha256": "5164ef72563a1b8b18d5fd39677ca2f73ffa4049ae75093282e785479e7f43d0",
+          "size": 4641
+        },
+        {
+          "path": "text_annotate.eps",
+          "sha256": "60fd12501a79836f2a76fe4e0772f3b1c0970fd52b1c88a41bbd247472a42d8c",
+          "size": 12522
+        },
+        {
+          "path": "text_annotate.pdf",
+          "sha256": "eb7a963c1c811d79fb19d3bbde8322964f8787592e528ced067d497555a35f25",
+          "size": 8311
+        },
+        {
+          "path": "text_annotate.png",
+          "sha256": "90457d6cceeb61dfc235aafe061ea19a6eb385ca098f99abef305cf2caf4698b",
+          "size": 34871
+        },
+        {
+          "path": "text_annotate.svg",
+          "sha256": "420d36d2b38274a724f321c9002951b867cd8a7e24b30918297256463286db2a",
+          "size": 8957
+        },
+        {
+          "path": "text_options.eps",
+          "sha256": "c60cc501c022d7059d5273fa3761ab18b0542409ae2a96922388101090eac950",
+          "size": 9611
+        },
+        {
+          "path": "text_options.pdf",
+          "sha256": "d40cea89b0c4981500bf0c6dd8f164b55828425cd928a90cbcce7351fdbcff9a",
+          "size": 6578
+        },
+        {
+          "path": "text_options.png",
+          "sha256": "d3c9b07daa70a227281f139a6c9a733e5b997c315037ec148408f8ffe0eb3d76",
+          "size": 33987
+        },
+        {
+          "path": "text_options.svg",
+          "sha256": "780ffffe63383baa9ee8b189fe9ca7cfa8a4e5e56232921afee73a55de611600",
+          "size": 7763
+        },
+        {
+          "path": "tick_locator.eps",
+          "sha256": "60b4cf549ece4a098464552fc774f5d1e987650888aba2e053143c90d88bea99",
+          "size": 13359
+        },
+        {
+          "path": "tick_locator.pdf",
+          "sha256": "b4c66243e8342d342df507a9fa651178a13c76aad1d58da996e8d5d8742fc097",
+          "size": 9119
+        },
+        {
+          "path": "tick_locator.png",
+          "sha256": "c1ec9c6fcc505c3796b8fcd0945785684d18b696fccd5ae1d1b2d4661730ba6b",
+          "size": 32671
+        },
+        {
+          "path": "tick_locator.svg",
+          "sha256": "b03d8b1e81f6a39d0221e782304626bbd707326ed0ce6e996ef369e9fec256e2",
+          "size": 10692
+        },
+        {
+          "path": "tick_style.eps",
+          "sha256": "046eca67e15beece0b9ecedcd4f0ec64f5b21b6d44ce1339fb620360b6fd921e",
+          "size": 4743
+        },
+        {
+          "path": "tick_style.pdf",
+          "sha256": "9478e6cc3e7e584c2e8d2b8744bec80f240956a8907c220064f88adde0bfe2ac",
+          "size": 3327
+        },
+        {
+          "path": "tick_style.png",
+          "sha256": "a4eb5979533d4f49c731e0f310f0fa30319c90980d280861467f5cc2edf0e8f9",
+          "size": 27448
+        },
+        {
+          "path": "tick_style.svg",
+          "sha256": "20d4093b03b54782fb649b8cc235508d86d0f6fafa235cde47de6d5d1c5763ac",
+          "size": 3947
+        },
+        {
+          "path": "ticks_legend.eps",
+          "sha256": "79d435b1e2cdc1bc4ba10072930138f92a3b2129f2957a9f96422d54523e788f",
+          "size": 13957
+        },
+        {
+          "path": "ticks_legend.pdf",
+          "sha256": "3d3c0a60ef7cc98469e32dd0ab53950b4f154e5e0d931ac59c672bf8580cf82b",
+          "size": 9476
+        },
+        {
+          "path": "ticks_legend.png",
+          "sha256": "2cf996b1bb9da6cb568fd94c6d4540141c270e552ef24f49003b0cc88e2d96fb",
+          "size": 35711
+        },
+        {
+          "path": "ticks_legend.svg",
+          "sha256": "ef6acc020ba4d3f98f5c9b16c07ae0bad05dabffce633a04f988b0816cc40089",
+          "size": 10721
+        },
+        {
+          "path": "tight_layout.eps",
+          "sha256": "bb2d00828867e97a567b847b8c4403d002974af2280ca86c89f95ab487ca9541",
+          "size": 9091
+        },
+        {
+          "path": "tight_layout.pdf",
+          "sha256": "d1ec33cdfbd2d0c2872c73a03a9e67ae41f229c5ac940cb353e2485609bdeb4e",
+          "size": 5147
+        },
+        {
+          "path": "tight_layout.png",
+          "sha256": "cf5f53c96ab4ca5cf0b0636fbfb47faf5abb507743ad194aabeaeb9c44e86ea2",
+          "size": 40690
+        },
+        {
+          "path": "tight_layout.svg",
+          "sha256": "03d0a887aadd3ae10d4fed9748d8b8cfa33e3a91b18467eea4c1f3a1d7828dcd",
+          "size": 7137
+        },
+        {
+          "path": "title_loc.eps",
+          "sha256": "93a6745ccc58587885c4b4c9ed88f5e3cf7c5e2ee12e3e2c992f07ad224c5455",
+          "size": 8834
+        },
+        {
+          "path": "title_loc.pdf",
+          "sha256": "dcf042191a73a755e616178c252693e611271db48daf647576207323a6925808",
+          "size": 6008
+        },
+        {
+          "path": "title_loc.png",
+          "sha256": "7f86e5fc98d65e68f09995e20851f44077aef96881ab25a8dc6eb8eae27069cd",
+          "size": 28887
+        },
+        {
+          "path": "title_loc.svg",
+          "sha256": "295fe471e698e7c23e3672a319c4814d9a1e33639fa1302024646b91d638041a",
+          "size": 7093
+        },
+        {
+          "path": "transform_axes.eps",
+          "sha256": "2f6be998092a1ab27c6b7b196e02d939f9ea58453028e7ab2a369f5daff94762",
+          "size": 8885
+        },
+        {
+          "path": "transform_axes.pdf",
+          "sha256": "914101b87f8935822b735a6b6ea0f86c0b8d8524380cce295861abcf8f84cfae",
+          "size": 6124
+        },
+        {
+          "path": "transform_axes.png",
+          "sha256": "12de362e8785b4828178d7b39d89f258c8f61a0bdcbcd12d53310f3bbe77a49d",
+          "size": 33814
+        },
+        {
+          "path": "transform_axes.svg",
+          "sha256": "bf9426a3f90589335c4207884ab01dcd191636772f015a904f1c0d827bbeae50",
+          "size": 7107
+        },
+        {
+          "path": "tricontour.eps",
+          "sha256": "6c701038a38bac0066b53e7fabcc701b3ddab84e5c70c452ecbc9645a31b1a3f",
+          "size": 73430
+        },
+        {
+          "path": "tricontour.pdf",
+          "sha256": "38ca1a84873a5c571e85adcbd1a88ad10d0bc1f8ff47defb49a9dd3fdff13e00",
+          "size": 46453
+        },
+        {
+          "path": "tricontour.png",
+          "sha256": "8f63b767b47f4deb7c179a64e3c1618b031640c19435b8ec1c99b0acefef7342",
+          "size": 82284
+        },
+        {
+          "path": "tricontour.svg",
+          "sha256": "802e863128e73b5e5df4ab9a207bdfcc34c99c5b847d9119cc1843734e746d33",
+          "size": 44665
+        },
+        {
+          "path": "tricontourf.eps",
+          "sha256": "ef0068267f90fa386f3c5a15020264762933f4d386df784047432c5a54effb0f",
+          "size": 196467
+        },
+        {
+          "path": "tricontourf.pdf",
+          "sha256": "ec6cb011bdc096a03a157705a5307fc6af3597099fbc7f14a407b9487d007466",
+          "size": 120784
+        },
+        {
+          "path": "tricontourf.png",
+          "sha256": "386c478edfe0f9229f40ac99b437b8a11bf8ab1783aa8cb8f66589411e3a6ba2",
+          "size": 100627
+        },
+        {
+          "path": "tricontourf.svg",
+          "sha256": "854ab976965878e4564f6e843f61d5c68abd35a24c3d9fee18a047c9451832ff",
+          "size": 89950
+        },
+        {
+          "path": "tripcolor.eps",
+          "sha256": "dcdeb4ebc635322310b9a1887af70f6c4ba6b40186d9e0fa23502288375fc24a",
+          "size": 31920
+        },
+        {
+          "path": "tripcolor.pdf",
+          "sha256": "f25335fbc94540ee36fb3d65c7f16c6dcd1b13637e1376c43a89bb11864412a6",
+          "size": 18630
+        },
+        {
+          "path": "tripcolor.png",
+          "sha256": "d05e1ee87e235669d872214ab5e4983b924072b3fa747037f33620ca6bfd1d46",
+          "size": 55774
+        },
+        {
+          "path": "tripcolor.svg",
+          "sha256": "e0e0ddb74c94acc4b4e9ee9c1948d44281c69edb8b91fa5a2066cf8c3cdfe6cd",
+          "size": 16074
+        },
+        {
+          "path": "triplot.eps",
+          "sha256": "e6b36181557d0667a5867016ec2550959d28eaa9be84a2281b077c9b50304fab",
+          "size": 28434
+        },
+        {
+          "path": "triplot.pdf",
+          "sha256": "f88b8f86dcde2f573ebaa56097f7d48316569b2bdb5af8efc949270fab208aac",
+          "size": 19818
+        },
+        {
+          "path": "triplot.png",
+          "sha256": "2118015ebaa15e883f6d0af8b14b8bc85b31bcbf877c7caf7147db45933807ef",
+          "size": 81305
+        },
+        {
+          "path": "triplot.svg",
+          "sha256": "34e074955201127421b901f6de9df23cba2dfc3354f15ca648b5b2a291c797c7",
+          "size": 13460
+        },
+        {
+          "path": "trisurf.eps",
+          "sha256": "b6f464c7496fc04b97b17bdcc6b7530946494ba63076c4cad7c31d8214381834",
+          "size": 42561
+        },
+        {
+          "path": "trisurf.pdf",
+          "sha256": "d28529e476784e0a9489d880329accefab62bf7d3927ec58284215c71cf625e2",
+          "size": 24733
+        },
+        {
+          "path": "trisurf.png",
+          "sha256": "79bf6ddce2b6e5f6b19745c572aa6d776d0440745c738df4d51b3c22945e2d3a",
+          "size": 78047
+        },
+        {
+          "path": "trisurf.svg",
+          "sha256": "8e220c270921f87e8d75acbf1a098fdb93bf6df384b62b1587e109b09e273c57",
+          "size": 23721
+        },
+        {
+          "path": "twinx.eps",
+          "sha256": "213e13462bd6ffc4ff3324cab5a477d4a28671a3be3b0caded94388657ce01ef",
+          "size": 7293
+        },
+        {
+          "path": "twinx.pdf",
+          "sha256": "8ecbdbbbf27cb453190d2518e714aec673b31c24c4fdc1ff48c8e4aeae4f60c3",
+          "size": 4337
+        },
+        {
+          "path": "twinx.png",
+          "sha256": "ebe138b0b874b0179d63cbbde3dcda733a41f6836e3a5618a2318fbf06ec1588",
+          "size": 35698
+        },
+        {
+          "path": "twinx.svg",
+          "sha256": "131940bda8b1f819ecf9e5457f4c815c7a4f3eccd3fb48b3d4f09b3f7dae8530",
+          "size": 5886
+        },
+        {
+          "path": "violin_opts.eps",
+          "sha256": "5c502282656f1a3fdf1beb44fee8e8ebcb9c118a0d0472cd4207264bd70ae762",
+          "size": 30952
+        },
+        {
+          "path": "violin_opts.pdf",
+          "sha256": "9eaf81beabfc4ef2c7614e358dc8c11766f1e44fcd9020bccc1457704adf9f52",
+          "size": 23990
+        },
+        {
+          "path": "violin_opts.png",
+          "sha256": "0299bd2fa5fcb7a913fadbf77f791ef97dd1000bf43970f925afca1c673ba206",
+          "size": 25102
+        },
+        {
+          "path": "violin_opts.svg",
+          "sha256": "854ea20e0879f149385f0bf1641b8e447eb1e61d71c03cbff4a07f4d57767742",
+          "size": 24473
+        },
+        {
+          "path": "violinplot.eps",
+          "sha256": "6ef8bb782918a5a844b4d808d19427dbf0566cd4fbd1c490c21c9a0f068177d3",
+          "size": 17583
+        },
+        {
+          "path": "violinplot.pdf",
+          "sha256": "c9221e0b2ec2a2a20189190e5530ebb9846e400cff21f1d17f44c18ee1c6f257",
+          "size": 13475
+        },
+        {
+          "path": "violinplot.png",
+          "sha256": "c9caabe201ab1dda0fccb2b41f4826d6f84ef4eb0e0c10144fd34480dcc24369",
+          "size": 21405
+        },
+        {
+          "path": "violinplot.svg",
+          "sha256": "1380ace20c0a565d1ef03748352ef6dcea111df22ae386a25f04324855848db8",
+          "size": 13823
+        },
+        {
+          "path": "zorder.eps",
+          "sha256": "f49ad0031f3d63975f9f23d7632e76f9568b70623302f450af180edbe85a5778",
+          "size": 10414
+        },
+        {
+          "path": "zorder.pdf",
+          "sha256": "79b8e8d109b7f6b00361911fe56e616ba8242dc7e0a9f8dd2e8557d8ef20d947",
+          "size": 6442
+        },
+        {
+          "path": "zorder.png",
+          "sha256": "5d2dfdcde80c24b0f231a1a70442d00286988200a52f6583444210a255464b72",
+          "size": 31652
+        },
+        {
+          "path": "zorder.svg",
+          "sha256": "310d1507a9d00b3b6dc044cf27ca545b249f139ede347bdbc3748e96907a4ae6",
+          "size": 6551
+        }
+      ],
+      "generated_from": "tests/out"
+    },
     "linux-lfortran": {
       "files": [
         {

--- a/tests/reference_hashes.json
+++ b/tests/reference_hashes.json
@@ -2649,7 +2649,7 @@
         },
         {
           "path": "bar3d.png",
-          "sha256": "98e25a939fb6602ec8e51ff3a5e781cc5507572b5b929aebb2f03f261e44361e",
+          "sha256": "6cb71a60a5b74a3808f6999efc211284a3b49b290c790d20f4907320785d46c1",
           "size": 57527
         },
         {
@@ -3029,7 +3029,7 @@
         },
         {
           "path": "contour3d.png",
-          "sha256": "593521ccb984587658a7d29741c1e555916c9b2404e45cf27af717c929951b05",
+          "sha256": "ef45b2a12d367dfe53866a62f327f391799dd815146e3803fd3be93b1d2adcd5",
           "size": 94817
         },
         {
@@ -3769,7 +3769,7 @@
         },
         {
           "path": "line3d.png",
-          "sha256": "d2872916de6c86e5ee3350d1368ebcf5ab065ded046bd9154fc235a4368279ba",
+          "sha256": "10bd8a3f33c90577ddccf73e7b9c833695428e8b4f16357f9a5f91a3072d6e3e",
           "size": 67870
         },
         {
@@ -4249,7 +4249,7 @@
         },
         {
           "path": "quiver3d.png",
-          "sha256": "7398bbdbf57ff8fac1d7c7c83739f45fa132a279e81ecb00278a361ca0b2013b",
+          "sha256": "9a1adedd15b285273be9136f6733412bdc012e860a213e8eb85d65d5c6a7457a",
           "size": 83816
         },
         {
@@ -4569,7 +4569,7 @@
         },
         {
           "path": "surface3d.png",
-          "sha256": "2e2c3fc7cc7bf534c379f7f171b2274d43ec69cfa215fa2e4734c7bc424d63ee",
+          "sha256": "641b388d9280d1eaae87949e9a5973767eb165ee103332c44cc0884ecde729cf",
           "size": 86896
         },
         {
@@ -4589,7 +4589,7 @@
         },
         {
           "path": "surface3d_extra.png",
-          "sha256": "7e91c273e58ca2b6560704719d71502735e933e82c49292df37332a455aa6570",
+          "sha256": "e0296bfcc363b006c82cfe98ae573382718734789d06123d3edb1738d3a1dba9",
           "size": 109161
         },
         {
@@ -4889,7 +4889,7 @@
         },
         {
           "path": "trisurf.png",
-          "sha256": "557d249c446b4aebb28e0db06fb08b880c721f84b94285730e24d1c6adbafdfd",
+          "sha256": "b7c66b9c22558ae1a46f0666ed7e27d8ca78ba5fd6328fe1fb960a0f8d638d73",
           "size": 78115
         },
         {

--- a/tests/test_plots.f90
+++ b/tests/test_plots.f90
@@ -1,4 +1,5 @@
 program test_plots
+    use, intrinsic :: iso_fortran_env, only: error_unit
     use fplot
     implicit none
     integer :: fig1
@@ -82,6 +83,9 @@ program test_plots
     real(dp) :: stx(nst), sty(3, nst)
     character(len=4), parameter :: stlab(3) = ["low ", "mid ", "high"]
     real(dp), parameter :: pi = 3.14159265358979323846_dp
+    logical :: test_paths_ready = .false.
+    character(len=1024) :: test_repo_root = ""
+    character(len=1024) :: test_output_dir = ""
 
     ! Shared data
     do i = 1, n
@@ -1509,10 +1513,11 @@ program test_plots
         call title("anim_sine")
         call add_frame()
     end do
-    call save_animation("tests/out/anim_sine.gif", fps=10.0_dp)
-    print *, "wrote tests/out/anim_sine.gif"
+    call save_animation(output_path("anim_sine", ".gif"), fps=10.0_dp)
+    print *, "wrote ", trim(output_path("anim_sine", ".gif"))
 
     print *, "All test plots written."
+    call verify_reference_hashes()
 
 contains
 
@@ -1535,15 +1540,131 @@ contains
         character(len=*), intent(in), optional :: facecolor, bbox_inches
         real(dp), intent(in), optional :: dpi
 
-        call savefig("tests/out/"//stem//".svg", facecolor=facecolor, &
+        call savefig(output_path(stem, ".svg"), facecolor=facecolor, &
                      bbox_inches=bbox_inches, dpi=dpi)
-        call savefig("tests/out/"//stem//".pdf", facecolor=facecolor, &
+        call savefig(output_path(stem, ".pdf"), facecolor=facecolor, &
                      bbox_inches=bbox_inches, dpi=dpi)
-        call savefig("tests/out/"//stem//".png", facecolor=facecolor, &
+        call savefig(output_path(stem, ".png"), facecolor=facecolor, &
                      bbox_inches=bbox_inches, dpi=dpi)
-        call savefig("tests/out/"//stem//".eps", facecolor=facecolor, &
+        call savefig(output_path(stem, ".eps"), facecolor=facecolor, &
                      bbox_inches=bbox_inches, dpi=dpi)
-        print *, "wrote tests/out/"//stem//".svg, .pdf, .png and .eps"
+        print *, "wrote ", trim(output_path(stem, ".svg")), ", .pdf, .png and .eps"
     end subroutine save_all
+
+    subroutine verify_reference_hashes()
+        character(len=32) :: env
+        character(len=256) :: python_cmd
+        character(len=1024) :: command, cmdmsg
+        integer :: status, cmdstat, exitstat
+
+        call get_environment_variable("FPLOT_SKIP_HASH_VERIFY", env, status=status)
+        if (status == 0) then
+            if (len_trim(env) > 0 .and. trim(env) /= "0") then
+                print *, "Skipping reference hash verification (FPLOT_SKIP_HASH_VERIFY set)."
+                return
+            end if
+        end if
+
+        call get_environment_variable("FPLOT_TEST_PYTHON", python_cmd, status=status)
+        if (status /= 0 .or. len_trim(python_cmd) == 0) python_cmd = "python"
+
+        call ensure_test_paths(python_cmd)
+        command = trim(python_cmd)//' "'//trim(join_path(trim(test_repo_root), "tests/verify_reference_hashes.py"))//'"'
+        call execute_command_line(trim(command), wait=.true., exitstat=exitstat, &
+                                  cmdstat=cmdstat, cmdmsg=cmdmsg)
+        if (cmdstat /= 0) then
+            write (error_unit, '(a)') "fplot: failed to start reference hash verifier: "//trim(cmdmsg)
+            error stop 1
+        end if
+        if (exitstat /= 0) then
+            write (error_unit, '(a,i0)') "fplot: reference hash verification failed with exit code ", exitstat
+            error stop 1
+        end if
+    end subroutine verify_reference_hashes
+
+    function output_path(stem, suffix) result(path)
+        character(len=*), intent(in) :: stem, suffix
+        character(len=1024) :: path
+
+        call ensure_test_paths()
+        path = join_path(trim(test_output_dir), trim(stem)//trim(suffix))
+    end function output_path
+
+    subroutine ensure_test_paths(python_cmd)
+        character(len=*), intent(in), optional :: python_cmd
+        character(len=1024) :: exe_path, probe, mkdir_cmd, cmdmsg, pycmd
+        integer :: status, cmdstat, exitstat, slash
+        logical :: exists
+
+        if (test_paths_ready) return
+
+        call get_command_argument(0, exe_path, status=status)
+        if (status == 0 .and. len_trim(exe_path) > 0) then
+            probe = normalize_path(trim(exe_path))
+            slash = index(trim(probe), "/", back=.true.)
+            if (slash > 0) then
+                probe = probe(:slash - 1)
+            else
+                probe = "."
+            end if
+
+            do
+                inquire(file=trim(join_path(trim(probe), "fpm.toml")), exist=exists)
+                if (exists) then
+                    test_repo_root = trim(probe)
+                    exit
+                end if
+                slash = index(trim(probe), "/", back=.true.)
+                if (slash <= 0) exit
+                if (slash == 3 .and. probe(2:2) == ":") then
+                    probe = probe(:slash)
+                else
+                    probe = probe(:slash - 1)
+                end if
+            end do
+        end if
+
+        if (len_trim(test_repo_root) == 0) test_repo_root = "."
+        test_output_dir = join_path(trim(test_repo_root), "tests/out")
+
+        pycmd = "python"
+        if (present(python_cmd)) then
+            if (len_trim(python_cmd) > 0) pycmd = trim(python_cmd)
+        end if
+        mkdir_cmd = trim(pycmd)//' -c "from pathlib import Path; Path(r'''//trim(test_output_dir)//''').mkdir(parents=True, exist_ok=True)"'
+        call execute_command_line(trim(mkdir_cmd), wait=.true., exitstat=exitstat, &
+                                  cmdstat=cmdstat, cmdmsg=cmdmsg)
+        if (cmdstat /= 0 .or. exitstat /= 0) then
+            write (error_unit, '(a)') "fplot: failed to create output directory: "//trim(test_output_dir)
+            if (len_trim(cmdmsg) > 0) write (error_unit, '(a)') trim(cmdmsg)
+            error stop 1
+        end if
+
+        test_paths_ready = .true.
+    end subroutine ensure_test_paths
+
+    function join_path(base, leaf) result(path)
+        character(len=*), intent(in) :: base, leaf
+        character(len=1024) :: path
+        integer :: n
+
+        path = trim(base)
+        n = len_trim(path)
+        if (n > 0 .and. path(n:n) /= "/") then
+            path = trim(path)//"/"
+        end if
+        path = trim(path)//trim(leaf)
+    end function join_path
+
+    function normalize_path(raw) result(path)
+        character(len=*), intent(in) :: raw
+        character(len=1024) :: path
+        integer :: idx
+
+        path = trim(raw)
+        do idx = 1, len_trim(path)
+            if (path(idx:idx) == "\\") path(idx:idx) = "/"
+        end do
+    end function normalize_path
 
 end program test_plots

--- a/tests/update_reference_hashes.py
+++ b/tests/update_reference_hashes.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Refresh the committed reference hash manifest from tests/out."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "reference_hashes.json"
+OUT = ROOT / "out"
+TEXT_SUFFIXES = {".svg", ".eps"}
+
+
+def normalize_bytes(path: Path) -> bytes:
+    data = path.read_bytes()
+    if path.suffix.lower() in TEXT_SUFFIXES:
+        return data.replace(b"\r\n", b"\n")
+    return data
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(normalize_bytes(path)).hexdigest()
+
+
+def main() -> int:
+    if not OUT.exists():
+        print(f"output directory not found: {OUT}")
+        print("run: fpm test")
+        return 1
+
+    files = sorted(path for path in OUT.iterdir() if path.is_file())
+    if not files:
+        print(f"no output files found in {OUT}")
+        print("run: fpm test")
+        return 1
+
+    payload = {
+        "version": 1,
+        "generated_from": str(OUT.relative_to(ROOT.parent)).replace("\\", "/"),
+        "files": [
+            {
+                "path": path.name,
+                "sha256": sha256(path),
+                "size": len(normalize_bytes(path)),
+            }
+            for path in files
+        ],
+    }
+
+    MANIFEST.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"updated {MANIFEST} with {len(files)} file hashes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/update_reference_hashes.py
+++ b/tests/update_reference_hashes.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
+import os
+import platform
+import re
 import sys
 from pathlib import Path
 
@@ -25,7 +29,70 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(normalize_bytes(path)).hexdigest()
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", help="Reference hash profile to update")
+    return parser.parse_args()
+
+
+def existing_profiles() -> list[str]:
+    if not MANIFEST.exists():
+        return []
+
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    version = int(payload.get("version", 1))
+    if version == 1:
+        return ["default"]
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, dict):
+        return []
+    return sorted(profiles)
+
+
+def infer_profile_name() -> str:
+    profile = os.environ.get("FPLOT_HASH_PROFILE", "").strip()
+    if profile:
+        return profile
+
+    system_name = platform.system().lower() or "unknown"
+    matches = [name for name in existing_profiles() if name.startswith(f"{system_name}-")]
+    if len(matches) == 1:
+        return matches[0]
+
+    compiler = "unknown"
+    for key in ("FPLOT_HASH_COMPILER", "FPM_FC", "FC"):
+        value = os.environ.get(key, "").strip()
+        if value:
+            compiler = Path(value).stem.lower()
+            break
+    compiler = re.sub(r"[^0-9A-Za-z._-]+", "-", compiler).strip("-") or "unknown"
+    return f"{system_name}-{compiler}"
+
+
+def load_profiles() -> dict[str, dict[str, object]]:
+    if not MANIFEST.exists():
+        return {}
+
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    version = int(payload.get("version", 1))
+    if version == 1:
+        return {
+            "default": {
+                "generated_from": str(payload.get("generated_from", "tests/out")),
+                "files": payload["files"],
+            }
+        }
+
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, dict):
+        raise ValueError(f"reference hash manifest has no profiles: {MANIFEST}")
+    return profiles
+
+
 def main() -> int:
+    args = parse_args()
+    profile = args.profile or infer_profile_name()
+
     if not OUT.exists():
         print(f"output directory not found: {OUT}")
         print("run: fpm test")
@@ -37,8 +104,8 @@ def main() -> int:
         print("run: fpm test")
         return 1
 
-    payload = {
-        "version": 1,
+    profiles = load_profiles()
+    profiles[profile] = {
         "generated_from": str(OUT.relative_to(ROOT.parent)).replace("\\", "/"),
         "files": [
             {
@@ -50,8 +117,13 @@ def main() -> int:
         ],
     }
 
+    payload = {
+        "version": 2,
+        "profiles": {name: profiles[name] for name in sorted(profiles)},
+    }
+
     MANIFEST.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(f"updated {MANIFEST} with {len(files)} file hashes")
+    print(f"updated {MANIFEST} profile {profile} with {len(files)} file hashes")
     return 0
 
 

--- a/tests/verify_reference_hashes.py
+++ b/tests/verify_reference_hashes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Verify committed reference hashes for the files emitted by tests/test_plots.f90."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "reference_hashes.json"
+OUT = ROOT / "out"
+TEXT_SUFFIXES = {".svg", ".eps"}
+
+
+def normalize_bytes(path: Path) -> bytes:
+    data = path.read_bytes()
+    if path.suffix.lower() in TEXT_SUFFIXES:
+        return data.replace(b"\r\n", b"\n")
+    return data
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(normalize_bytes(path)).hexdigest()
+
+
+def load_manifest() -> dict[str, dict[str, object]]:
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    return {entry["path"]: entry for entry in payload["files"]}
+
+
+def main() -> int:
+    if not MANIFEST.exists():
+        print(f"reference hash manifest not found: {MANIFEST}")
+        print("run: python tests/update_reference_hashes.py")
+        return 1
+    if not OUT.exists():
+        print(f"output directory not found: {OUT}")
+        print("run: fpm test")
+        return 1
+
+    expected = load_manifest()
+    actual_files = sorted(path for path in OUT.iterdir() if path.is_file())
+    actual_names = {path.name for path in actual_files}
+    expected_names = set(expected)
+
+    missing = sorted(expected_names - actual_names)
+    extra = sorted(actual_names - expected_names)
+    mismatched: list[tuple[str, str, str]] = []
+
+    for path in actual_files:
+        name = path.name
+        if name not in expected:
+            continue
+        digest = sha256(path)
+        wanted = str(expected[name]["sha256"])
+        if digest != wanted:
+            mismatched.append((name, wanted, digest))
+
+    if missing:
+        print("missing output files:")
+        for name in missing:
+            print(f"  {name}")
+    if extra:
+        print("unexpected output files:")
+        for name in extra:
+            print(f"  {name}")
+    if mismatched:
+        print("hash mismatches:")
+        for name, wanted, got in mismatched[:20]:
+            print(f"  {name}")
+            print(f"    expected {wanted}")
+            print(f"    got      {got}")
+        if len(mismatched) > 20:
+            print(f"  ... {len(mismatched) - 20} more mismatch(es)")
+
+    if missing or extra or mismatched:
+        print("\nreference hash verification failed")
+        print("update the manifest intentionally with: python tests/update_reference_hashes.py")
+        return 1
+
+    print(f"reference hash verification passed for {len(actual_files)} files")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/verify_reference_hashes.py
+++ b/tests/verify_reference_hashes.py
@@ -3,8 +3,11 @@
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
+import os
+import re
 import sys
 from pathlib import Path
 
@@ -25,12 +28,96 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(normalize_bytes(path)).hexdigest()
 
 
-def load_manifest() -> dict[str, dict[str, object]]:
+def sanitize_profile(profile: str) -> str:
+    return re.sub(r"[^0-9A-Za-z._-]+", "-", profile.strip()).strip("-") or "actual"
+
+
+def load_manifest() -> dict[str, dict[str, dict[str, object]]]:
     payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    return {entry["path"]: entry for entry in payload["files"]}
+    version = int(payload.get("version", 1))
+
+    if version == 1:
+        generated_from = str(payload.get("generated_from", "tests/out"))
+        files = {entry["path"]: entry for entry in payload["files"]}
+        return {"default": {"generated_from": generated_from, "files": files}}
+
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        raise ValueError(f"reference hash manifest has no profiles: {MANIFEST}")
+
+    normalized: dict[str, dict[str, dict[str, object]]] = {}
+    for profile, entry in profiles.items():
+        if isinstance(entry, dict) and "files" in entry:
+            files = entry["files"]
+            generated_from = str(entry.get("generated_from", "tests/out"))
+        else:
+            files = entry
+            generated_from = "tests/out"
+        normalized[profile] = {
+            "generated_from": generated_from,
+            "files": {item["path"]: item for item in files},
+        }
+    return normalized
+
+
+def actual_entries() -> list[dict[str, object]]:
+    return [
+        {
+            "path": path.name,
+            "sha256": sha256(path),
+            "size": len(normalize_bytes(path)),
+        }
+        for path in sorted(path for path in OUT.iterdir() if path.is_file())
+    ]
+
+
+def write_candidate_manifest(profile: str, files: list[dict[str, object]]) -> Path:
+    candidate = ROOT / f"reference_hashes.{sanitize_profile(profile)}.candidate.json"
+    payload = {
+        "version": 2,
+        "profiles": {
+            profile: {
+                "generated_from": str(OUT.relative_to(ROOT.parent)).replace("\\", "/"),
+                "files": files,
+            }
+        },
+    }
+    candidate.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return candidate
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", help="Reference hash profile to verify")
+    return parser.parse_args()
+
+
+def compare_profile(
+    expected: dict[str, dict[str, object]], actual_files: list[dict[str, object]]
+) -> tuple[list[str], list[str], list[tuple[str, str, str]]]:
+    actual_names = {entry["path"] for entry in actual_files}
+    expected_names = set(expected)
+
+    missing = sorted(expected_names - actual_names)
+    extra = sorted(actual_names - expected_names)
+    mismatched: list[tuple[str, str, str]] = []
+
+    for entry in actual_files:
+        name = str(entry["path"])
+        if name not in expected:
+            continue
+        digest = str(entry["sha256"])
+        wanted = str(expected[name]["sha256"])
+        if digest != wanted:
+            mismatched.append((name, wanted, digest))
+
+    return missing, extra, mismatched
 
 
 def main() -> int:
+    args = parse_args()
+    requested_profile = args.profile or os.environ.get("FPLOT_HASH_PROFILE", "").strip()
+
     if not MANIFEST.exists():
         print(f"reference hash manifest not found: {MANIFEST}")
         print("run: python tests/update_reference_hashes.py")
@@ -40,24 +127,36 @@ def main() -> int:
         print("run: fpm test")
         return 1
 
-    expected = load_manifest()
-    actual_files = sorted(path for path in OUT.iterdir() if path.is_file())
-    actual_names = {path.name for path in actual_files}
-    expected_names = set(expected)
+    manifests = load_manifest()
+    actual_files = actual_entries()
 
-    missing = sorted(expected_names - actual_names)
-    extra = sorted(actual_names - expected_names)
-    mismatched: list[tuple[str, str, str]] = []
+    if requested_profile:
+        if requested_profile not in manifests:
+            print(f"reference hash profile not found: {requested_profile}")
+            print("available profiles:")
+            for profile in sorted(manifests):
+                print(f"  {profile}")
+            candidate = write_candidate_manifest(requested_profile, actual_files)
+            print(f"\nwrote candidate manifest for this run to: {candidate}")
+            return 1
+        profiles = [requested_profile]
+    else:
+        profiles = sorted(manifests)
 
-    for path in actual_files:
-        name = path.name
-        if name not in expected:
-            continue
-        digest = sha256(path)
-        wanted = str(expected[name]["sha256"])
-        if digest != wanted:
-            mismatched.append((name, wanted, digest))
+    failures: list[tuple[str, list[str], list[str], list[tuple[str, str, str]]]] = []
+    for profile in profiles:
+        expected = manifests[profile]["files"]
+        missing, extra, mismatched = compare_profile(expected, actual_files)
+        if not missing and not extra and not mismatched:
+            print(f"reference hash verification passed for {len(actual_files)} files ({profile})")
+            return 0
+        failures.append((profile, missing, extra, mismatched))
 
+    profile, missing, extra, mismatched = min(
+        failures,
+        key=lambda item: (len(item[1]) + len(item[2]) + len(item[3]), item[0]),
+    )
+    print(f"reference hash verification failed against profile: {profile}")
     if missing:
         print("missing output files:")
         for name in missing:
@@ -75,13 +174,11 @@ def main() -> int:
         if len(mismatched) > 20:
             print(f"  ... {len(mismatched) - 20} more mismatch(es)")
 
-    if missing or extra or mismatched:
-        print("\nreference hash verification failed")
-        print("update the manifest intentionally with: python tests/update_reference_hashes.py")
-        return 1
-
-    print(f"reference hash verification passed for {len(actual_files)} files")
-    return 0
+    candidate = write_candidate_manifest(requested_profile or profile, actual_files)
+    print("\nreference hash verification failed")
+    print(f"wrote candidate manifest to: {candidate}")
+    print("update the manifest intentionally with: python tests/update_reference_hashes.py")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enhance the CI by comparing a set of hash reference keys instead of having to track each file format individually.